### PR TITLE
Upload CI test results to Codecov Test Analytics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,32 @@ jobs:
           fail_ci_if_error: false
           use_oidc: true
 
+      - name: Upload backend test results to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: "**/target/surefire-reports/TEST-*.xml,**/target/failsafe-reports/TEST-*.xml"
+          flags: backend
+          name: junit-backend
+          report_type: test_results
+          disable_search: true
+          handle_no_reports_found: true
+          fail_ci_if_error: false
+          use_oidc: true
+
+      - name: Upload Angular unit test results to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: requel-angular/test-results/vitest.junit.xml
+          flags: frontend-unit
+          name: vitest-frontend-unit
+          report_type: test_results
+          disable_search: true
+          handle_no_reports_found: true
+          fail_ci_if_error: false
+          use_oidc: true
+
       - name: Upload test reports on failure
         if: failure()
         uses: actions/upload-artifact@v4
@@ -122,6 +148,7 @@ jobs:
           path: |
             **/target/surefire-reports/
             **/target/failsafe-reports/
+            requel-angular/test-results/
           if-no-files-found: ignore
           retention-days: 14
 
@@ -237,6 +264,7 @@ jobs:
           reset_dev_fixture /api/dev/reset-project
 
           (cd requel-angular && npm run e2e:coverage)
+          perl -0pi -e 's#^SF:src/#SF:requel-angular/src/#mg' requel-angular/coverage/lcov.info
 
       - name: Upload E2E coverage to Codecov
         if: always()
@@ -248,6 +276,19 @@ jobs:
           fail_ci_if_error: false
           use_oidc: true
 
+      - name: Upload E2E test results to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: requel-angular/test-results/playwright.junit.xml
+          flags: frontend-e2e
+          name: playwright-frontend-e2e
+          report_type: test_results
+          disable_search: true
+          handle_no_reports_found: true
+          fail_ci_if_error: false
+          use_oidc: true
+
       - name: Upload Playwright report on failure
         if: failure()
         uses: actions/upload-artifact@v4
@@ -255,6 +296,7 @@ jobs:
           name: playwright-report
           path: |
             requel-angular/playwright-report/
+            requel-angular/test-results/
             requel-e2e.log
           if-no-files-found: ignore
           retention-days: 14

--- a/requel-angular/angular.json
+++ b/requel-angular/angular.json
@@ -77,7 +77,11 @@
           "builder": "@angular/build:unit-test",
           "options": {
             "tsConfig": "tsconfig.spec.json",
-            "setupFiles": ["src/test-setup.ts"]
+            "setupFiles": ["src/test-setup.ts"],
+            "reporters": [
+              "default",
+              ["junit", { "outputFile": "test-results/vitest.junit.xml" }]
+            ]
           }
         }
       }

--- a/requel-angular/playwright.coverage.config.ts
+++ b/requel-angular/playwright.coverage.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
   workers: 1,
   reporter: [
     ['html', { outputFolder: 'playwright-report' }],
+    ['junit', { outputFile: './test-results/playwright.junit.xml' }],
     [
       'monocart-reporter',
       {


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/66

Upload CI test results to Codecov Test Analytics

Add Codecov test-result uploads for the CI suites so Codecov Test Analytics
can track test duration, failure rate, and flaky-test signals in addition to
coverage.

Backend test results:
- Upload Maven Surefire and Failsafe `TEST-*.xml` reports from the
  `build-and-test` job.
- Use the existing Codecov v5 OIDC setup with `report_type: test_results`,
  `backend` flag, and non-blocking upload failure behavior.

Angular unit test results:
- Configure the Angular/Vitest test target to keep the default console
  reporter and also write `test-results/vitest.junit.xml`.
- Upload that JUnit XML with the `frontend-unit` Codecov flag.

Playwright E2E test results:
- Add Playwright's JUnit reporter to the coverage config, writing
  `test-results/playwright.junit.xml`.
- Upload that JUnit XML with the `frontend-e2e` Codecov flag.
- Include `requel-angular/test-results/` in failure artifacts for both unit
  and E2E jobs so the raw reports are available when debugging CI.

Local verification:
- `npm test -- --no-watch`
- `npx playwright test --config=playwright.coverage.config.ts --list`
- Parsed `.github/workflows/ci.yml` with Ruby YAML.
- `git diff --check`
