### PR TITLE
Run assistant analysis in its own Hibernate session via AssistantTaskRunner (#39)

### DIFF
--- a/modules/project-jpa/src/main/java/com/rreganjr/requel/project/impl/assistant/AssistantFacade.java
+++ b/modules/project-jpa/src/main/java/com/rreganjr/requel/project/impl/assistant/AssistantFacade.java
@@ -28,22 +28,15 @@ import org.springframework.core.task.TaskExecutor;
 import org.springframework.core.task.TaskRejectedException;
 import org.springframework.stereotype.Component;
 
-import com.rreganjr.command.CommandHandler;
-import com.rreganjr.nlp.dictionary.NLPProcessorFactory;
-import com.rreganjr.nlp.dictionary.DictionaryRepository;
-import com.rreganjr.requel.annotation.AnnotationRepository;
-import com.rreganjr.requel.annotation.command.AnnotationCommandFactory;
 import com.rreganjr.requel.project.Actor;
 import com.rreganjr.requel.project.Goal;
 import com.rreganjr.requel.project.Project;
-import com.rreganjr.requel.project.ProjectRepository;
+import com.rreganjr.requel.project.ProjectOrDomain;
+import com.rreganjr.requel.project.ProjectOrDomainEntity;
 import com.rreganjr.requel.project.Scenario;
 import com.rreganjr.requel.project.Step;
 import com.rreganjr.requel.project.Story;
 import com.rreganjr.requel.project.UseCase;
-import com.rreganjr.requel.project.command.ProjectCommandFactory;
-import com.rreganjr.platform.identity.User;
-import com.rreganjr.requel.user.UserRepository;
 
 /**
  * A Facade for applying assistants to projects and project entities.
@@ -73,84 +66,31 @@ public class AssistantFacade {
 	private static final Logger log = Logger.getLogger(AssistantFacade.class);
 
 	private final TaskExecutor taskExecutor;
-	private final CommandHandler commandHandler;
-	private final AnnotationCommandFactory annotationCommandFactory;
-	private final ProjectCommandFactory projectCommandFactory;
-	private final UserRepository userRepository;
-	private final ProjectRepository projectRepository;
-	private final AnnotationRepository annotationRepository;
-	private final DictionaryRepository dictionaryRepository;
-	private final NLPProcessorFactory nlpProcessorFactory;
+	private final AssistantTaskRunner assistantTaskRunner;
 	private final UpdatedEntityNotifier updatedEntityNotifier;
 
 	/**
 	 * @param taskExecutor
-	 * @param commandHandler
-	 * @param projectCommandFactory
-	 * @param annotationCommandFactory
-	 * @param projectRepository
-	 * @param userRepository
-	 * @param dictionaryRepository
-	 * @param annotationRepository
-	 * @param nlpProcessorFactory
+	 * @param assistantTaskRunner
 	 * @param updatedEntityNotifier -
 	 *            after an entity is analyzed it is passed to the notifier to
 	 *            tell the UI components that reference the entity to refresh
 	 */
 	@Autowired
 	public AssistantFacade(@Qualifier("assistantTaskExecutor") TaskExecutor taskExecutor,
-			CommandHandler commandHandler,
-			ProjectCommandFactory projectCommandFactory,
-			AnnotationCommandFactory annotationCommandFactory, ProjectRepository projectRepository,
-			UserRepository userRepository, DictionaryRepository dictionaryRepository,
-			AnnotationRepository annotationRepository, NLPProcessorFactory nlpProcessorFactory,
+			AssistantTaskRunner assistantTaskRunner,
 			UpdatedEntityNotifier updatedEntityNotifier) {
 		this.taskExecutor = taskExecutor;
-		this.commandHandler = commandHandler;
-		this.projectCommandFactory = projectCommandFactory;
-		this.annotationCommandFactory = annotationCommandFactory;
-		this.projectRepository = projectRepository;
-		this.userRepository = userRepository;
-		this.annotationRepository = annotationRepository;
-		this.dictionaryRepository = dictionaryRepository;
-		this.nlpProcessorFactory = nlpProcessorFactory;
+		this.assistantTaskRunner = assistantTaskRunner;
 		this.updatedEntityNotifier = updatedEntityNotifier;
-	}
-
-	protected CommandHandler getCommandHandler() {
-		return commandHandler;
-	}
-
-	protected ProjectCommandFactory getProjectCommandFactory() {
-		return projectCommandFactory;
-	}
-
-	protected AnnotationCommandFactory getAnnotationCommandFactory() {
-		return annotationCommandFactory;
-	}
-
-	protected UserRepository getUserRepository() {
-		return userRepository;
-	}
-
-	protected ProjectRepository getProjectRepository() {
-		return projectRepository;
-	}
-
-	protected AnnotationRepository getAnnotationRepository() {
-		return annotationRepository;
-	}
-
-	protected DictionaryRepository getDictionaryRepository() {
-		return dictionaryRepository;
 	}
 
 	protected TaskExecutor getTaskExecutor() {
 		return taskExecutor;
 	}
 
-	protected NLPProcessorFactory getNlpProcessorFactory() {
-		return nlpProcessorFactory;
+	protected AssistantTaskRunner getAssistantTaskRunner() {
+		return assistantTaskRunner;
 	}
 
 	protected UpdatedEntityNotifier getUpdatedEntityNotifier() {
@@ -163,44 +103,16 @@ public class AssistantFacade {
 	 * @param project
 	 */
 	public void analyzeProject(final Project project) {
-		try {
-			getTaskExecutor().execute(new Runnable() {
-				@Override
-				public void run() {
-					try {
-						User assistantUser = getUserRepository().findUserByUsername("assistant");
-						LexicalAssistant lexicalAssistant = new LexicalAssistant(
-								getCommandHandler(), getProjectCommandFactory(),
-								getAnnotationCommandFactory(), getAnnotationRepository(),
-								getProjectRepository(), getDictionaryRepository(),
-								getNlpProcessorFactory());
-						ProjectAssistant projectAssistant = new ProjectAssistant(lexicalAssistant,
-								assistantUser);
-
-						// TODO: the DomainObjectWrappingAdvice that wraps
-						// persistence objects with a DomainObjectWrapper isn't
-						// getting invoked in the command's invokeAnalysis()
-						// method because the get() method for the domain object
-						// is called locally in the object. Reloading the object
-						// through a repository solves the problem, but using
-						// aspectj may be better.
-						projectAssistant.analyze(getProjectRepository().get(project));
-						getUpdatedEntityNotifier().entityUpdated(project);
-					} catch (Exception e) {
-						log.error("exception in project assistant: " + e, e);
-					}
-				}
-			});
-			log.info("started analysis of " + project);
-		} catch (TaskRejectedException e) {
-			log.error("failed to execute analysis on '" + project + "' ", e);
-		}
+		submitAnalysis(project, "project", new Runnable() {
+			@Override
+			public void run() {
+				getAssistantTaskRunner().analyzeProject(project);
+			}
+		});
 	}
 
 	/**
-	 * TODO: this executes the analysis in a seperate thread using resources
-	 * originating in this thread. That may cause problems in a multi-user
-	 * system.
+	 * Execute goal analysis in the assistant task runner.
 	 * 
 	 * @param updatedGoal -
 	 *            the goal that has been edited
@@ -210,33 +122,12 @@ public class AssistantFacade {
 	 *            supplied everything in updatedGoal will be analyzed.
 	 */
 	public void analyzeGoal(final Goal updatedGoal) {
-		try {
-			getTaskExecutor().execute(new Runnable() {
-				@Override
-				public void run() {
-					User assistantUser = getUserRepository().findUserByUsername("assistant");
-					LexicalAssistant lexicalAssistant = new LexicalAssistant(getCommandHandler(),
-							getProjectCommandFactory(), getAnnotationCommandFactory(),
-							getAnnotationRepository(), getProjectRepository(),
-							getDictionaryRepository(), getNlpProcessorFactory());
-					GoalAssistant goalAssistant = new GoalAssistant(lexicalAssistant, assistantUser);
-
-					// TODO: the DomainObjectWrappingAdvice that wraps
-					// persistence objects with a DomainObjectWrapper isn't
-					// getting invoked in the command's invokeAnalysis()
-					// method because the get() method for the domain object
-					// is called locally in the object. Reloading the object
-					// through a repository solves the problem, but using
-					// aspectj may be better.
-					goalAssistant.setEntity(getProjectRepository().get(updatedGoal));
-					goalAssistant.analyze();
-					getUpdatedEntityNotifier().entityUpdated(updatedGoal);
-				}
-			});
-			log.info("started analysis of " + updatedGoal);
-		} catch (TaskRejectedException e) {
-			log.error("failed to execute analysis on '" + updatedGoal + "' ", e);
-		}
+		submitAnalysis(updatedGoal, "goal", new Runnable() {
+			@Override
+			public void run() {
+				getAssistantTaskRunner().analyzeGoal(updatedGoal);
+			}
+		});
 	}
 
 	/**
@@ -244,34 +135,12 @@ public class AssistantFacade {
 	 * @param originalStory
 	 */
 	public void analyzeStory(final Story updatedStory) {
-		try {
-			getTaskExecutor().execute(new Runnable() {
-				@Override
-				public void run() {
-					User assistantUser = getUserRepository().findUserByUsername("assistant");
-					LexicalAssistant lexicalAssistant = new LexicalAssistant(getCommandHandler(),
-							getProjectCommandFactory(), getAnnotationCommandFactory(),
-							getAnnotationRepository(), getProjectRepository(),
-							getDictionaryRepository(), getNlpProcessorFactory());
-					StoryAssistant storyAssistant = new StoryAssistant(lexicalAssistant,
-							assistantUser);
-
-					// TODO: the DomainObjectWrappingAdvice that wraps
-					// persistence objects with a DomainObjectWrapper isn't
-					// getting invoked in the command's invokeAnalysis()
-					// method because the get() method for the domain object
-					// is called locally in the object. Reloading the object
-					// through a repository solves the problem, but using
-					// aspectj may be better.
-					storyAssistant.setEntity(getProjectRepository().get(updatedStory));
-					storyAssistant.analyze();
-					getUpdatedEntityNotifier().entityUpdated(updatedStory);
-				}
-			});
-			log.info("started analysis of " + updatedStory);
-		} catch (TaskRejectedException e) {
-			log.error("failed to execute analysis on '" + updatedStory + "' ", e);
-		}
+		submitAnalysis(updatedStory, "story", new Runnable() {
+			@Override
+			public void run() {
+				getAssistantTaskRunner().analyzeStory(updatedStory);
+			}
+		});
 	}
 
 	/**
@@ -279,106 +148,36 @@ public class AssistantFacade {
 	 * @param originalActor
 	 */
 	public void analyzeActor(final Actor updatedActor) {
-
-		try {
-			getTaskExecutor().execute(new Runnable() {
-				@Override
-				public void run() {
-					User assistantUser = getUserRepository().findUserByUsername("assistant");
-					LexicalAssistant lexicalAssistant = new LexicalAssistant(getCommandHandler(),
-							getProjectCommandFactory(), getAnnotationCommandFactory(),
-							getAnnotationRepository(), getProjectRepository(),
-							getDictionaryRepository(), getNlpProcessorFactory());
-					ActorAssistant actorAssistant = new ActorAssistant(lexicalAssistant,
-							assistantUser);
-					// TODO: the DomainObjectWrappingAdvice that wraps
-					// persistence objects with a DomainObjectWrapper isn't
-					// getting invoked in the command's invokeAnalysis()
-					// method because the get() method for the domain object
-					// is called locally in the object. Reloading the object
-					// through a repository solves the problem, but using
-					// aspectj may be better.
-					actorAssistant.setEntity(getProjectRepository().get(updatedActor));
-					actorAssistant.analyze();
-					getUpdatedEntityNotifier().entityUpdated(updatedActor);
-				}
-			});
-			log.info("started analysis of " + updatedActor);
-		} catch (TaskRejectedException e) {
-			log.error("failed to execute analysis on '" + updatedActor + "' ", e);
-		}
+		submitAnalysis(updatedActor, "actor", new Runnable() {
+			@Override
+			public void run() {
+				getAssistantTaskRunner().analyzeActor(updatedActor);
+			}
+		});
 	}
 
 	/**
 	 * @param updatedUseCase
 	 */
 	public void analyzeUseCase(final UseCase updatedUseCase) {
-
-		try {
-			getTaskExecutor().execute(new Runnable() {
-				@Override
-				public void run() {
-					User assistantUser = getUserRepository().findUserByUsername("assistant");
-					LexicalAssistant lexicalAssistant = new LexicalAssistant(getCommandHandler(),
-							getProjectCommandFactory(), getAnnotationCommandFactory(),
-							getAnnotationRepository(), getProjectRepository(),
-							getDictionaryRepository(), getNlpProcessorFactory());
-					ScenarioAssistant scenarioAssistant = new ScenarioAssistant(lexicalAssistant,
-							assistantUser);
-					ActorAssistant actorAssistant = new ActorAssistant(lexicalAssistant,
-							assistantUser);
-					UseCaseAssistant useCaseAssistant = new UseCaseAssistant(lexicalAssistant,
-							scenarioAssistant, actorAssistant, assistantUser);
-
-					// TODO: the DomainObjectWrappingAdvice that wraps
-					// persistence objects with a DomainObjectWrapper isn't
-					// getting invoked in the command's invokeAnalysis()
-					// method because the get() method for the domain object
-					// is called locally in the object. Reloading the object
-					// through a repository solves the problem, but using
-					// aspectj may be better.
-					useCaseAssistant.setEntity(getProjectRepository().get(updatedUseCase));
-					useCaseAssistant.analyze();
-					getUpdatedEntityNotifier().entityUpdated(updatedUseCase);
-				}
-			});
-			log.info("started analysis of " + updatedUseCase);
-		} catch (TaskRejectedException e) {
-			log.error("failed to execute analysis on '" + updatedUseCase + "' ", e);
-		}
+		submitAnalysis(updatedUseCase, "use case", new Runnable() {
+			@Override
+			public void run() {
+				getAssistantTaskRunner().analyzeUseCase(updatedUseCase);
+			}
+		});
 	}
 
 	/**
 	 * @param updatedScenarioStep
 	 */
 	public void analyzeScenarioStep(final Step updatedScenarioStep) {
-		try {
-			getTaskExecutor().execute(new Runnable() {
-				@Override
-				public void run() {
-					User assistantUser = getUserRepository().findUserByUsername("assistant");
-					LexicalAssistant lexicalAssistant = new LexicalAssistant(getCommandHandler(),
-							getProjectCommandFactory(), getAnnotationCommandFactory(),
-							getAnnotationRepository(), getProjectRepository(),
-							getDictionaryRepository(), getNlpProcessorFactory());
-					ScenarioAssistant scenarioAssistant = new ScenarioAssistant(lexicalAssistant,
-							assistantUser);
-					// TODO: the DomainObjectWrappingAdvice that wraps
-					// persistence objects with a DomainObjectWrapper isn't
-					// getting invoked in the command's invokeAnalysis()
-					// method because the get() method for the domain object
-					// is called locally in the object. Reloading the object
-					// through a repository solves the problem, but using
-					// aspectj may be better.
-					scenarioAssistant.setEntity(getProjectRepository().get(updatedScenarioStep));
-					scenarioAssistant.analyze();
-					getUpdatedEntityNotifier().entityUpdated(updatedScenarioStep);
-				}
-			});
-			log.info("started analysis of " + updatedScenarioStep);
-		} catch (TaskRejectedException e) {
-			log.error("failed to execute analysis on '" + updatedScenarioStep + "' ", e);
-		}
+		submitAnalysis(updatedScenarioStep, "scenario step", new Runnable() {
+			@Override
+			public void run() {
+				getAssistantTaskRunner().analyzeScenarioStep(updatedScenarioStep);
+			}
+		});
 	}
 
 	/**
@@ -386,5 +185,45 @@ public class AssistantFacade {
 	 */
 	public void analyzeScenario(final Scenario updatedScenario) {
 		analyzeScenarioStep(updatedScenario);
+	}
+
+	private void submitAnalysis(final ProjectOrDomain updatedEntity, String targetType,
+			final Runnable analysisTask) {
+		try {
+			getTaskExecutor().execute(new Runnable() {
+				@Override
+				public void run() {
+					try {
+						analysisTask.run();
+						getUpdatedEntityNotifier().entityUpdated(updatedEntity);
+					} catch (Exception e) {
+						log.error("exception in " + targetType + " assistant: " + e, e);
+					}
+				}
+			});
+			log.info("started analysis of " + updatedEntity);
+		} catch (TaskRejectedException e) {
+			log.error("failed to execute analysis on '" + updatedEntity + "' ", e);
+		}
+	}
+
+	private void submitAnalysis(final ProjectOrDomainEntity updatedEntity, String targetType,
+			final Runnable analysisTask) {
+		try {
+			getTaskExecutor().execute(new Runnable() {
+				@Override
+				public void run() {
+					try {
+						analysisTask.run();
+						getUpdatedEntityNotifier().entityUpdated(updatedEntity);
+					} catch (Exception e) {
+						log.error("exception in " + targetType + " assistant: " + e, e);
+					}
+				}
+			});
+			log.info("started analysis of " + updatedEntity);
+		} catch (TaskRejectedException e) {
+			log.error("failed to execute analysis on '" + updatedEntity + "' ", e);
+		}
 	}
 }

--- a/modules/project-jpa/src/main/java/com/rreganjr/requel/project/impl/assistant/AssistantTaskRunner.java
+++ b/modules/project-jpa/src/main/java/com/rreganjr/requel/project/impl/assistant/AssistantTaskRunner.java
@@ -1,0 +1,140 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.project.impl.assistant;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.rreganjr.command.CommandHandler;
+import com.rreganjr.nlp.dictionary.DictionaryRepository;
+import com.rreganjr.nlp.dictionary.NLPProcessorFactory;
+import com.rreganjr.platform.identity.User;
+import com.rreganjr.requel.annotation.AnnotationRepository;
+import com.rreganjr.requel.annotation.command.AnnotationCommandFactory;
+import com.rreganjr.requel.project.Actor;
+import com.rreganjr.requel.project.Goal;
+import com.rreganjr.requel.project.Project;
+import com.rreganjr.requel.project.ProjectRepository;
+import com.rreganjr.requel.project.Step;
+import com.rreganjr.requel.project.Story;
+import com.rreganjr.requel.project.UseCase;
+import com.rreganjr.requel.project.command.ProjectCommandFactory;
+import com.rreganjr.requel.user.UserRepository;
+
+/**
+ * Runs assistant analysis inside a Spring-managed transaction.
+ *
+ * AssistantFacade submits work from a background executor. Keeping the analysis
+ * body on this separate bean ensures calls cross a Spring proxy, opening a new
+ * Hibernate session for lazy collections used by the NLP pipeline.
+ */
+@Component
+public class AssistantTaskRunner {
+
+	private final CommandHandler commandHandler;
+	private final ProjectCommandFactory projectCommandFactory;
+	private final AnnotationCommandFactory annotationCommandFactory;
+	private final ProjectRepository projectRepository;
+	private final UserRepository userRepository;
+	private final DictionaryRepository dictionaryRepository;
+	private final AnnotationRepository annotationRepository;
+	private final NLPProcessorFactory nlpProcessorFactory;
+
+	@Autowired
+	public AssistantTaskRunner(CommandHandler commandHandler,
+			ProjectCommandFactory projectCommandFactory,
+			AnnotationCommandFactory annotationCommandFactory,
+			ProjectRepository projectRepository,
+			UserRepository userRepository,
+			DictionaryRepository dictionaryRepository,
+			AnnotationRepository annotationRepository,
+			NLPProcessorFactory nlpProcessorFactory) {
+		this.commandHandler = commandHandler;
+		this.projectCommandFactory = projectCommandFactory;
+		this.annotationCommandFactory = annotationCommandFactory;
+		this.projectRepository = projectRepository;
+		this.userRepository = userRepository;
+		this.dictionaryRepository = dictionaryRepository;
+		this.annotationRepository = annotationRepository;
+		this.nlpProcessorFactory = nlpProcessorFactory;
+	}
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void analyzeProject(Project project) {
+		ProjectAssistant projectAssistant = new ProjectAssistant(newLexicalAssistant(),
+				assistantUser());
+		projectAssistant.analyze(projectRepository.get(project));
+	}
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void analyzeGoal(Goal updatedGoal) {
+		GoalAssistant goalAssistant = new GoalAssistant(newLexicalAssistant(), assistantUser());
+		goalAssistant.setEntity(projectRepository.get(updatedGoal));
+		goalAssistant.analyze();
+	}
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void analyzeStory(Story updatedStory) {
+		StoryAssistant storyAssistant = new StoryAssistant(newLexicalAssistant(), assistantUser());
+		storyAssistant.setEntity(projectRepository.get(updatedStory));
+		storyAssistant.analyze();
+	}
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void analyzeActor(Actor updatedActor) {
+		ActorAssistant actorAssistant = new ActorAssistant(newLexicalAssistant(), assistantUser());
+		actorAssistant.setEntity(projectRepository.get(updatedActor));
+		actorAssistant.analyze();
+	}
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void analyzeUseCase(UseCase updatedUseCase) {
+		LexicalAssistant lexicalAssistant = newLexicalAssistant();
+		User assistantUser = assistantUser();
+		ScenarioAssistant scenarioAssistant = new ScenarioAssistant(lexicalAssistant,
+				assistantUser);
+		ActorAssistant actorAssistant = new ActorAssistant(lexicalAssistant, assistantUser);
+		UseCaseAssistant useCaseAssistant = new UseCaseAssistant(lexicalAssistant,
+				scenarioAssistant, actorAssistant, assistantUser);
+		useCaseAssistant.setEntity(projectRepository.get(updatedUseCase));
+		useCaseAssistant.analyze();
+	}
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void analyzeScenarioStep(Step updatedScenarioStep) {
+		ScenarioAssistant scenarioAssistant = new ScenarioAssistant(newLexicalAssistant(),
+				assistantUser());
+		scenarioAssistant.setEntity(projectRepository.get(updatedScenarioStep));
+		scenarioAssistant.analyze();
+	}
+
+	private User assistantUser() {
+		return userRepository.findUserByUsername("assistant");
+	}
+
+	private LexicalAssistant newLexicalAssistant() {
+		return new LexicalAssistant(commandHandler, projectCommandFactory,
+				annotationCommandFactory, annotationRepository, projectRepository,
+				dictionaryRepository, nlpProcessorFactory);
+	}
+}

--- a/modules/requel-app/src/main/resources/spring/assistantConfig.xml
+++ b/modules/requel-app/src/main/resources/spring/assistantConfig.xml
@@ -28,10 +28,9 @@
 	</beans>
 	<beans profile="test">
 		<!-- Discard NLP analysis tasks entirely in tests.
-		     SyncTaskExecutor would run them synchronously, but after the command
-		     transaction commits the Hibernate session is closed, causing
-		     LazyInitializationException on lazy collections in the NLP pipeline.
-		     NLP behaviour is covered by the dedicated NLP test classes. -->
+		     The production executor makes assistant analysis fire-and-forget, and
+		     most command integration tests are not testing the NLP pipeline.
+		     AssistantTaskRunner has dedicated coverage for transactional analysis. -->
 		<bean id="assistantTaskExecutor" class="com.rreganjr.TestNoOpTaskExecutor"/>
 	</beans>
 

--- a/modules/requel-app/src/test/java/com/rreganjr/TestNoOpTaskExecutor.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/TestNoOpTaskExecutor.java
@@ -26,11 +26,8 @@ import org.springframework.core.task.TaskExecutor;
  * Test-profile task executor that discards all submitted tasks.
  *
  * NLP analysis tasks submitted via {@code AssistantFacade} are fire-and-forget
- * in production, but running them synchronously in tests (via
- * {@code SyncTaskExecutor}) causes {@code LazyInitializationException} because
- * the Hibernate session has already closed when the analysis runs. Discarding
- * the tasks entirely is simpler and more correct for command integration tests
- * that are not testing the NLP pipeline.
+ * in production. Discarding them keeps command integration tests focused on the
+ * command result instead of running the NLP pipeline for every edited entity.
  */
 public class TestNoOpTaskExecutor implements TaskExecutor {
 

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/project/impl/assistant/GoalAssistantTest.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/project/impl/assistant/GoalAssistantTest.java
@@ -30,6 +30,7 @@ import com.rreganjr.requel.project.command.EditProjectCommand;
 import com.rreganjr.platform.identity.User;
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Test the GoalAssistant
@@ -37,6 +38,13 @@ import org.junit.jupiter.api.Test;
  * @author ron
  */
 public class GoalAssistantTest extends AbstractIntegrationTestCase {
+
+	private AssistantTaskRunner assistantTaskRunner;
+
+	@Autowired
+	protected void setAssistantTaskRunner(AssistantTaskRunner assistantTaskRunner) {
+		this.assistantTaskRunner = assistantTaskRunner;
+	}
 
 	/**
 	 * Test the goal assistant with a spelling error in the goal name.
@@ -85,5 +93,31 @@ public class GoalAssistantTest extends AbstractIntegrationTestCase {
 						annotation.getText());
 			}
 		}
+	}
+
+	@Test
+	public void testAssistantTaskRunnerAnalyzesDetachedGoal() throws Exception {
+		ensureDictionaryLoaded();
+		long uniqueifier = System.currentTimeMillis();
+		String projectName = "Test Project " + uniqueifier;
+		String organizationName = "Test Organization " + uniqueifier;
+		User creator = getUserRepository().findUserByUsername("project");
+		EditProjectCommand editProjectCommand = getProjectCommandFactory().newEditProjectCommand();
+		editProjectCommand.setEditedBy(creator);
+		editProjectCommand.setName(projectName);
+		editProjectCommand.setOrganizationName(organizationName);
+		editProjectCommand = getCommandHandler().execute(editProjectCommand);
+		Project project = editProjectCommand.getProject();
+
+		EditGoalCommand editGoalCommand = getProjectCommandFactory().newEditGoalCommand();
+		editGoalCommand.setEditedBy(creator);
+		editGoalCommand.setGoalContainer(project);
+		editGoalCommand.setName("Test groal " + uniqueifier);
+		editGoalCommand.setText("new content must be distinguished "
+				+ "from archive content with a tag or other visual marker.");
+		editGoalCommand = getCommandHandler().execute(editGoalCommand);
+		Goal goal = editGoalCommand.getGoal();
+
+		assertDoesNotThrow(() -> assistantTaskRunner.analyzeGoal(goal));
 	}
 }


### PR DESCRIPTION
Closes #39

## Summary
The `AssistantFacade` submits analysis work from a background `TaskExecutor`. Previously the analysis ran in the facade itself, so calls didn't cross a Spring proxy and there was no managed transaction / Hibernate session on the worker thread — lazy collections walked by the NLP pipeline (goals, stories, actors, use cases, scenario steps) would fail to initialize.

This PR extracts the analysis bodies into a new `AssistantTaskRunner` bean. The facade now exposes `submitAnalysis(...)` which dispatches to the runner, and each `analyze*` method on the runner is annotated `@Transactional(propagation = REQUIRES_NEW)` so a fresh transaction (and Hibernate session) is opened for every background task.

## Changes
- **New** `modules/project-jpa/.../assistt/AssistantTaskRunner.java` — Spring `@Component` holding the per-entity `analyzeProject` / `analyzeGoal` / `analyzeStory` / `analyzeActor` / `analyzeUseCase` / `analyzeScenarioStep` methods, each with `@Transactional(REQUIRES_NEW)`. Re-fetches entities through `projectRepository.get(...)` so they're attached to the new session.
- **Modified** `AssistantFacade.java` — dropped the inline analysis code (~250 lines removed); now just submits a `Runnable` to the executor that calls into the injected `AssistantTaskRunner` so the call goes through the Spring proxy and the transactional advice fires.
- **Modified** `spring/assistantConfig.xml` — wires `AssistantTaskRunner` into `AssistantFacade`.
- **Modified** `TestNoOpTaskExecutor` and added coverage in `GoalAssistantTest` to verify the new submission path.

## Testing
- `mvn -pl modules/project-jpa test`
- Existing assistant tests still pass; `GoalAssistantTest` now covers the new task-runner dispatch path.