### PR TITLE
#76 Upgrade Spring Boot 3.3.4 → 3.5.14; pin Spring AI 1.1.7 baseline

### DIFF
--- a/modules/dictionary-jpa/src/main/java/com/rreganjr/nlp/dictionary/DictionaryRepository.java
+++ b/modules/dictionary-jpa/src/main/java/com/rreganjr/nlp/dictionary/DictionaryRepository.java
@@ -35,6 +35,14 @@ import com.rreganjr.repository.Repository;
 public interface DictionaryRepository extends Repository {
 
 	/**
+	 * Insert a new entity (graph) for an import, always creating new rows. Unlike
+	 * {@link Repository#persist(Object)}, this never routes an id-bearing deserialized entity to
+	 * {@code merge()} (which Hibernate 6.6 turns into a stale 0-row update for absent rows).
+	 * IDENTITY ids are regenerated; assigned/natural keys are kept. See issue #76.
+	 */
+	<T> T create(T entity) throws com.rreganjr.platform.exception.EntityException;
+
+	/**
 	 * @return The full dictonary of wordnet synsets, categories, and words.
 	 */
 	public Dictionary getDictionary();

--- a/modules/dictionary-jpa/src/main/java/com/rreganjr/nlp/dictionary/impl/command/ImportDictionaryCommandImpl.java
+++ b/modules/dictionary-jpa/src/main/java/com/rreganjr/nlp/dictionary/impl/command/ImportDictionaryCommandImpl.java
@@ -83,11 +83,10 @@ public class ImportDictionaryCommandImpl extends AbstractDictionaryCommand imple
 			Dictionary dictionary = (Dictionary) unmarshaller.unmarshal(getInputStream());
 			for (Word word : dictionary.getWords()) {
 				try {
-					getDictionaryRepository().persist(word);
-					// Word existingWord =
-					// wordNetRepository.getWord(word.getLemma());
-				} catch (NoResultException e) {
-					getDictionaryRepository().persist(word);
+					// Import always creates new rows (issue #76): persist() would route the
+					// id-bearing, just-unmarshalled Word to merge(), which Hibernate 6.6 turns
+					// into a stale 0-row update because the row is absent in a fresh DB.
+					getDictionaryRepository().create(word);
 				} catch (Exception e) {
 					log.error("could not save word '" + word.getLemma() + "': " + e, e);
 					throw e;

--- a/modules/platform-core/src/main/java/com/rreganjr/repository/jpa/AbstractJpaRepository.java
+++ b/modules/platform-core/src/main/java/com/rreganjr/repository/jpa/AbstractJpaRepository.java
@@ -68,7 +68,16 @@ public class AbstractJpaRepository extends AbstractRepository {
 			}
 			Object id = getId(target);
 			if (id != null) {
-				return entityManager.merge(target);
+				// Detached, id-bearing entity. If the row exists this is an update -> merge. If
+				// the row is absent (an id carried from an import or a stale cross-context cache),
+				// Hibernate 6.6's merge issues a 0-row UPDATE and throws StaleObjectStateException;
+				// insert it as new instead (IDENTITY ids regenerate, assigned/natural keys kept).
+				// See issue #76.
+				if (entityManager.find(target.getClass(), id) != null) {
+					return entityManager.merge(target);
+				}
+				insertNew(target);
+				return target;
 			}
 			entityManager.persist(target);
 			return target;
@@ -76,6 +85,42 @@ public class AbstractJpaRepository extends AbstractRepository {
 			log.warn(e, e);
 			throw convertException(e, entity.getClass(), entity, EntityExceptionActionType.Creating);
 		}
+	}
+
+	/**
+	 * Import semantics: always INSERT a new row graph for the supplied (typically just-
+	 * deserialized) entity, regardless of any id it carries. {@link #persist(Object)} routes
+	 * id-bearing entities to {@code merge()}; under Hibernate 6.6 a merge of a detached entity
+	 * whose row is absent (e.g. an IDENTITY entity carrying an id used only for XML
+	 * cross-references) becomes a 0-row UPDATE and throws StaleObjectStateException. This forces
+	 * an insert of the whole cascade graph: IDENTITY ids are (re)generated, assigned/natural keys
+	 * (e.g. composite ids) are kept. See issue #76.
+	 *
+	 * <p>Uses Hibernate's legacy insert-graph primitive, deprecated-for-removal in Hibernate 7 —
+	 * revisit when upgrading past 6.x.
+	 */
+	public <T> T create(T entity) throws EntityException {
+		if (entity == null) {
+			return null;
+		}
+		try {
+			insertNew(entity);
+			return entity;
+		} catch (Exception e) {
+			log.warn(e, e);
+			throw convertException(e, entity.getClass(), entity, EntityExceptionActionType.Creating);
+		}
+	}
+
+	/**
+	 * Insert a new row (graph) for a detached/transient entity, (re)generating IDENTITY ids and
+	 * keeping assigned/natural keys. Uses Hibernate's legacy insert primitive (deprecated-for-
+	 * removal in Hibernate 7 — revisit then). Shared by {@link #create(Object)} and the
+	 * absent-row branch of {@link #persist(Object)}.
+	 */
+	@SuppressWarnings("deprecation")
+	private void insertNew(Object target) {
+		entityManager.unwrap(org.hibernate.Session.class).save(target);
 	}
 
 	/**

--- a/modules/requel-app/src/test/java/com/rreganjr/AbstractIntegrationTestCase.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/AbstractIntegrationTestCase.java
@@ -21,7 +21,6 @@
 package com.rreganjr;
 
 import java.io.InputStream;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.GZIPInputStream;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -78,7 +77,6 @@ public abstract class AbstractIntegrationTestCase {
 	private StakeholderPermissionsInitializer stakeholderPermissionsInitializer;
 	private TestRoleGrantHelper testRoleGrantHelper;
 
-	private static final AtomicBoolean baselineInitialized = new AtomicBoolean(false);
 
 	protected ProjectCommandFactory getProjectCommandFactory() {
 		return projectCommandFactory;
@@ -158,23 +156,26 @@ public abstract class AbstractIntegrationTestCase {
 
     @BeforeEach
     public void initializeBaselineData() throws Exception {
-        boolean first = baselineInitialized.compareAndSet(false, true);
-        if (first) {
-            if (userRolePermissionsInitializer != null) {
-                userRolePermissionsInitializer.initialize();
-            }
-            if (stakeholderPermissionsInitializer != null) {
-                stakeholderPermissionsInitializer.initialize();
-			}
-			if (adminUserInitializer != null) {
-				adminUserInitializer.initialize();
-			}
-			if (assistantUserInitializer != null) {
-				assistantUserInitializer.initialize();
-            }
-            if (projectUserInitializer != null) {
-                projectUserInitializer.initialize();
-            }
+        // Seed baseline data for the CURRENT Spring context's database. Each test context gets
+        // its own in-memory DB (jdbc:h2:mem:requel-${random.uuid}, per #43/#76), so this must run
+        // per context, not once per JVM. The initializers are idempotent (check-then-create), so
+        // re-running against an already-seeded context is just cheap existence checks. (A prior
+        // JVM-wide AtomicBoolean guard left every context after the first unseeded -> intermittent
+        // "No user for username 'project'" in the full suite.)
+        if (userRolePermissionsInitializer != null) {
+            userRolePermissionsInitializer.initialize();
+        }
+        if (stakeholderPermissionsInitializer != null) {
+            stakeholderPermissionsInitializer.initialize();
+        }
+        if (adminUserInitializer != null) {
+            adminUserInitializer.initialize();
+        }
+        if (assistantUserInitializer != null) {
+            assistantUserInitializer.initialize();
+        }
+        if (projectUserInitializer != null) {
+            projectUserInitializer.initialize();
         }
         // Always ensure the key users have ProjectUserRole; idempotent and cheap.
         try { grantProjectRoleIfMissing("admin"); } catch (Exception e) { log.warn("grant admin project role failed", e); }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.4</version>
+        <version>3.5.14</version>
         <relativePath/>
     </parent>
 
@@ -18,7 +18,21 @@
 
     <properties>
         <java.version>17</java.version>
+        <!-- Spring AI baseline for the AI/MCP work (issues #69, #spring-ai port). -->
+        <spring-ai.version>1.1.7</spring-ai.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.ai</groupId>
+                <artifactId>spring-ai-bom</artifactId>
+                <version>${spring-ai.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <!--
       Project-local Maven repository for jars that are not available on


### PR DESCRIPTION
Closes #76.

Foundation bump so the v2.0 AI/MCP work (#69 series + the Spring AI provider-client port) builds on a supported combination — Spring AI 1.x requires Spring Boot 3.4.x/3.5.x, so 3.3.4 was not a drop-in.

**Version bump (root pom)**
- spring-boot-starter-parent 3.3.4 → 3.5.14 (Java stays 17).
- spring-ai.version=1.1.7 + dependencyManagement import of spring-ai-bom (no starters wired yet — baseline only).

**Hibernate 6.6 fix (AbstractJpaRepository.persist)**
- Boot 3.5 brings Hibernate 6.6, whose merge() of a detached, id-bearing entity with an absent row now does a 0-row UPDATE → StaleObjectStateException instead of inserting.
- persist() now find-checks an id-bearing entity: merge() only when the row exists, otherwise insertegenerating IDENTITY ids, keeping assigned/natural keys). Covers the dictionary XML import and the seed initializers (which persist() id-bearing entities held in a static cross-context cache). Adds an explicit Repository.create() used by the dictionary import.

**Test-seeding fix**
- Per-context DB isolation (#43, jdbc:h2:mem:requel-\${random.uuid}) made AbstractIntegrationTestCase's once-per-JVM seeding guard leave later contexts unseeded. Removed the guard so seed initializers run per @BeforeEach (idempotent now that persist() inserts-on-absent).

**Known benign (test-only):** under H2 2.3.232, DictionarySQLInitializer's MySQL-only "SET SQL_MODE=''" throws and is caught/logged; production (MySQL) is unaffected. Optional follow-up: skip it on H2.

Full `mvn clean verify` is green. Details in commit.md.