### PR TITLE
Add E2E frontend coverage CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,3 +124,121 @@ jobs:
             **/target/failsafe-reports/
           if-no-files-found: ignore
           retention-days: 14
+
+  e2e:
+    name: E2E + frontend coverage
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_DATABASE: requel
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -ppassword"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Write Maven toolchains.xml
+        run: |
+          mkdir -p "$HOME/.m2"
+          cat > "$HOME/.m2/toolchains.xml" <<EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <toolchains>
+            <toolchain>
+              <type>jdk</type>
+              <provides>
+                <version>17</version>
+                <vendor>any</vendor>
+              </provides>
+              <configuration>
+                <jdkHome>${JAVA_HOME}</jdkHome>
+              </configuration>
+            </toolchain>
+          </toolchains>
+          EOF
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: requel-angular/package-lock.json
+
+      - name: Build app jar
+        run: >
+          mvn -pl modules/requel-app -am package
+          --batch-mode --no-transfer-progress
+          -DskipTests
+          -Dstyle.color=always
+
+      - name: Install Playwright browsers
+        working-directory: requel-angular
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Run Playwright with coverage
+        run: |
+          APP_JAR="$(find modules/requel-app/target -maxdepth 1 -name 'requel-app-*.jar' ! -name '*-sources.jar' | head -n 1)"
+          java -jar "$APP_JAR" \
+            --spring.profiles.active=dev \
+            --server.port=8080 \
+            '--spring.datasource.url=jdbc:mysql://127.0.0.1:3306/requel?createDatabaseIfNotExist=true&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC' \
+            --spring.datasource.username=root \
+            --spring.datasource.password=password \
+            > requel-e2e.log 2>&1 &
+          APP_PID=$!
+          trap 'kill "$APP_PID" 2>/dev/null || true' EXIT
+
+          for i in {1..60}; do
+            if curl -fsS http://localhost:8080/actuator/health > /dev/null; then
+              break
+            fi
+            sleep 2
+          done
+
+          if ! curl -fsS http://localhost:8080/actuator/health > /dev/null; then
+            cat requel-e2e.log
+            exit 1
+          fi
+
+          curl -fsS -X POST http://localhost:8080/api/dev/reset-admin > /dev/null
+          (cd requel-angular && npm run e2e:coverage)
+
+      - name: Upload E2E coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: requel-angular/coverage/lcov.info
+          flags: frontend-e2e
+          name: monocart-frontend-e2e
+          fail_ci_if_error: false
+          use_oidc: true
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            requel-angular/playwright-report/
+            requel-e2e.log
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,7 @@ jobs:
             '--spring.datasource.url=jdbc:mysql://127.0.0.1:3306/requel?createDatabaseIfNotExist=true&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC' \
             --spring.datasource.username=root \
             --spring.datasource.password=password \
+            --requel.dictionary.sql-initializer.enabled=false \
             > requel-e2e.log 2>&1 &
           APP_PID=$!
           trap 'kill "$APP_PID" 2>/dev/null || true' EXIT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,22 @@ jobs:
             exit 1
           fi
 
-          curl -fsS -X POST http://localhost:8080/api/dev/reset-admin > /dev/null
+          reset_dev_fixture() {
+            local path="$1"
+            for i in {1..60}; do
+              if curl -fsS -X POST "http://localhost:8080${path}" > /dev/null; then
+                return 0
+              fi
+              sleep 2
+            done
+            echo "Timed out waiting for ${path}"
+            cat requel-e2e.log
+            exit 1
+          }
+
+          reset_dev_fixture /api/dev/reset-admin
+          reset_dev_fixture /api/dev/reset-project
+
           (cd requel-angular && npm run e2e:coverage)
 
       - name: Upload E2E coverage to Codecov

--- a/modules/dictionary-jpa/src/main/java/com/rreganjr/nlp/dictionary/impl/repository/init/DictionarySQLInitializer.java
+++ b/modules/dictionary-jpa/src/main/java/com/rreganjr/nlp/dictionary/impl/repository/init/DictionarySQLInitializer.java
@@ -31,6 +31,7 @@ import java.sql.Statement;
 import java.util.zip.GZIPInputStream;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Scope;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
@@ -46,6 +47,9 @@ import com.rreganjr.nlp.dictionary.DictionaryRepository;
  * 
  * @author ron
  */
+@ConditionalOnProperty(name = "requel.dictionary.sql-initializer.enabled",
+		havingValue = "true",
+		matchIfMissing = true)
 @Component("dictionarySQLInitializer")
 @Scope("prototype")
 public class DictionarySQLInitializer extends AbstractSystemInitializer {


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/63

Add E2E frontend coverage CI job

Add the phase 3 CI job for Playwright frontend coverage. The new `e2e`
job runs after `build-and-test`, starts a MySQL 8.4 service, builds the
Spring Boot app jar with tests skipped, boots Requel with the `dev`
profile on port 8080, and runs `npm run e2e:coverage` from
`requel-angular`.

Upload the Monocart/Playwright LCOV output at
`requel-angular/coverage/lcov.info` to Codecov with the `frontend-e2e`
flag and `monocart-frontend-e2e` upload name. The upload uses the same
Codecov v5 OIDC setup as backend coverage and keeps
`fail_ci_if_error: false` so coverage telemetry does not fail CI.

Keep the existing Playwright configs and e2e specs; they already exist and
use port 8080, so no new test scaffolding was needed. On e2e failure, upload
the Playwright report plus `requel-e2e.log` for debugging.

Local verification:
- Parsed `.github/workflows/ci.yml` with Ruby YAML.

Full verification happens in GitHub Actions, where the MySQL service,
booted app, Playwright coverage run, and Codecov upload execute together.
