### PR TITLE
#58 Reset project user state in E2E global-setup

### DIFF
--- a/.run/Requel [Run App].run.xml
+++ b/.run/Requel [Run App].run.xml
@@ -4,7 +4,7 @@
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="com.rreganjr.requel.Application" />
     <module name="requel-app" />
-    <option name="PROGRAM_PARAMETERS" value="--server.port=8081" />
+    <option name="PROGRAM_PARAMETERS" value="--spring.profiles.active=dev --server.port=8081" />
     <shortenClasspath name="NONE" />
     <option name="VM_PARAMETERS" value="-Dspring.devtools.restart.enabled=false" />
     <method v="2">

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
       "request": "launch",
       "mainClass": "com.rreganjr.requel.Application",
       "projectName": "requel-app",
-      "args": "--server.port=8081",
+      "args": "--spring.profiles.active=dev --server.port=8080",
       "vmArgs": "-Dspring.devtools.restart.enabled=false"
     },
     {

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Requires **Java 17** and a running **MySQL 8.4** instance.
 # macOS
 JAVA_HOME=$(/usr/libexec/java_home -v 17) PATH="$JAVA_HOME/bin:$PATH" \
 java -jar modules/requel-app/target/requel-app-2.0.0.jar \
+  --spring.profiles.active=dev \
   '--spring.datasource.url=jdbc:mysql://127.0.0.1:3306/requel?createDatabaseIfNotExist=true&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC' \
   --spring.datasource.username=root \
   --spring.datasource.password=password \
@@ -76,6 +77,7 @@ java -jar modules/requel-app/target/requel-app-2.0.0.jar \
 export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 export PATH="$JAVA_HOME/bin:$PATH"
 java -jar modules/requel-app/target/requel-app-2.0.0.jar \
+  --spring.profiles.active=dev \
   '--spring.datasource.url=jdbc:mysql://127.0.0.1:3306/requel?createDatabaseIfNotExist=true&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC' \
   --spring.datasource.username=root \
   --spring.datasource.password=password \
@@ -83,6 +85,13 @@ java -jar modules/requel-app/target/requel-app-2.0.0.jar \
 ```
 
 Then open http://localhost:8081/ and log in as **admin** / **admin**.
+
+`--spring.profiles.active=dev` activates [`application-dev.properties`](modules/requel-app/src/main/resources/application-dev.properties) which:
+
+- allows the Angular dev server on `:4200` to reach the API (CORS),
+- registers `/api/dev/reset-admin` and `/api/dev/reset-project` endpoints used by the Playwright E2E global-setup to put built-in users back to canonical state before each run.
+
+The reset endpoints are unauthenticated and destructive, so leaving the `dev` profile off (the default, what Docker Compose runs with) keeps them out of the running server.
 
 > **zsh users:** quote the JDBC URL (contains `?`) or prefix the command with `noglob`.
 

--- a/doc/RELEASE_20_TEST_PLAN.md
+++ b/doc/RELEASE_20_TEST_PLAN.md
@@ -690,8 +690,21 @@ production builds.
 | `POST /api/dev/reset-project` | `requel.dev.reset-project.enabled` | project user's name, password (`project`), and roles (forces back to `ProjectUserRole` only — drops any drift such as a manually-added `SystemAdminUserRole`) |
 
 `e2e/global-setup.ts` calls both endpoints before every E2E run; if either is absent (404),
-the call is silently skipped with a console warning. To enable them when running e2e
-locally, start the server with both flags:
+the call is silently skipped with a console warning.
+
+The simplest way to enable both endpoints (and a couple of other dev-only conveniences like
+CORS for the Angular dev server) is to activate the `dev` Spring profile when running the
+JAR locally:
+
+```bash
+java -jar modules/requel-app/target/requel-app-2.0.0-dev.jar \
+  --spring.profiles.active=dev \
+  --server.port=8080
+```
+
+This activates `modules/requel-app/src/main/resources/application-dev.properties` which
+flips both reset-endpoint flags. Equivalent explicit-flag form (useful for opting in to
+only one endpoint, or for non-`dev` profile situations):
 
 ```bash
 java -jar modules/requel-app/target/requel-app-2.0.0-dev.jar \
@@ -701,8 +714,8 @@ java -jar modules/requel-app/target/requel-app-2.0.0-dev.jar \
 ```
 
 Docker-compose runs (`docker-compose up`) start with a fresh database every time and don't
-need the flags — those endpoints are useful primarily for developers running e2e against a
-persistent local install.
+activate the `dev` profile — those endpoints are useful primarily for developers running
+e2e against a persistent local install.
 
 ### 4.3 Test generation approach
 

--- a/doc/RELEASE_20_TEST_PLAN.md
+++ b/doc/RELEASE_20_TEST_PLAN.md
@@ -675,6 +675,35 @@ export default defineConfig({
 `:4200` with `proxy.conf.json` forwarding `/api` to Spring Boot on `:8081`. Change `baseURL` to
 `http://localhost:4200` in this mode. Do not mix the two — pick one per environment.
 
+### 4.2.1 Dev-only reset endpoints for E2E
+
+E2E tests need built-in users (`admin`, `project`, …) in known-canonical state at the start
+of every run, regardless of what happened to those records during prior debugging or test
+runs on a developer's local database. To support this, the server exposes dev-only reset
+endpoints under `/api/dev/*` that re-seed each built-in user. The endpoints are registered
+only when the matching `requel.dev.reset-*.enabled` flag is `true`, so they are absent from
+production builds.
+
+| Endpoint | Property flag | What it resets |
+|---|---|---|
+| `POST /api/dev/reset-admin` | `requel.dev.reset-admin.enabled` | admin's password (default `admin`) |
+| `POST /api/dev/reset-project` | `requel.dev.reset-project.enabled` | project user's name, password (`project`), and roles (forces back to `ProjectUserRole` only — drops any drift such as a manually-added `SystemAdminUserRole`) |
+
+`e2e/global-setup.ts` calls both endpoints before every E2E run; if either is absent (404),
+the call is silently skipped with a console warning. To enable them when running e2e
+locally, start the server with both flags:
+
+```bash
+java -jar modules/requel-app/target/requel-app-2.0.0-dev.jar \
+  --requel.dev.reset-admin.enabled=true \
+  --requel.dev.reset-project.enabled=true \
+  --server.port=8080
+```
+
+Docker-compose runs (`docker-compose up`) start with a fresh database every time and don't
+need the flags — those endpoints are useful primarily for developers running e2e against a
+persistent local install.
+
 ### 4.3 Test generation approach
 
 Writing Playwright tests from scratch is slow and produces fragile selectors. The recommended

--- a/modules/requel-app/src/main/resources/application-default.properties
+++ b/modules/requel-app/src/main/resources/application-default.properties
@@ -1,5 +1,0 @@
-spring.jpa.hibernate.ddl-auto=none
-spring.datasource.url=jdbc:mysql://localhost:3306/requel?createDatabaseIfNotExist=true&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.username=root
-spring.datasource.password=password

--- a/modules/requel-app/src/main/resources/application-dev.properties
+++ b/modules/requel-app/src/main/resources/application-dev.properties
@@ -1,3 +1,12 @@
 # Development profile — activate with --spring.profiles.active=dev
 # Allows the Angular dev server (ng serve) to reach the API when running locally.
 spring.cors.allowed-origins=http://localhost:4200
+
+# Register the /api/dev/reset-* endpoints used by the Playwright global-setup
+# to put built-in users back to canonical state before each E2E run. These
+# endpoints are unauthenticated and destructive (they bypass normal auth to
+# rewrite admin/project credentials), so they MUST stay out of production
+# builds — they're guarded by @ConditionalOnProperty per-endpoint and only
+# turned on here in the dev profile.
+requel.dev.reset-admin.enabled=true
+requel.dev.reset-project.enabled=true

--- a/modules/requel-app/src/main/resources/application.properties
+++ b/modules/requel-app/src/main/resources/application.properties
@@ -1,3 +1,16 @@
+# Datasource defaults — local MySQL on the conventional host/port/credentials.
+# These are loaded regardless of which Spring profile is active so that
+# activating `dev` (or any other profile that doesn't override them) doesn't
+# leave the application without a datasource. Profile-specific files like
+# application-test.properties (H2 in-memory) override these for their
+# respective profiles. Production deployments override via environment
+# variables (SPRING_DATASOURCE_URL etc., see docker-compose.yml).
+spring.datasource.url=jdbc:mysql://localhost:3306/requel?createDatabaseIfNotExist=true&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.username=root
+spring.datasource.password=password
+spring.jpa.hibernate.ddl-auto=none
+
 spring.flyway.enabled=true
 spring.flyway.baseline-on-migrate=true
 spring.flyway.baseline-version=0

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/dev/DevProjectResetController.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/dev/DevProjectResetController.java
@@ -1,0 +1,135 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.dev;
+
+import com.rreganjr.command.CommandHandler;
+import com.rreganjr.requel.project.ProjectUserRole;
+import com.rreganjr.requel.user.User;
+import com.rreganjr.requel.user.UserRepository;
+import com.rreganjr.requel.user.command.EditUserCommand;
+import com.rreganjr.requel.user.command.UserCommandFactory;
+import com.rreganjr.requel.user.exception.NoSuchUserException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Dev-only endpoint that resets the project user back to its canonical
+ * initializer-defined state. Only registered when
+ * {@code requel.dev.reset-project.enabled=true}.
+ *
+ * <p>Companion to {@link DevAdminResetController}. The E2E global-setup
+ * calls this before each run so the suite always starts with the
+ * "project" user holding exactly {@code ProjectUserRole} — guarding
+ * against drift that can accumulate on developer laptops (e.g., a
+ * manual edit promoting "project" to SystemAdminUserRole during
+ * debugging, which would invisibly break the {@code adminGuard} e2e
+ * tests since they rely on "project" being a non-admin).</p>
+ *
+ * <p>The endpoint is unauthenticated (see ApiSecurityConfig
+ * {@code /api/dev/**} permitAll). It is safe in production because the
+ * bean is absent unless the property is explicitly set.</p>
+ */
+@ConditionalOnProperty(name = "requel.dev.reset-project.enabled", havingValue = "true")
+@RestController
+@RequestMapping("/api/dev")
+public class DevProjectResetController {
+
+    private static final String PROJECT_USERNAME = "project";
+    private static final String PROJECT_NAME = "Builtin Project User";
+
+    private final UserCommandFactory userCommandFactory;
+    private final UserRepository userRepository;
+    private final CommandHandler commandHandler;
+
+    @Value("${requel.project.password:project}")
+    private String projectPassword;
+
+    @Autowired
+    public DevProjectResetController(UserCommandFactory userCommandFactory,
+                                     UserRepository userRepository,
+                                     CommandHandler commandHandler) {
+        this.userCommandFactory = userCommandFactory;
+        this.userRepository = userRepository;
+        this.commandHandler = commandHandler;
+    }
+
+    /**
+     * Resets the project user to canonical state:
+     * <ul>
+     *   <li>name = "Builtin Project User"</li>
+     *   <li>password = {@code requel.project.password} (default "project")</li>
+     *   <li>roles = exactly {@code ProjectUserRole} (any drift is removed)</li>
+     *   <li>permission = {@code createProjects} on ProjectUserRole</li>
+     * </ul>
+     *
+     * <p>Email, phone, and organization fields are preserved as-is to
+     * avoid stamping over any deliberate test fixture setup.</p>
+     *
+     * <p>Sets editedBy to admin (which has authority over any user) so the
+     * authorization chain allows the update without a live security
+     * context.</p>
+     *
+     * @return 204 No Content on success, 404 if either "project" or "admin"
+     *         does not exist (admin is needed for editedBy), 500 on error.
+     */
+    @PostMapping("/reset-project")
+    public ResponseEntity<Void> resetProject() {
+        try {
+            User project = userRepository.findUserByUsername(PROJECT_USERNAME);
+            User admin = userRepository.findUserByUsername("admin");
+            String orgName = project.getOrganization() != null
+                    ? project.getOrganization().getName()
+                    : null;
+
+            EditUserCommand cmd = userCommandFactory.newEditUserCommand();
+            cmd.setUser(project);
+            // admin editing project: admin has SystemAdminUserRole so the
+            // authorization requirement for editing any user is satisfied
+            cmd.setEditedBy(admin);
+            cmd.setUsername(project.getUsername());
+            cmd.setName(PROJECT_NAME);
+            cmd.setEmailAddress(project.getEmailAddress());
+            cmd.setPhoneNumber(project.getPhoneNumber());
+            cmd.setOrganizationName(orgName);
+            cmd.setPassword(projectPassword);
+            cmd.setRepassword(projectPassword);
+            // Force roles back to exactly ProjectUserRole — userRoleNames
+            // provided => userRolesProvided=true => existing roles are
+            // replaced with this set (drift like SystemAdminUserRole is
+            // dropped). See EditUserCommandImpl.
+            cmd.addUserRoleName(ProjectUserRole.getRoleName(ProjectUserRole.class));
+            cmd.addUserRolePermissionName(
+                    ProjectUserRole.getRoleName(ProjectUserRole.class),
+                    ProjectUserRole.createProjects.getName());
+            commandHandler.execute(cmd);
+            return ResponseEntity.noContent().build();
+        } catch (NoSuchUserException e) {
+            return ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+}

--- a/requel-angular/e2e/global-setup.ts
+++ b/requel-angular/e2e/global-setup.ts
@@ -16,7 +16,7 @@ async function resetAdminPassword(): Promise<void> {
   try {
     const res = await ctx.post('/api/dev/reset-admin');
     if (res.status() === 404) {
-      console.warn('[global-setup] /api/dev/reset-admin not available — start the server with --requel.dev.reset-admin.enabled=true to auto-reset admin credentials before each run');
+      console.warn('[global-setup] /api/dev/reset-admin not available — start the server with --spring.profiles.active=dev (or --requel.dev.reset-admin.enabled=true) to auto-reset admin credentials before each run');
     }
   } finally {
     await ctx.dispose();
@@ -37,7 +37,7 @@ async function resetProjectUser(): Promise<void> {
   try {
     const res = await ctx.post('/api/dev/reset-project');
     if (res.status() === 404) {
-      console.warn('[global-setup] /api/dev/reset-project not available — start the server with --requel.dev.reset-project.enabled=true to auto-reset the project user to canonical state before each run');
+      console.warn('[global-setup] /api/dev/reset-project not available — start the server with --spring.profiles.active=dev (or --requel.dev.reset-project.enabled=true) to auto-reset the project user to canonical state before each run');
     }
   } finally {
     await ctx.dispose();

--- a/requel-angular/e2e/global-setup.ts
+++ b/requel-angular/e2e/global-setup.ts
@@ -23,6 +23,27 @@ async function resetAdminPassword(): Promise<void> {
   }
 }
 
+/**
+ * Calls POST /api/dev/reset-project to ensure the project user is in its
+ * canonical state before the test suite runs (name, password, and crucially
+ * roles = [ProjectUserRole] only). Guards against state drift that breaks
+ * adminGuard tests when the project user has inadvertently been granted
+ * SystemAdminUserRole on a developer's local database. Only registered when
+ * the server is started with --requel.dev.reset-project.enabled=true; if the
+ * endpoint is absent (404) the call is silently skipped.
+ */
+async function resetProjectUser(): Promise<void> {
+  const ctx = await request.newContext({ baseURL: BASE_URL });
+  try {
+    const res = await ctx.post('/api/dev/reset-project');
+    if (res.status() === 404) {
+      console.warn('[global-setup] /api/dev/reset-project not available — start the server with --requel.dev.reset-project.enabled=true to auto-reset the project user to canonical state before each run');
+    }
+  } finally {
+    await ctx.dispose();
+  }
+}
+
 async function saveAuthState(username: string, password: string): Promise<void> {
   // Use the API to obtain a JWT — no UI login needed
   const ctx = await request.newContext({ baseURL: BASE_URL });
@@ -54,7 +75,12 @@ async function saveAuthState(username: string, password: string): Promise<void> 
 export default async function globalSetup(): Promise<void> {
   fs.mkdirSync(AUTH_DIR, { recursive: true });
 
+  // Reset built-in users to canonical state before capturing storage state.
+  // Order matters: resetAdminPassword first (so admin can authenticate the
+  // subsequent project reset, since resetProjectUser uses admin as editedBy
+  // server-side), then resetProjectUser.
   await resetAdminPassword();
+  await resetProjectUser();
 
   const adminUser = process.env['E2E_ADMIN_USERNAME'] ?? 'admin';
   const adminPass = process.env['E2E_ADMIN_PASSWORD'] ?? 'admin';


### PR DESCRIPTION
Closes #58. Adds parallel `/api/dev/reset-project` endpoint plus a global-setup call that puts the project user back to canonical state before each E2E run. Guards against the state-leak that was breaking the two adminGuard tests on drifted local databases.