### PR TITLE
#47 Add primaryActorRef to story XSD and plumb it through streaming import

### DIFF
--- a/doc/samples/project.xsd
+++ b/doc/samples/project.xsd
@@ -508,6 +508,7 @@
             </xs:complexType>
           </xs:element>
           <xs:element name="name" type="xs:string" form="qualified" minOccurs="0"/>
+          <xs:element name="primaryActorRef" type="xs:IDREF" form="qualified" minOccurs="0"/>
         </xs:sequence>
         <xs:attribute name="storyType" type="xs:string"/>
         <xs:attribute name="id" type="xs:ID"/>

--- a/modules/platform-core/src/main/java/com/rreganjr/requel/imports/project/StoryImportDraft.java
+++ b/modules/platform-core/src/main/java/com/rreganjr/requel/imports/project/StoryImportDraft.java
@@ -34,6 +34,7 @@ public class StoryImportDraft {
     private final String name;
     private final String description;
     private final String storyType;
+    private final String primaryActorExternalId;
     private final Set<String> goalExternalIds;
     private final Set<String> actorExternalIds;
     private final Set<String> annotationExternalIds;
@@ -45,6 +46,7 @@ public class StoryImportDraft {
         this.name = builder.name;
         this.description = builder.description;
         this.storyType = builder.storyType;
+        this.primaryActorExternalId = builder.primaryActorExternalId;
         this.goalExternalIds = Collections.unmodifiableSet(new HashSet<>(builder.goalExternalIds));
         this.actorExternalIds = Collections.unmodifiableSet(new HashSet<>(builder.actorExternalIds));
         this.annotationExternalIds =
@@ -70,6 +72,10 @@ public class StoryImportDraft {
     }
 
     public String getStoryType() { return storyType; }
+
+    public String getPrimaryActorExternalId() {
+        return primaryActorExternalId;
+    }
 
     public Set<String> getGoalExternalIds() {
         return goalExternalIds;
@@ -97,6 +103,7 @@ public class StoryImportDraft {
         private String name;
         private String description;
         private String storyType;
+        private String primaryActorExternalId;
         private Set<String> goalExternalIds = new HashSet<>();
         private Set<String> actorExternalIds = new HashSet<>();
         private Set<String> annotationExternalIds = new HashSet<>();
@@ -124,6 +131,11 @@ public class StoryImportDraft {
 
         public Builder storyType(String storyType) {
             this.storyType = storyType;
+            return this;
+        }
+
+        public Builder primaryActorExternalId(String primaryActorExternalId) {
+            this.primaryActorExternalId = primaryActorExternalId;
             return this;
         }
 

--- a/modules/project-jpa/src/main/java/com/rreganjr/requel/project/imports/StoryAssembler.java
+++ b/modules/project-jpa/src/main/java/com/rreganjr/requel/project/imports/StoryAssembler.java
@@ -89,6 +89,17 @@ public class StoryAssembler implements AggregateAssembler<StoryImportDraft, Stor
             });
         });
 
+        // 2.0 adds a single primary actor on stories alongside the additional
+        // actors collection (V7 Flyway migration, primary_actor_id column). The
+        // streaming import flow previously dropped this on the floor — the
+        // round-trip test in #47 caught it. Resolve via the same unit-of-work
+        // the actors collection uses; actors are assembled before stories, so
+        // by the time we get here the actor is registered.
+        if (StringUtils.hasText(draft.getPrimaryActorExternalId())) {
+            unitOfWork.resolve(Actor.class, draft.getPrimaryActorExternalId())
+                    .ifPresent(story::setPrimaryActor);
+        }
+
         attachGlossaryTerms(story, draft.getGlossaryTermExternalIds(), unitOfWork);
 
         return story;

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/ProjectXmlStreamingRoundTripIT.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/ProjectXmlStreamingRoundTripIT.java
@@ -44,7 +44,6 @@ import javax.xml.validation.Validator;
 
 import com.rreganjr.requel.user.User;
 import com.rreganjr.requel.user.impl.repository.jpa.JpaUserRepository;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -147,9 +146,6 @@ class ProjectXmlStreamingRoundTripIT {
 
 	@Test
 	@Transactional
-	@Disabled("https://github.com/rreganjr/Requel/issues/47 — exported XML emits"
-			+ " <primaryActorRef> in a position the XSD doesn't expect."
-			+ " Re-enable once the XSD ordering and the JAXB marshaller agree.")
 	void importExportRoundTripKeepsProjectRoundTrippable() throws Exception {
 		initializeBaselineData();
 

--- a/modules/utils-jaxb/src/main/java/com/rreganjr/requel/utils/jaxb/imports/StoryImportXml.java
+++ b/modules/utils-jaxb/src/main/java/com/rreganjr/requel/utils/jaxb/imports/StoryImportXml.java
@@ -48,6 +48,9 @@ public class StoryImportXml {
     @XmlElement(name = "text", namespace = "http://www.rreganjr.com/requel")
     private String text;
 
+    @XmlElement(name = "primaryActorRef", namespace = "http://www.rreganjr.com/requel")
+    private String primaryActorRef;
+
     @XmlElementWrapper(name = "goals", namespace = "http://www.rreganjr.com/requel")
     @XmlElement(name = "goalRef", namespace = "http://www.rreganjr.com/requel")
     private List<String> goalRefs = new ArrayList<>();
@@ -69,6 +72,7 @@ public class StoryImportXml {
     public String getStoryType() { return storyType; }
     public String getName() { return name; }
     public String getText() { return text; }
+    public String getPrimaryActorRef() { return primaryActorRef; }
     public List<String> getGoalRefs() { return goalRefs; }
     public List<String> getActorRefs() { return actorRefs; }
     public List<String> getAnnotationRefs() { return annotationRefs; }

--- a/modules/utils-jaxb/src/main/java/com/rreganjr/requel/utils/jaxb/imports/StoryImportXmlMapper.java
+++ b/modules/utils-jaxb/src/main/java/com/rreganjr/requel/utils/jaxb/imports/StoryImportXmlMapper.java
@@ -37,6 +37,7 @@ public class StoryImportXmlMapper {
                 .name(xml.getName())
                 .description(xml.getText())
                 .storyType(xml.getStoryType())
+                .primaryActorExternalId(xml.getPrimaryActorRef())
                 .goalExternalIds(new HashSet<>(xml.getGoalRefs()))
                 .actorExternalIds(new HashSet<>(xml.getActorRefs()))
                 .annotationExternalIds(new HashSet<>(xml.getAnnotationRefs()))


### PR DESCRIPTION
Closes #47. Two commits: (1) XSD declaration for primaryActorRef on the story complexType + un-disable the test; (2) plumb primaryActor through the four-layer streaming import flow so it survives export → re-import.