### PR TITLE
#82 MCP cleanup: tool naming, client recipe, transport/JSON-RPC decisions, constraint diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,14 @@ work/
 target/
 .m2/
 
+# Secrets
+.env
+
+# Per-developer local AI-client config (MCP server wiring, machine-specific paths, tokens).
+# The portable setup is documented in doc/mcp_remote_connection.md instead.
+.cursor/
+.claude/
+
 # Defensive: any errant `npx`/`npm` invocation from the repo root materializes
 # a node_modules tree here (vitest .vite cache, etc.). The real Angular deps
 # live under requel-angular/node_modules, which is ignored by that subdir's

--- a/doc/mcp_remote_connection.md
+++ b/doc/mcp_remote_connection.md
@@ -62,6 +62,7 @@ In `claude_desktop_config.json` (Settings → Developer → Edit Config):
       "args": [
         "mcp-remote",
         "http://localhost:8080/api/mcp/sse",
+        "--transport", "sse-only",
         "--header", "Authorization: Bearer ${REQUEL_TOKEN}",
         "--header", "X-Requel-Client: claude-desktop"
       ],
@@ -71,9 +72,13 @@ In `claude_desktop_config.json` (Settings → Developer → Edit Config):
 }
 ```
 
-Restart Claude Desktop. The Requel tools (`requel.listProjects`, `requel.getProject`,
-`requel.createGoal`, `requel.runCommand`, …) appear in the tools list. Write tools only appear when
-the server has writes enabled.
+Restart Claude Desktop. The Requel tools (`listProjects`, `getProject`, `createGoal`, `runCommand`,
+…) appear in the tools list. Write tools only appear when the server has writes enabled.
+
+`--transport sse-only` is important: `mcp-remote` defaults to Streamable HTTP and probes it first;
+since Requel currently serves only SSE, the probe fails and `mcp-remote` falls into an OAuth flow our
+server doesn't expose. Forcing SSE avoids that. (Tool names are bare — no `requel.` prefix — because
+MCP tool names must match `^[a-zA-Z0-9_-]{1,64}$`; dots are rejected by spec-compliant clients.)
 
 ### Codex (or any stdio MCP client)
 
@@ -81,12 +86,44 @@ Point the client's MCP server command at the same proxy invocation:
 
 ```
 npx mcp-remote http://localhost:8080/api/mcp/sse \
+  --transport sse-only \
   --header "Authorization: Bearer $REQUEL_TOKEN" \
   --header "X-Requel-Client: codex"
 ```
 
+### Cursor (and the robust wrapper-script pattern)
+
+Some clients (Cursor observed) pre-expand `$VAR` references and mangle quoting in the `args` of
+`mcp.json` before spawning the process, which produced an empty `Authorization: Bearer ` header.
+The reliable pattern is a tiny wrapper script that the client launches; the shell reads everything
+verbatim, loads the token from a gitignored `.env`, and execs the proxy. Keep the token only in
+`.env` — never in the script or `mcp.json`.
+
+`.cursor/mcp.json` (the per-developer config; gitignored):
+
+```json
+{ "mcpServers": { "requel": { "command": "/abs/path/to/requel-mcp.sh" } } }
+```
+
+`requel-mcp.sh` (also gitignored; make it executable):
+
+```sh
+#!/bin/sh
+# Load nvm (GUI-spawned shells often lack it on PATH) and the JWT from .env, then exec the proxy.
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+set -a; . /abs/path/to/Requel/.env; set +a   # provides REQUEL_JWT
+exec npx -y mcp-remote http://localhost:8080/api/mcp/sse \
+  --transport sse-only \
+  --header "Authorization: Bearer $REQUEL_JWT" \
+  --header "X-Requel-Client: cursor"
+```
+
+The same wrapper works for Claude Code (`claude mcp add`) when inline header expansion misbehaves.
+
 The `X-Requel-Client` header is optional; Requel records it for per-client audit attribution
-(`GatewayRequest.clientId` / the MCP call audit).
+(`GatewayRequest.clientId` / the MCP call audit). Per-developer `.cursor/` and `.claude/` configs
+are gitignored — only this portable recipe is committed.
 
 ## 3. Verify
 

--- a/modules/mcp-server/pom.xml
+++ b/modules/mcp-server/pom.xml
@@ -33,7 +33,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <!-- AnnotationAction / EntityRef for the requel.draftAnnotation tool, which
+            <!-- AnnotationAction / EntityRef for the draftAnnotation tool, which
                  returns an annotation draft (not persisted) for the applicator. -->
             <groupId>com.rreganjr.requel</groupId>
             <artifactId>assistant-api</artifactId>

--- a/modules/mcp-server/src/main/java/com/rreganjr/requel/mcp/McpJsonRpcController.java
+++ b/modules/mcp-server/src/main/java/com/rreganjr/requel/mcp/McpJsonRpcController.java
@@ -28,9 +28,16 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * JSON-RPC endpoint for the in-process MCP read server. It is mounted under
- * {@code /api/**}, so the existing JWT security chain and current-user
- * resolution are reused.
+ * JSON-RPC endpoint for the in-process MCP server, mounted under {@code /api/**} so the existing JWT
+ * security chain and current-user resolution are reused.
+ *
+ * <p><b>Retained intentionally (issue #82 decision).</b> The Spring AI MCP transport
+ * ({@code /api/mcp/sse}, see {@code RequelMcpServerConfig}) is the client-facing path. This
+ * hand-rolled JSON-RPC endpoint is kept as a thin, dependency-light POST transport and as the
+ * in-process driver used by {@code RequelMcpEndToEndIT}; both transports delegate to the same
+ * {@code McpReadService}/{@code McpWriteService} tool logic, so the duplication is minimal. Full
+ * removal was weighed and deferred as not worth the churn (it would require rewriting the e2e
+ * harness onto the {@code ToolCallback} path for no functional gain).
  */
 @RestController
 @RequestMapping("/api/mcp")

--- a/modules/mcp-server/src/main/java/com/rreganjr/requel/mcp/McpReadService.java
+++ b/modules/mcp-server/src/main/java/com/rreganjr/requel/mcp/McpReadService.java
@@ -71,40 +71,40 @@ public class McpReadService {
 
 	public Map<String, Object> listTools() {
 		List<McpToolDescriptor> tools = new ArrayList<>(List.of(
-				new McpToolDescriptor("requel.listProjects",
+				new McpToolDescriptor("listProjects",
 						"List projects visible to the current authenticated user.",
 						Map.of("type", "object", "properties", Map.of(), "additionalProperties",
 								false)),
-				new McpToolDescriptor("requel.getProject",
+				new McpToolDescriptor("getProject",
 						"Read one project summary by project name.",
 						projectNameSchema()),
-				new McpToolDescriptor("requel.getProjectTree",
+				new McpToolDescriptor("getProjectTree",
 						"Read the project content tree by project name.",
 						projectNameSchema()),
-				new McpToolDescriptor("requel.getGlossary",
+				new McpToolDescriptor("getGlossary",
 						"Read the glossary terms defined in a project.",
 						projectNameSchema()),
-				new McpToolDescriptor("requel.getOpenIssues",
+				new McpToolDescriptor("getOpenIssues",
 						"List the unresolved issues across all entities in a project.",
 						projectNameSchema()),
-				new McpToolDescriptor("requel.getAnnotations",
+				new McpToolDescriptor("getAnnotations",
 						"Read the notes and issues attached to one entity (by type and id).",
 						entityRefSchema()),
-				new McpToolDescriptor("requel.getEntity",
+				new McpToolDescriptor("getEntity",
 						"Read one entity (Goal, Story, Actor, UseCase, Scenario, or GlossaryTerm)"
 								+ " by type and id.",
 						entityRefSchema()),
-				new McpToolDescriptor("requel.getEntityNeighbors",
+				new McpToolDescriptor("getEntityNeighbors",
 						"Read an entity's related entities, grouped by relationship.",
 						entityRefSchema()),
-				new McpToolDescriptor("requel.searchProjectEntities",
+				new McpToolDescriptor("searchProjectEntities",
 						"Search a project's entities by name (case-insensitive substring).",
 						searchSchema()),
-				new McpToolDescriptor("requel.getProjectContext",
+				new McpToolDescriptor("getProjectContext",
 						"Read a composite context bundle for a project (summary, tree, glossary,"
 								+ " open issues).",
 						projectNameSchema()),
-				new McpToolDescriptor("requel.draftAnnotation",
+				new McpToolDescriptor("draftAnnotation",
 						"Build a draft annotation (note or issue) for an entity and return it"
 								+ " WITHOUT persisting; the caller submits it for application.",
 						draftAnnotationSchema())));
@@ -124,29 +124,29 @@ public class McpReadService {
 					"isError", false);
 		}
 		Object result = switch (name) {
-			case "requel.listProjects" -> projectQueryGateway.listProjects();
-			case "requel.getProject" -> projectQueryGateway.getProject(requiredText(arguments,
+			case "listProjects" -> projectQueryGateway.listProjects();
+			case "getProject" -> projectQueryGateway.getProject(requiredText(arguments,
 					"projectName"));
-			case "requel.getProjectTree" -> projectQueryGateway.getProjectTree(requiredText(
+			case "getProjectTree" -> projectQueryGateway.getProjectTree(requiredText(
 					arguments, "projectName"));
-			case "requel.getGlossary" -> projectQueryGateway.getGlossaryTerms(requiredText(
+			case "getGlossary" -> projectQueryGateway.getGlossaryTerms(requiredText(
 					arguments, "projectName"));
-			case "requel.getOpenIssues" -> projectQueryGateway.getOpenIssues(requiredText(
+			case "getOpenIssues" -> projectQueryGateway.getOpenIssues(requiredText(
 					arguments, "projectName"));
-			case "requel.getAnnotations" -> projectQueryGateway.getAnnotations(
+			case "getAnnotations" -> projectQueryGateway.getAnnotations(
 					requiredText(arguments, "projectName"), requiredText(arguments, "entityType"),
 					requiredLong(arguments, "entityId"));
-			case "requel.getEntity" -> projectQueryGateway.getEntity(
+			case "getEntity" -> projectQueryGateway.getEntity(
 					requiredText(arguments, "projectName"), requiredText(arguments, "entityType"),
 					requiredLong(arguments, "entityId"));
-			case "requel.getEntityNeighbors" -> projectQueryGateway.getEntityNeighbors(
+			case "getEntityNeighbors" -> projectQueryGateway.getEntityNeighbors(
 					requiredText(arguments, "projectName"), requiredText(arguments, "entityType"),
 					requiredLong(arguments, "entityId"));
-			case "requel.searchProjectEntities" -> projectQueryGateway.searchProjectEntities(
+			case "searchProjectEntities" -> projectQueryGateway.searchProjectEntities(
 					requiredText(arguments, "projectName"), requiredText(arguments, "query"));
-			case "requel.getProjectContext" -> projectQueryGateway.getProjectContext(
+			case "getProjectContext" -> projectQueryGateway.getProjectContext(
 					requiredText(arguments, "projectName"));
-			case "requel.draftAnnotation" -> draftAnnotation(arguments);
+			case "draftAnnotation" -> draftAnnotation(arguments);
 			default -> throw new McpInvalidParamsException("Unknown MCP tool: " + name);
 		};
 		return Map.of("content", List.of(new McpTextContent("text", toJson(result))),

--- a/modules/mcp-server/src/main/java/com/rreganjr/requel/mcp/McpWriteService.java
+++ b/modules/mcp-server/src/main/java/com/rreganjr/requel/mcp/McpWriteService.java
@@ -35,7 +35,7 @@ import com.rreganjr.requel.gateway.GatewayResult;
 
 /**
  * MCP write tools, backed by the {@link CommandGateway}. Exposes a generic
- * {@code requel.runCommand} (any allowlisted command type + JSON input) plus a curated set of
+ * {@code runCommand} (any allowlisted command type + JSON input) plus a curated set of
  * ergonomic typed tools whose argument names already match the command input DTOs, so they are
  * thin wrappers that fix the command type and forward the arguments.
  * <p>
@@ -49,16 +49,16 @@ import com.rreganjr.requel.gateway.GatewayResult;
 public class McpWriteService {
 
 	/** Generic escape hatch: run any allowlisted command by type + input. */
-	static final String RUN_COMMAND = "requel.runCommand";
+	static final String RUN_COMMAND = "runCommand";
 
 	/** Typed convenience tools -> the gateway command type each forwards to. */
 	private static final Map<String, String> TYPED_TOOLS = Map.of(
-			"requel.createProject", "EditProject",
-			"requel.createGoal", "EditGoal",
-			"requel.editGoal", "EditGoal",
-			"requel.addGoalToContainer", "AddGoalToGoalContainer",
-			"requel.createNote", "EditNote",
-			"requel.createIssue", "EditIssue");
+			"createProject", "EditProject",
+			"createGoal", "EditGoal",
+			"editGoal", "EditGoal",
+			"addGoalToContainer", "AddGoalToGoalContainer",
+			"createNote", "EditNote",
+			"createIssue", "EditIssue");
 
 	private final CommandGateway commandGateway;
 	private final ObjectMapper objectMapper;
@@ -91,33 +91,33 @@ public class McpWriteService {
 								+ " object. Subject to the gateway allow/deny policy and the caller's"
 								+ " stakeholder permissions.",
 						runCommandSchema()),
-				new McpToolDescriptor("requel.createProject",
+				new McpToolDescriptor("createProject",
 						"Create a project. Arguments: name, organizationName, optional description.",
 						objectSchema(Map.of("name", stringType(), "organizationName", stringType(),
 								"description", stringType()), List.of("name", "organizationName"))),
-				new McpToolDescriptor("requel.createGoal",
+				new McpToolDescriptor("createGoal",
 						"Create a goal in a project. Arguments: projectName, name, optional text.",
 						objectSchema(Map.of("projectName", stringType(), "name", stringType(),
 								"text", stringType()), List.of("projectName", "name"))),
-				new McpToolDescriptor("requel.editGoal",
+				new McpToolDescriptor("editGoal",
 						"Edit an existing goal. Arguments: projectName, goalId, optional name/text.",
 						objectSchema(Map.of("projectName", stringType(), "goalId", integerType(),
 								"name", stringType(), "text", stringType()),
 								List.of("projectName", "goalId"))),
-				new McpToolDescriptor("requel.addGoalToContainer",
+				new McpToolDescriptor("addGoalToContainer",
 						"Associate a goal with a container (Project, Story, UseCase, Actor, or"
 								+ " Stakeholder). Arguments: projectName, goalId, goalContainerId,"
 								+ " containerType.",
 						objectSchema(Map.of("projectName", stringType(), "goalId", integerType(),
 								"goalContainerId", integerType(), "containerType", stringType()),
 								List.of("projectName", "goalId", "goalContainerId", "containerType"))),
-				new McpToolDescriptor("requel.createNote",
+				new McpToolDescriptor("createNote",
 						"Attach a note to an entity. Arguments: projectName, entityType, entityId,"
 								+ " text.",
 						objectSchema(Map.of("projectName", stringType(), "entityType", stringType(),
 								"entityId", integerType(), "text", stringType()),
 								List.of("projectName", "entityType", "entityId", "text"))),
-				new McpToolDescriptor("requel.createIssue",
+				new McpToolDescriptor("createIssue",
 						"Raise an issue on an entity. Arguments: projectName, entityType, entityId,"
 								+ " text, optional mustBeResolved.",
 						objectSchema(Map.of("projectName", stringType(), "entityType", stringType(),

--- a/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/McpJsonRpcHandlerTest.java
+++ b/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/McpJsonRpcHandlerTest.java
@@ -52,7 +52,7 @@ class McpJsonRpcHandlerTest {
 		JsonNode result = objectMapper.valueToTree(response.result());
 		assertThat(result.path("tools")).hasSize(11);
 		assertThat(result.path("tools").get(0).path("name").asText()).isEqualTo(
-				"requel.listProjects");
+				"listProjects");
 	}
 
 	@Test
@@ -72,7 +72,7 @@ class McpJsonRpcHandlerTest {
 	void returnsInvalidParamsForUnknownTool() {
 		McpJsonRpcHandler handler = new McpJsonRpcHandler(new McpReadService(
 				new StubProjectQueryGateway(), objectMapper), noOpAuditor());
-		JsonNode params = objectMapper.createObjectNode().put("name", "requel.bogusTool");
+		JsonNode params = objectMapper.createObjectNode().put("name", "bogusTool");
 
 		McpJsonRpcResponse response = handler.handle(new McpJsonRpcRequest("2.0",
 				objectMapper.valueToTree(2), "tools/call", params));
@@ -85,8 +85,8 @@ class McpJsonRpcHandlerTest {
 	void returnsInvalidParamsForMissingRequiredArgument() {
 		McpJsonRpcHandler handler = new McpJsonRpcHandler(new McpReadService(
 				new StubProjectQueryGateway(), objectMapper), noOpAuditor());
-		// requel.getProject requires arguments.projectName, which is absent here.
-		JsonNode params = objectMapper.createObjectNode().put("name", "requel.getProject");
+		// getProject requires arguments.projectName, which is absent here.
+		JsonNode params = objectMapper.createObjectNode().put("name", "getProject");
 
 		McpJsonRpcResponse response = handler.handle(new McpJsonRpcRequest("2.0",
 				objectMapper.valueToTree(3), "tools/call", params));

--- a/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/McpReadServiceTest.java
+++ b/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/McpReadServiceTest.java
@@ -45,17 +45,17 @@ class McpReadServiceTest {
 		McpReadService limited = new McpReadService(new StubProjectQueryGateway(),
 				new McpWriteService(null, objectMapper, false), blocking, objectMapper);
 		assertThatThrownBy(() -> limited.callTool(json("""
-				{ "name": "requel.getProject", "arguments": { "projectName": "Sample" } }
+				{ "name": "getProject", "arguments": { "projectName": "Sample" } }
 				""")))
 				.isInstanceOf(McpRateLimitExceededException.class)
-				.hasMessageContaining("requel.getProject");
+				.hasMessageContaining("getProject");
 	}
 
 	@Test
 	void callsReadOnlyProjectTool() {
 		Map<String, Object> response = service.callTool(json("""
 				{
-				  "name": "requel.getProject",
+				  "name": "getProject",
 				  "arguments": { "projectName": "Sample" }
 				}
 				"""));
@@ -90,7 +90,7 @@ class McpReadServiceTest {
 	@Test
 	void callsOpenIssuesTool() {
 		Map<String, Object> response = service.callTool(json("""
-				{ "name": "requel.getOpenIssues", "arguments": { "projectName": "Sample" } }
+				{ "name": "getOpenIssues", "arguments": { "projectName": "Sample" } }
 				"""));
 
 		JsonNode content = objectMapper.valueToTree(response.get("content"));
@@ -102,7 +102,7 @@ class McpReadServiceTest {
 	void callsGetAnnotationsTool() {
 		Map<String, Object> response = service.callTool(json("""
 				{
-				  "name": "requel.getAnnotations",
+				  "name": "getAnnotations",
 				  "arguments": { "projectName": "Sample", "entityType": "Goal", "entityId": 10 }
 				}
 				"""));
@@ -116,7 +116,7 @@ class McpReadServiceTest {
 	void callsGetEntityTool() {
 		Map<String, Object> response = service.callTool(json("""
 				{
-				  "name": "requel.getEntity",
+				  "name": "getEntity",
 				  "arguments": { "projectName": "Sample", "entityType": "Goal", "entityId": 10 }
 				}
 				"""));
@@ -130,7 +130,7 @@ class McpReadServiceTest {
 	void callsGetEntityNeighborsTool() {
 		Map<String, Object> response = service.callTool(json("""
 				{
-				  "name": "requel.getEntityNeighbors",
+				  "name": "getEntityNeighbors",
 				  "arguments": { "projectName": "Sample", "entityType": "Goal", "entityId": 10 }
 				}
 				"""));
@@ -144,7 +144,7 @@ class McpReadServiceTest {
 	void callsSearchProjectEntitiesTool() {
 		Map<String, Object> response = service.callTool(json("""
 				{
-				  "name": "requel.searchProjectEntities",
+				  "name": "searchProjectEntities",
 				  "arguments": { "projectName": "Sample", "query": "login" }
 				}
 				"""));
@@ -157,7 +157,7 @@ class McpReadServiceTest {
 	@Test
 	void callsGetProjectContextTool() {
 		Map<String, Object> response = service.callTool(json("""
-				{ "name": "requel.getProjectContext", "arguments": { "projectName": "Sample" } }
+				{ "name": "getProjectContext", "arguments": { "projectName": "Sample" } }
 				"""));
 
 		JsonNode content = objectMapper.valueToTree(response.get("content"));
@@ -180,7 +180,7 @@ class McpReadServiceTest {
 	void draftAnnotationReturnsUnpersistedDraft() {
 		Map<String, Object> response = service.callTool(json("""
 				{
-				  "name": "requel.draftAnnotation",
+				  "name": "draftAnnotation",
 				  "arguments": {
 				    "entityType": "Goal", "entityId": 10, "kind": "ISSUE",
 				    "text": "Clarify the SLA"
@@ -199,7 +199,7 @@ class McpReadServiceTest {
 	void draftAnnotationRejectsUnknownKind() {
 		assertThatThrownBy(() -> service.callTool(json("""
 				{
-				  "name": "requel.draftAnnotation",
+				  "name": "draftAnnotation",
 				  "arguments": { "entityType": "Goal", "entityId": 10, "kind": "BOGUS",
 				    "text": "x" }
 				}

--- a/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/McpToolNamingTest.java
+++ b/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/McpToolNamingTest.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rreganjr.requel.gateway.GatewayResult;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the MCP tool-name convention (issue #82). MCP tool names must match
+ * {@code ^[a-zA-Z0-9_-]{1,64}$} — dots are not allowed — and a dotted prefix (the old
+ * {@code requel.*}) caused spec-compliant clients (Cursor, Claude Code) to reject the tools. This
+ * asserts every advertised tool name (read + write) stays within the pattern so the regression
+ * can't return.
+ */
+class McpToolNamingTest {
+
+	private static final java.util.regex.Pattern MCP_TOOL_NAME =
+			java.util.regex.Pattern.compile("^[a-zA-Z0-9_-]{1,64}$");
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void allAdvertisedToolNamesMatchTheMcpPattern() {
+		// Write-enabled so the write tools are advertised and checked too.
+		McpWriteService writes = new McpWriteService(
+				request -> new GatewayResult(request.commandType(), null), objectMapper, true);
+		McpReadService service = new McpReadService(new StubProjectQueryGateway(), writes,
+				McpRateLimiter.NOOP, objectMapper);
+
+		List<McpToolDescriptor> tools =
+				(List<McpToolDescriptor>) service.listTools().get("tools");
+
+		assertThat(tools).isNotEmpty();
+		assertThat(tools).extracting(McpToolDescriptor::name)
+				.allSatisfy(name -> assertThat(name)
+						.as("MCP tool name '%s' must match %s", name, MCP_TOOL_NAME.pattern())
+						.matches(MCP_TOOL_NAME));
+		// Sanity: both a read and a write tool are present.
+		assertThat(tools).extracting(McpToolDescriptor::name)
+				.contains("listProjects", "createGoal", "runCommand");
+	}
+}

--- a/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/McpWriteServiceTest.java
+++ b/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/McpWriteServiceTest.java
@@ -72,8 +72,8 @@ class McpWriteServiceTest {
 	void writeToolsAbsentAndRejectedWhenDisabled() {
 		McpWriteService disabled = new McpWriteService(new RecordingGateway(), objectMapper, false);
 		assertThat(disabled.toolDescriptors()).isEmpty();
-		assertThat(disabled.handles("requel.createGoal")).isTrue();
-		assertThatThrownBy(() -> disabled.call("requel.createGoal",
+		assertThat(disabled.handles("createGoal")).isTrue();
+		assertThatThrownBy(() -> disabled.call("createGoal",
 				json("{\"projectName\":\"P\",\"name\":\"G\"}")))
 				.isInstanceOf(McpInvalidParamsException.class)
 				.hasMessageContaining("disabled");
@@ -85,17 +85,17 @@ class McpWriteServiceTest {
 		Map<String, Object> tools = readOnly.listTools();
 		@SuppressWarnings("unchecked")
 		List<McpToolDescriptor> descriptors = (List<McpToolDescriptor>) tools.get("tools");
-		assertThat(descriptors).noneMatch(d -> d.name().startsWith("requel.runCommand")
-				|| d.name().equals("requel.createGoal"));
+		assertThat(descriptors).noneMatch(d -> d.name().startsWith("runCommand")
+				|| d.name().equals("createGoal"));
 	}
 
 	@Test
 	void writeToolsListedWhenEnabled() {
 		McpWriteService enabled = new McpWriteService(new RecordingGateway(), objectMapper, true);
 		assertThat(enabled.toolDescriptors()).extracting(McpToolDescriptor::name)
-				.contains("requel.runCommand", "requel.createGoal", "requel.editGoal",
-						"requel.addGoalToContainer", "requel.createNote", "requel.createIssue",
-						"requel.createProject");
+				.contains("runCommand", "createGoal", "editGoal",
+						"addGoalToContainer", "createNote", "createIssue",
+						"createProject");
 	}
 
 	// ---- delegation ----------------------------------------------------------------------------
@@ -104,7 +104,7 @@ class McpWriteServiceTest {
 	void runCommandForwardsTypeAndInput() {
 		RecordingGateway gw = new RecordingGateway();
 		McpWriteService svc = new McpWriteService(gw, objectMapper, true);
-		Object result = svc.call("requel.runCommand",
+		Object result = svc.call("runCommand",
 				json("{\"commandType\":\"EditGoal\",\"input\":{\"projectName\":\"P\",\"name\":\"G\"}}"));
 		assertThat(gw.last.commandType()).isEqualTo("EditGoal");
 		assertThat(gw.last.input()).isInstanceOf(Map.class);
@@ -119,7 +119,7 @@ class McpWriteServiceTest {
 		McpWriteService svc = new McpWriteService(gw, objectMapper, true);
 		McpClientContext.setClientId("claude-desktop");
 		try {
-			svc.call("requel.createGoal", json("{\"projectName\":\"P\",\"name\":\"G\"}"));
+			svc.call("createGoal", json("{\"projectName\":\"P\",\"name\":\"G\"}"));
 		} finally {
 			McpClientContext.clear();
 		}
@@ -130,7 +130,7 @@ class McpWriteServiceTest {
 	void typedToolFixesCommandTypeAndForwardsArgs() {
 		RecordingGateway gw = new RecordingGateway();
 		McpWriteService svc = new McpWriteService(gw, objectMapper, true);
-		svc.call("requel.createGoal",
+		svc.call("createGoal",
 				json("{\"projectName\":\"P\",\"name\":\"G\",\"text\":\"T\"}"));
 		assertThat(gw.last.commandType()).isEqualTo("EditGoal");
 		assertThat(asMap(gw.last.input()))
@@ -144,7 +144,7 @@ class McpWriteServiceTest {
 		RecordingGateway gw = new RecordingGateway();
 		gw.resultPayload = null; // e.g. AddGoalToGoalContainer returns no DTO
 		McpWriteService svc = new McpWriteService(gw, objectMapper, true);
-		Object result = svc.call("requel.addGoalToContainer",
+		Object result = svc.call("addGoalToContainer",
 				json("{\"projectName\":\"P\",\"goalId\":1,\"goalContainerId\":2,"
 						+ "\"containerType\":\"Project\"}"));
 		assertThat(asMap(result)).containsEntry("ok", true)
@@ -158,7 +158,7 @@ class McpWriteServiceTest {
 		RecordingGateway gw = new RecordingGateway();
 		gw.toThrow = new GatewayException(GatewayException.Kind.NOT_ALLOWED, "denied");
 		McpWriteService svc = new McpWriteService(gw, objectMapper, true);
-		assertThatThrownBy(() -> svc.call("requel.createGoal",
+		assertThatThrownBy(() -> svc.call("createGoal",
 				json("{\"projectName\":\"P\",\"name\":\"G\"}")))
 				.isInstanceOf(McpInvalidParamsException.class)
 				.hasMessageContaining("denied");
@@ -169,7 +169,7 @@ class McpWriteServiceTest {
 		RecordingGateway gw = new RecordingGateway();
 		gw.toThrow = new GatewayException(GatewayException.Kind.EXECUTION_ERROR, "boom");
 		McpWriteService svc = new McpWriteService(gw, objectMapper, true);
-		assertThatThrownBy(() -> svc.call("requel.createGoal",
+		assertThatThrownBy(() -> svc.call("createGoal",
 				json("{\"projectName\":\"P\",\"name\":\"G\"}")))
 				.isInstanceOf(IllegalStateException.class)
 				.hasMessageContaining("boom");

--- a/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/RequelMcpServerConfigTest.java
+++ b/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/RequelMcpServerConfigTest.java
@@ -56,10 +56,10 @@ class RequelMcpServerConfigTest {
 		ToolCallbackProvider provider = config.requelToolCallbackProvider(readOnly, auditor, objectMapper);
 
 		List<String> names = toolNames(provider);
-		assertThat(names).contains("requel.listProjects", "requel.getProject",
-				"requel.getOpenIssues", "requel.draftAnnotation");
-		assertThat(names).noneMatch(n -> n.equals("requel.runCommand")
-				|| n.equals("requel.createGoal"));
+		assertThat(names).contains("listProjects", "getProject",
+				"getOpenIssues", "draftAnnotation");
+		assertThat(names).noneMatch(n -> n.equals("runCommand")
+				|| n.equals("createGoal"));
 	}
 
 	@Test
@@ -71,7 +71,7 @@ class RequelMcpServerConfigTest {
 		ToolCallbackProvider provider = config.requelToolCallbackProvider(withWrites, auditor,
 				objectMapper);
 
-		assertThat(toolNames(provider)).contains("requel.runCommand", "requel.createGoal");
+		assertThat(toolNames(provider)).contains("runCommand", "createGoal");
 	}
 
 	@Test
@@ -88,11 +88,11 @@ class RequelMcpServerConfigTest {
 		ToolCallbackProvider provider = config.requelToolCallbackProvider(readOnly, recording,
 				objectMapper);
 		ToolCallback getProject = Arrays.stream(provider.getToolCallbacks())
-				.filter(tc -> tc.getToolDefinition().name().equals("requel.getProject"))
+				.filter(tc -> tc.getToolDefinition().name().equals("getProject"))
 				.findFirst().orElseThrow();
 
 		getProject.call("{\"projectName\":\"Sample\"}");
-		assertThat(audited).contains("requel.getProject:true");
+		assertThat(audited).contains("getProject:true");
 	}
 
 	@Test
@@ -100,7 +100,7 @@ class RequelMcpServerConfigTest {
 		McpReadService readOnly = new McpReadService(new StubProjectQueryGateway(), objectMapper);
 		ToolCallbackProvider provider = config.requelToolCallbackProvider(readOnly, auditor, objectMapper);
 		ToolCallback getProject = Arrays.stream(provider.getToolCallbacks())
-				.filter(tc -> tc.getToolDefinition().name().equals("requel.getProject"))
+				.filter(tc -> tc.getToolDefinition().name().equals("getProject"))
 				.findFirst().orElseThrow();
 
 		String result = getProject.call("{\"projectName\":\"Sample\"}");

--- a/modules/platform-core/src/main/java/com/rreganjr/repository/jpa/ConstraintViolationExceptionAdapter.java
+++ b/modules/platform-core/src/main/java/com/rreganjr/repository/jpa/ConstraintViolationExceptionAdapter.java
@@ -50,12 +50,21 @@ public class ConstraintViolationExceptionAdapter implements EntityExceptionAdapt
 	@Override
 	public EntityException convert(Throwable original, Class<?> entityType, Object entity,
 			EntityExceptionActionType actionType) {
-        if (entityType == null && entity == null && original instanceof ConstraintViolationException) {
-            ConstraintViolationException cve = (ConstraintViolationException) original;
+        if (entityType == null && entity == null && original instanceof ConstraintViolationException cve) {
             SQLException sqle = cve.getSQLException();
-            // SQLState '23000' indicates integrity constraint violation across vendors
-            if (sqle != null && "23000".equals(sqle.getSQLState())) {
-                return EntityException.uniquenessConflict(sqle, sqle.getMessage());
+            // SQLState class "23" is the integrity-constraint-violation family — uniqueness AND
+            // referential-integrity (FK) violations. The old check only matched the exact "23000",
+            // so an H2 FK violation (e.g. SQLState 23506/23503) fell through to the generic
+            // "unknown" label below, masking a real referential-integrity failure during #69
+            // testing. Surface the actual constraint name + DB message for any 23xxx so the error
+            // is self-explanatory.
+            String sqlState = sqle != null ? sqle.getSQLState() : null;
+            if (sqlState != null && sqlState.startsWith("23")) {
+                String constraint = cve.getConstraintName();
+                String detail = (constraint != null && !constraint.isBlank())
+                        ? "constraint " + constraint + ": " + sqle.getMessage()
+                        : sqle.getMessage();
+                return EntityException.uniquenessConflict(sqle, detail);
             }
         }
         return EntityException.uniquenessConflict(entityType, entity, propertyName, actionType);

--- a/modules/requel-app/src/main/resources/application.properties
+++ b/modules/requel-app/src/main/resources/application.properties
@@ -64,11 +64,13 @@ requel.gateway.write.enabled=true
 spring.ai.mcp.server.enabled=true
 spring.ai.mcp.server.name=requel-mcp-server
 spring.ai.mcp.server.version=2.0.0-dev
-# Classic SSE transport (broad client compatibility).
+# Transport decision (issue #82): SSE only for now. SSE is verified end-to-end and works with every
+# client tested (Cursor, Claude Code, MCP Inspector) using `mcp-remote --transport sse-only`.
+# Streamable HTTP is the MCP spec's forward direction and is left as a future spike — whether the
+# 1.1.7 WebMVC starter can serve SSE + Streamable simultaneously (vs. selecting one) is unverified,
+# so it's deferred until a client actually requires it rather than enabled blind. To spike it,
+# uncomment the protocol/endpoint properties below and confirm both transports at run.
 spring.ai.mcp.server.sse-endpoint=/api/mcp/sse
 spring.ai.mcp.server.sse-message-endpoint=/api/mcp/message
-# Streamable HTTP transport (MCP spec direction; Spring AI 1.1). Enable per the 1.1.7 starter's
-# capabilities — confirm at run whether SSE and Streamable can be served simultaneously or whether
-# this selects one. Default endpoint relocated under /api/mcp as well.
 # spring.ai.mcp.server.protocol=STREAMABLE
 # spring.ai.mcp.server.streamable-http.mcp-endpoint=/api/mcp

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/service/RequelMcpEndToEndIT.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/service/RequelMcpEndToEndIT.java
@@ -141,30 +141,30 @@ public class RequelMcpEndToEndIT extends AbstractIntegrationTestCase {
 		long mcpCallsBefore = mcpCallAuditRepository.count();
 		try {
 			// 1. Create a goal.
-			JsonNode goal = callTool("requel.createGoal",
+			JsonNode goal = callTool("createGoal",
 					Map.of("projectName", projectName, "name", "E2E Goal", "text", "via mcp"));
 			long goalId = goal.get("id").asLong();
 			assertThat(goalId).isPositive();
 
 			// 2. Create a non-user stakeholder via the generic runCommand tool.
-			JsonNode stakeholder = callTool("requel.runCommand",
+			JsonNode stakeholder = callTool("runCommand",
 					Map.of("commandType", "EditNonUserStakeholder",
 							"input", Map.of("projectName", projectName, "name", "E2E Vendor")));
 			long stakeholderId = stakeholder.get("id").asLong();
 			assertThat(stakeholderId).isPositive();
 
 			// 3. Associate the goal with the stakeholder (a goal container).
-			callTool("requel.addGoalToContainer",
+			callTool("addGoalToContainer",
 					Map.of("projectName", projectName, "goalId", goalId,
 							"goalContainerId", stakeholderId, "containerType", "NonUserStakeholder"));
 
 			// 4. Attach a note to the goal.
-			callTool("requel.createNote",
+			callTool("createNote",
 					Map.of("projectName", projectName, "entityType", "Goal", "entityId", goalId,
 							"text", "a note added over MCP"));
 
 			// 5. Read the project context back and confirm the goal is present.
-			JsonNode context = callTool("requel.getProjectContext",
+			JsonNode context = callTool("getProjectContext",
 					Map.of("projectName", projectName));
 			assertThat(context.toString()).contains("E2E Goal");
 		} finally {


### PR DESCRIPTION
Closes #82. Bare tool names + naming guard test; mcp-remote recipe (SSE-only + wrapper-script); kept JSON-RPC (documented) and SSE-only transport decision; ConstraintViolationExceptionAdapter surfaces the real constraint for any 23xxx integrity violation.