### PR TITLE
#73 User-mintable, revocable Personal Access Tokens (PATs)

### DIFF
--- a/doc/mcp_remote_connection.md
+++ b/doc/mcp_remote_connection.md
@@ -34,19 +34,33 @@ is tracked separately (see "Durable credentials" below).
 
 ## 1. Get a token
 
-The MCP endpoints require a JWT, same as any `/api/**` call. Log in as the Requel user you want the
-client to act as:
+The MCP endpoints require a bearer credential, same as any `/api/**` call. Two options:
+
+**Recommended — a personal access token (PAT, #73):** a durable, revocable token you mint once and
+leave configured. First log in to get a short-lived JWT, then use it to mint the PAT:
 
 ```bash
-curl -s -X POST http://localhost:8080/api/auth/login \
+# one-time: log in, then mint a named PAT (optionally expiresInDays)
+JWT=$(curl -s -X POST http://localhost:8080/api/auth/login \
   -H 'Content-Type: application/json' \
-  -d '{"username":"your-username","password":"your-password"}'
-# -> {"token":"<JWT>", ...}
+  -d '{"username":"your-username","password":"your-password"}' | jq -r .token)
+
+curl -s -X POST http://localhost:8080/api/auth/tokens \
+  -H "Authorization: Bearer $JWT" -H 'Content-Type: application/json' \
+  -d '{"name":"claude-desktop","expiresInDays":365}'
+# -> {"token":"reqpat_…","tokenInfo":{...}}   (the reqpat_ value is shown ONCE)
 ```
 
-The client will act as **that user** — its stakeholder permissions on each project govern what the
-tools can read and write. Use a user that is a stakeholder with the permissions you intend to grant
-the assistant (e.g. `Goal[Edit]`, `Annotation[Edit]`), not an over-privileged admin.
+Use the `reqpat_…` value as the bearer below. It doesn't expire on the JWT's ~8h schedule, and you
+can revoke it any time: `GET /api/auth/tokens` to list, `DELETE /api/auth/tokens/{id}` to revoke —
+revocation takes effect on the token's next request.
+
+**Quick alternative — the login JWT** (`…/api/auth/login` → `token`): fine for a one-off test, but it
+expires in ~8h, so a left-configured client will stop working. Prefer the PAT for anything persistent.
+
+Either way the client acts as **that user** — its stakeholder permissions on each project govern what
+the tools can read and write. Use a user scoped to what the assistant should do (e.g. `Goal[Edit]`,
+`Annotation[Edit]`), not an over-privileged admin.
 
 ## 2. Configure the client
 
@@ -151,10 +165,12 @@ In the client, list tools and call `requel.listProjects` to confirm reads, then 
 - **Auditing.** Every tool call is recorded as an MCP-call audit row, and every write additionally
   produces a command-audit row attributed to the acting user.
 
-## Durable credentials (follow-on: #73)
+## Durable credentials (PATs, #73)
 
-The login JWT is short-lived (~8h by default, `requel.jwt.expiry-hours`), so a left-configured
-client will need its token refreshed. Long-lived API keys / personal access tokens — minted for a
-chosen user and dropped into the `Authorization` header — are tracked in **issue #73**; that is the
-intended way to make this setup pleasant for a persistently-configured desktop client. Until then,
-re-run step 1 to refresh the token when it expires.
+The login JWT is short-lived (~8h by default, `requel.jwt.expiry-hours`), so it's a poor fit for a
+left-configured client. Personal access tokens (#73) are the durable answer: mint a named,
+revocable `reqpat_…` token for a chosen user (step 1), drop it in the `Authorization` header, and
+manage it via `GET`/`DELETE /api/auth/tokens` (revocation takes effect on the token's next request,
+and only the SHA-256 hash is stored server-side). Token *scoping* (read-only vs write-set) is a
+later enhancement; today a PAT carries its owner's full rights. Interactive OAuth 2.1 for agent
+clients that drive the discovery flow is a separate track (#83).

--- a/doc/oauth_mcp_plan.md
+++ b/doc/oauth_mcp_plan.md
@@ -1,0 +1,108 @@
+# MCP OAuth 2.1 authorization — design plan
+
+> Plan for spec-compliant authorization on the MCP endpoints so AI agent clients (Cursor, Claude
+> Code, Claude Cowork/desktop) authenticate via the OAuth flow they expect, instead of a static
+> Requel JWT. Surfaced while testing #69: those clients drive the MCP authorization spec's OAuth 2.1
+> discovery flow on a 401 and can't use a pasted bearer token. Tracked as a v2.0 ticket.
+
+## Goal
+
+Make `/api/mcp/**` a spec-compliant MCP OAuth 2.1 protected resource so an agent client can connect
+with no pre-shared token: it discovers the authorization server, runs authorization-code + PKCE
+(optionally self-registering via dynamic client registration), gets an access token, and calls tools
+that execute as the authenticated Requel user under the existing gateway authorization.
+
+## Decision
+
+**Embedded authorization server**: Requel runs its own OAuth 2.1 authorization server
+(Spring Authorization Server) against its existing user store, and `/api/mcp/**` is an OAuth2
+resource server validating tokens that AS issues. One deployable, no external IdP — fits the
+self-hosted "run Requel locally + connect agents" model. (External-IdP and pluggable options were
+considered and rejected for added ops/footprint.)
+
+## What the MCP spec / RFCs require
+
+- **RFC 9728 Protected Resource Metadata**: serve `/.well-known/oauth-protected-resource` for the MCP
+  resource, listing the authorization server(s); emit `WWW-Authenticate: Bearer resource_metadata="…"`
+  on 401 from the MCP endpoints.
+- **OAuth 2.1 Authorization Server** with **RFC 8414** Authorization Server Metadata
+  (`/.well-known/oauth-authorization-server`): authorization-code + PKCE, token endpoint, JWK set.
+- **RFC 7591 Dynamic Client Registration** (optional but practically needed): agent clients
+  self-register a client on first connect.
+
+## Architecture
+
+- **Authorization server** — `spring-boot-starter-oauth2-authorization-server` (Spring Authorization
+  Server, compatible with Boot 3.5.x). Provides RFC 8414 metadata, authorization/token/JWK endpoints,
+  and a login + consent flow. Back it with Requel's existing user store / `UserRepository` +
+  authentication so users log in with their Requel credentials. Issues JWT access tokens with `sub`
+  = the Requel username (or user id).
+- **Resource server** — `spring-boot-starter-oauth2-resource-server` on a dedicated security filter
+  chain for `/api/mcp/**`, validating the AS-issued JWTs via the AS's issuer/JWK set. Map the token
+  subject to a Requel user and set the security context (reuse `CurrentUserResolver`), so
+  `CommandGateway` / `CurrentUserCommandHandler` run per-stakeholder authorization as that user —
+  exactly as the static-JWT path does today.
+- **RFC 9728 Protected Resource Metadata** — a small endpoint serving
+  `/.well-known/oauth-protected-resource` (Spring AS doesn't provide this; it's a resource concern),
+  plus the `WWW-Authenticate` header on MCP 401s pointing at it.
+- **Dynamic Client Registration** — enable Spring AS's client-registration endpoint so agent clients
+  self-register; gate it (initial access token / allowed redirect patterns) to limit who can register.
+  Support loopback (`http://127.0.0.1`/`localhost`) redirect URIs for desktop clients.
+- **Coexistence with the existing JWT** — keep the current username/password → JWT chain for the SPA
+  and scripts on `/api/**`; add OAuth only for `/api/mcp/**` via a higher-precedence filter chain.
+  The AS's own endpoints get Spring AS's default security chain. Matcher ordering must be explicit
+  (three chains: AS endpoints, `/api/mcp/**` resource server, existing `/api/**` JWT).
+
+## Relationship to #73 (durable API tokens / PAT)
+
+Complementary, not duplicate: **OAuth 2.1 = interactive agent clients** (they do the discovery +
+code/PKCE dance); **PAT (#73) = scripts / CI / headless** (a long-lived token in a header). Both
+resolve to a Requel user and run through the same gateway authorization. Decide during
+implementation whether #73 folds in here or stays a separate non-interactive track; recommend
+keeping both.
+
+## Persistence / migration
+
+Spring Authorization Server needs tables for registered clients, authorizations, and consents
+(`JdbcRegisteredClientRepository` etc.). Add Flyway migrations for MySQL and mirror in the H2 test
+config. Decide whether registered clients are seeded or created via DCR.
+
+## Testing strategy
+
+- Metadata: `/.well-known/oauth-authorization-server` (RFC 8414) and
+  `/.well-known/oauth-protected-resource` (RFC 9728) return correct documents.
+- Resource server: `/api/mcp/**` returns 401 + `WWW-Authenticate: …resource_metadata=…` without a
+  token; accepts a valid AS-issued token and runs tools as the mapped user.
+- Token → Requel user mapping drives gateway authorization (per-stakeholder permissions still
+  enforced).
+- An integration test exercising authorization-code + PKCE end to end against the embedded AS.
+- DCR: a client can self-register (within the configured policy).
+
+## Implementation slices
+
+1. **Embedded AS**: add Spring Authorization Server, persistence + migrations, back it with the
+   Requel user store; issue tokens; expose RFC 8414 metadata + login/consent.
+2. **MCP resource server**: dedicated filter chain on `/api/mcp/**` validating AS tokens; map
+   subject → Requel user into the security context; keep the SPA JWT chain intact.
+3. **RFC 9728**: protected-resource metadata endpoint + `WWW-Authenticate` on MCP 401.
+4. **Dynamic Client Registration**: enable + gate; loopback redirect URIs for desktop clients.
+5. **End-to-end**: connect Cursor/Claude Code via OAuth (no static token) and verify discovery →
+   code+PKCE → token → tool calls execute as the user; then drop the static-bearer recipe from
+   `doc/mcp_remote_connection.md` (or mark it dev-only).
+
+## Open questions
+
+- DCR policy: open registration vs initial-access-token gating; which redirect URIs to allow.
+- Consent screen: required for third-party agent clients, or auto-approve for first-party?
+- Do we eventually unify SPA auth onto OAuth, or keep the username/password → JWT chain indefinitely?
+- Token lifetimes + refresh-token policy for long-lived desktop client configs.
+- Confirm Spring AS's DCR (OIDC client registration) satisfies what Cursor/Claude Code expect from
+  RFC 7591.
+
+## Risks
+
+- Spring Authorization Server + the existing JWT chain interaction (filter-chain ordering, matchers).
+- The MCP authorization spec is still evolving (RFC 9728 became mandatory in the 2025-06 revision);
+  track spec changes.
+- Complexity/footprint of standing up an AS in a single-maintainer app — mitigated by it being
+  embedded and config-driven.

--- a/doc/pat_ui_plan.md
+++ b/doc/pat_ui_plan.md
@@ -1,0 +1,122 @@
+# Personal Access Token UI — plan (#73, Slice 6)
+
+> Frontend for the PAT backend (Slices 1–3: store, `/api/auth/tokens` REST, filter validation).
+> Lets a project user mint, view, and revoke their own tokens from the Angular app.
+
+## API contract (already built, Slice 2)
+
+- `POST /api/auth/tokens` `{ name, expiresInDays? }` → `201 { token: "reqpat_…", tokenInfo: {...} }`
+  — the `reqpat_…` plaintext is returned **once**.
+- `GET /api/auth/tokens` → `[ { id, name, createdAt, lastUsedAt, expiresAt, status } ]`
+  (status = `ACTIVE` | `EXPIRED` | `REVOKED`).
+- `DELETE /api/auth/tokens/{id}` → `204` (revoke; own-tokens-only, else `404`).
+
+## Where it lives (decision)
+
+**Recommended: a "Personal Access Tokens" section on the existing Settings page** (`/settings` →
+`SettingsComponent`), reachable from the existing top-right Account menu → *Settings*. It's the
+natural home (account-level self-service), avoids a new top-level route, and keeps the menu tidy.
+
+Alternative considered: a dedicated `/settings/tokens` (or `/account/tokens`) route + its own
+top-right menu item. Cleaner separation and deep-linkable, at the cost of another route/guard and a
+busier menu. Easy to split out later if the Settings section grows. (Either way the table/dialog
+component is the same; only the host differs.)
+
+## Visibility / gating (decision)
+
+PATs are a **user-level** capability, not project-scoped, so gate them with a **user role**, not a
+stakeholder permission (see "Permission question" below). Gate in three places, mirroring the
+existing `adminGuard` / `SidebarNavComponent.isAdmin` pattern:
+
+1. **Menu/section render** — show the Tokens section/item only when
+   `authService.user()?.roles?.includes('ProjectUserRole')`.
+2. **Route guard** (if a dedicated route) — a `projectUserGuard` (CanActivateFn) cloned from
+   `adminGuard`, redirecting non-project-users to `/`.
+3. **Backend defense-in-depth** — role-gate the `/api/auth/tokens` endpoints so a direct API call
+   from a non-project user is rejected too (UI hiding alone isn't security). Proposed rule: allow
+   `ProjectUserRole` **or** `SystemAdminUserRole` (admins likely want tokens too) via an
+   `@PreAuthorize`/method-security check or an `ApiSecurityConfig` matcher. Decide the exact role
+   set during implementation.
+
+## Permission model — decision
+
+**v1 (this slice): role-gate on `ProjectUserRole`** — gate the UI section and the `/api/auth/tokens`
+endpoints on the role the user already holds (`UserDto.roles`, already present). No migration, no
+`UserDto` change, no touch of the permission cache. Use is unguarded (a PAT only authenticates as
+its owner — what it can do is governed by the owner's roles + stakeholder permissions at request
+time). NOT a StakeholderPermission (PATs aren't project-scoped — wrong layer).
+
+**Fast-follow (separate ticket): a `ManageApiTokens` `UserRolePermission`** for finer, per-user
+control. Deferred because it's a multi-part rollout (below) with known cache fragility; do it once
+the v1 UI is proven.
+
+How the permission model works here (discovered while planning), and the resulting work for the
+fast-follow:
+
+- `ProjectUserRole` declares static `UserRolePermission` constants (e.g. `createProjects`) and registers
+  the *available* set in a static block; `UserRolePermissionsInitializer` persists/caches them.
+- Crucially, holding the role does **not** auto-grant a permission. Each user's `ProjectUserRole`
+  **instance** has an explicit granted set (`user_roles_permissions` join table); permissions are
+  granted per-user via `EditUserCommand.addUserRolePermissionName(role, permissionName)`
+  (e.g. `ProjectUserInitializer` grants `createProjects` to the seeded `project` user).
+
+So `ManageApiTokens` is a rollout, not a one-liner:
+
+1. **Declare** `ProjectUserRole.manageApiTokens` + add to the available set in the static block;
+   add `canManageApiTokens()`.
+2. **Grant to existing users** — a one-time initializer/migration that grants `manageApiTokens` to
+   every existing `ProjectUserRole` instance (the join table). (New users get it via whatever grants
+   their role permissions at creation; decide whether creation auto-grants it or admins opt in.)
+3. **Enforce** on the token endpoints — resolve the current user and check
+   `getPermissionStrings(user).contains("manageApiTokens")` (works for both JWT and PAT callers,
+   which load the user live), returning 403 otherwise. (Simpler than mapping permissions to Spring
+   authorities, which the filter doesn't currently do.)
+4. **Expose to the UI** — `UserDto` currently carries `roles` but not `permissions`; add a
+   `permissions` list (populate from `getPermissionStrings`) so the Settings section can render only
+   when the user holds `manageApiTokens`.
+
+**Risk flag:** the static `AbstractUserRole.userRoleTypePermissions` cache + the
+`user_roles_permissions` rows interacted badly during the #76 upgrade ("UserRolePermission is out of
+date" stale-state errors across test contexts). Adding a permission must be done carefully and
+re-tested across the full suite.
+
+## Angular pieces
+
+- `models/api-token.ts` — `ApiTokenDto`, `CreateApiTokenRequest`, `CreateApiTokenResponse`.
+- `core/token.service.ts` — `list()`, `create(req)`, `revoke(id)` over `environment.apiBaseUrl`
+  (the existing `auth.interceptor` attaches the bearer), mirroring `user.service.ts` /
+  `project.service.ts`.
+- UI: a PrimeNG `p-table` of tokens (name, status badge, created, last used, expires) with a
+  per-row **Revoke** (confirm dialog); a **New token** dialog (name + optional expiry days). On
+  create, show the one-time `reqpat_…` plaintext in a highlighted, copy-to-clipboard block with a
+  clear "you won't see this again" warning (no plaintext is ever re-fetchable). Use the existing
+  `MessageService`/toast for success/errors. Hosted as a section in `SettingsComponent` (or the
+  dedicated route if chosen).
+
+## UX details
+
+- Status rendered as a colored tag (ACTIVE green / EXPIRED grey / REVOKED red).
+- Revoked/expired rows stay listed (history) but show no actions except maybe "remove from list" if
+  we later add hard-delete; v1 keeps them visible with the status.
+- Empty state: short explainer + a link to `doc/mcp_remote_connection.md` usage.
+- Copy button on the one-time token; dialog can't be dismissed without an explicit "I've copied it".
+
+## Testing
+
+- `token.service` unit test (HTTP calls shape) — Vitest, mirroring existing service specs.
+- Component spec: renders the list, opens the create dialog, shows the one-time token, calls revoke.
+- Guard spec for `projectUserGuard` (if added), mirroring `admin.guard.spec.ts`.
+- Backend: extend `ApiTokenIT` (or a new IT) to assert the role-gate (a non-project user is rejected
+  from `/api/auth/tokens`) once the role rule is added.
+
+## Open questions — resolved
+
+- **Settings section vs dedicated route** → Settings-page section (`SettingsComponent`). No new route.
+- **Backend role set for the endpoint gate** → `ProjectUserRole` **only**. PATs act against project
+  data, so a pure system admin (no project role) has no use for one; a system admin who *also* holds
+  `ProjectUserRole` still qualifies through that role. Both the endpoint matcher and the UI gate use
+  `ProjectUserRole` alone.
+- **UI expiry** → fixed preset dropdown of 30 / 90 / 180 / 365 days, **defaulting to 90**. No
+  free-form entry and no "never" from the UI (the API still accepts a null expiry for other callers).
+- **`ManageApiTokens` `UserRolePermission`** → deferred to a fast-follow ticket (see "Permission
+  model" above). v1 ships role-gated.

--- a/modules/requel-app/src/main/resources/db/migration/V11__api_tokens.sql
+++ b/modules/requel-app/src/main/resources/db/migration/V11__api_tokens.sql
@@ -1,0 +1,15 @@
+-- Personal access tokens (PATs) for non-interactive / static-bearer clients (issue #73).
+-- Opaque tokens; only the SHA-256 hash is stored. Looked up by hash on every request so
+-- revocation (revoked = true) and expiry take effect immediately. owner_user_id has no FK,
+-- mirroring command_audit_log.user_id; it is resolved via the user store at validation time.
+CREATE TABLE api_tokens (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    owner_user_id BIGINT NOT NULL,
+    name VARCHAR(120) NOT NULL,
+    token_hash VARCHAR(64) NOT NULL UNIQUE,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_used_at TIMESTAMP NULL,
+    expires_at TIMESTAMP NULL,
+    revoked BOOLEAN NOT NULL DEFAULT FALSE,
+    INDEX idx_api_tokens_owner (owner_user_id)
+);

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/service/ApiTokenIT.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/service/ApiTokenIT.java
@@ -1,0 +1,179 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rreganjr.AbstractIntegrationTestCase;
+import com.rreganjr.requel.user.User;
+import com.rreganjr.requel.user.command.EditUserCommand;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * End-to-end integration test for personal access tokens (issue #73, Slices 1-3 together): mint a
+ * PAT via {@code /api/auth/tokens}, use it as a bearer to reach a protected endpoint, confirm
+ * revocation takes effect on the next request, and that token management is strictly own-tokens-only.
+ * Exercises the REST API + the JwtAuthenticationFilter PAT branch as a real client would.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@AutoConfigureMockMvc
+public class ApiTokenIT extends AbstractIntegrationTestCase {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	private String adminJwt;
+	private String otherUsername;
+	private String otherJwt;
+
+	@BeforeAll
+	void setUp() throws Exception {
+		initializeBaselineData();
+		adminJwt = login("admin", "admin");
+
+		long ts = System.currentTimeMillis();
+		otherUsername = "tok-other-" + ts;
+		createUser(otherUsername, "secret");
+		otherJwt = login(otherUsername, "secret");
+	}
+
+	@Test
+	void mintedTokenAuthenticatesAndIsListed() throws Exception {
+		String[] minted = mintToken(adminJwt, "ci");
+		String pat = minted[0];
+
+		// The PAT authenticates a protected endpoint as the owning user.
+		mockMvc.perform(get("/api/auth/me").header("Authorization", "Bearer " + pat))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.username").value("admin"));
+
+		// And the token is listed for its owner.
+		mockMvc.perform(get("/api/auth/tokens").header("Authorization", "Bearer " + pat))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$[?(@.name=='ci')]").exists());
+	}
+
+	@Test
+	void revocationTakesEffectImmediately() throws Exception {
+		String[] minted = mintToken(adminJwt, "to-revoke");
+		String pat = minted[0];
+		String id = minted[1];
+
+		mockMvc.perform(get("/api/auth/me").header("Authorization", "Bearer " + pat))
+				.andExpect(status().isOk());
+
+		mockMvc.perform(delete("/api/auth/tokens/" + id).header("Authorization", "Bearer " + adminJwt))
+				.andExpect(status().isNoContent());
+
+		// Next request with the revoked token is unauthenticated.
+		mockMvc.perform(get("/api/auth/me").header("Authorization", "Bearer " + pat))
+				.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	void revokeIsOwnTokensOnly() throws Exception {
+		String[] minted = mintToken(adminJwt, "admins-token");
+		String id = minted[1];
+
+		// Another user cannot revoke admin's token (404, not revealing it exists).
+		mockMvc.perform(delete("/api/auth/tokens/" + id).header("Authorization", "Bearer " + otherJwt))
+				.andExpect(status().isNotFound());
+
+		// Admin's token still works.
+		mockMvc.perform(get("/api/auth/me").header("Authorization", "Bearer " + minted[0]))
+				.andExpect(status().isOk());
+	}
+
+	@Test
+	void unauthenticatedCreateIsRejected() throws Exception {
+		mockMvc.perform(post("/api/auth/tokens")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content("{\"name\":\"nope\"}"))
+				.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	void blankNameIsRejected() throws Exception {
+		mockMvc.perform(post("/api/auth/tokens")
+						.header("Authorization", "Bearer " + adminJwt)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content("{\"name\":\"  \"}"))
+				.andExpect(status().isBadRequest());
+	}
+
+	// ---- helpers ------------------------------------------------------------------------------
+
+	/** @return {plaintextToken, tokenId} */
+	private String[] mintToken(String jwt, String name) throws Exception {
+		MvcResult result = mockMvc.perform(post("/api/auth/tokens")
+						.header("Authorization", "Bearer " + jwt)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(Map.of("name", name))))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.token").value(org.hamcrest.Matchers.startsWith("reqpat_")))
+				.andExpect(jsonPath("$.tokenInfo.status").value("ACTIVE"))
+				.andReturn();
+		JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+		return new String[] {body.get("token").asText(), body.get("tokenInfo").get("id").asText()};
+	}
+
+	private String login(String username, String password) throws Exception {
+		MvcResult result = mockMvc.perform(post("/api/auth/login")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(
+								Map.of("username", username, "password", password))))
+				.andExpect(status().isOk())
+				.andReturn();
+		return objectMapper.readTree(result.getResponse().getContentAsString()).get("token").asText();
+	}
+
+	private void createUser(String username, String password) throws Exception {
+		User admin = getUserRepository().findUserByUsername("admin");
+		EditUserCommand cmd = getUserCommandFactory().newEditUserCommand();
+		cmd.setEditedBy(admin);
+		cmd.setUsername(username);
+		cmd.setPassword(password);
+		cmd.setRepassword(password);
+		cmd.setName(username);
+		cmd.setEmailAddress(username + "@example.com");
+		cmd.setPhoneNumber("");
+		cmd.setOrganizationName("TokTestOrg");
+		cmd.addUserRoleName("ProjectUserRole");
+		getCommandHandler().execute(cmd);
+	}
+}

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/service/auth/ApiTokenServiceTest.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/service/auth/ApiTokenServiceTest.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Unit tests for {@link ApiTokenService} (issue #73, Slice 2). Lives in requel-app because
+ * service-impl carries no test dependencies; the service classes are public, so they are reachable
+ * across the module boundary. Plain Mockito unit test — no Spring context.
+ */
+class ApiTokenServiceTest {
+
+	private final ApiTokenRepository repository = mock(ApiTokenRepository.class);
+	private final ApiTokenService service = new ApiTokenService(repository);
+
+	@Test
+	void createMintsPrefixedTokenAndStoresOnlyTheHash() {
+		when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+		ApiTokenService.IssuedToken issued = service.create(7L, "ci", 30);
+
+		assertThat(issued.plaintext()).startsWith(ApiTokenService.PREFIX);
+
+		ArgumentCaptor<ApiToken> captor = ArgumentCaptor.forClass(ApiToken.class);
+		verify(repository).save(captor.capture());
+		ApiToken saved = captor.getValue();
+		assertThat(saved.getTokenHash()).isEqualTo(ApiTokenService.hash(issued.plaintext()));
+		assertThat(saved.getTokenHash()).isNotEqualTo(issued.plaintext()); // hash, not plaintext
+		assertThat(saved.getOwnerUserId()).isEqualTo(7L);
+		assertThat(saved.getName()).isEqualTo("ci");
+		assertThat(saved.getExpiresAt()).isNotNull();
+		assertThat(saved.isRevoked()).isFalse();
+	}
+
+	@Test
+	void nullExpiryMeansNeverExpires() {
+		when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+		ArgumentCaptor<ApiToken> captor = ArgumentCaptor.forClass(ApiToken.class);
+
+		service.create(1L, "forever", null);
+
+		verify(repository).save(captor.capture());
+		assertThat(captor.getValue().getExpiresAt()).isNull();
+	}
+
+	@Test
+	void isApiTokenDetectsThePrefixOnly() {
+		assertThat(ApiTokenService.isApiToken("reqpat_abc123")).isTrue();
+		assertThat(ApiTokenService.isApiToken("eyJhbGciOi.jwt.token")).isFalse();
+		assertThat(ApiTokenService.isApiToken(null)).isFalse();
+	}
+
+	@Test
+	void hashIs64HexCharsAndDeterministic() {
+		String hash = ApiTokenService.hash("reqpat_xyz");
+		assertThat(hash).hasSize(64).matches("[0-9a-f]+");
+		assertThat(hash).isEqualTo(ApiTokenService.hash("reqpat_xyz"));
+		assertThat(hash).isNotEqualTo(ApiTokenService.hash("reqpat_other"));
+	}
+
+	@Test
+	void revokeOnlyAffectsTheCallersOwnToken() {
+		ApiToken othersToken = new ApiToken(99L, "theirs", "h", Instant.now(), null);
+		when(repository.findById(5L)).thenReturn(Optional.of(othersToken));
+
+		assertThat(service.revoke(7L, 5L)).isFalse(); // user 7 cannot revoke user 99's token
+		assertThat(othersToken.isRevoked()).isFalse();
+		verify(repository, never()).save(any());
+
+		ApiToken ownToken = new ApiToken(7L, "mine", "h2", Instant.now(), null);
+		when(repository.findById(6L)).thenReturn(Optional.of(ownToken));
+
+		assertThat(service.revoke(7L, 6L)).isTrue();
+		assertThat(ownToken.isRevoked()).isTrue();
+	}
+
+	@Test
+	void revokeMissingTokenReturnsFalse() {
+		when(repository.findById(404L)).thenReturn(Optional.empty());
+		assertThat(service.revoke(7L, 404L)).isFalse();
+	}
+}

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/service/auth/JwtAuthenticationFilterPatTest.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/service/auth/JwtAuthenticationFilterPatTest.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.rreganjr.requel.user.User;
+import com.rreganjr.requel.user.UserRepository;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Tests the personal-access-token branch of {@link JwtAuthenticationFilter} (issue #73, Slice 3):
+ * a valid PAT authenticates as the owning user with live authorities; revoked / expired / unknown
+ * tokens leave the request unauthenticated.
+ */
+class JwtAuthenticationFilterPatTest {
+
+	private final JwtService jwtService = mock(JwtService.class);
+	private final ApiTokenRepository tokenRepository = mock(ApiTokenRepository.class);
+	private final UserRepository userRepository = mock(UserRepository.class);
+	private final UserDtoMapper userDtoMapper = mock(UserDtoMapper.class);
+
+	private final JwtAuthenticationFilter filter = new JwtAuthenticationFilter(
+			jwtService, tokenRepository, userRepository, userDtoMapper);
+
+	private static final String PLAINTEXT = ApiTokenService.PREFIX + "unit-test-token";
+	private static final String HASH = ApiTokenService.hash(PLAINTEXT);
+
+	@AfterEach
+	void clear() {
+		SecurityContextHolder.clearContext();
+	}
+
+	private Authentication runWith(ApiToken token) throws Exception {
+		when(tokenRepository.findByTokenHash(HASH)).thenReturn(Optional.ofNullable(token));
+		User user = mock(User.class);
+		lenient().when(user.getUsername()).thenReturn("alice");
+		lenient().when(userRepository.findUserById(7L)).thenReturn(user);
+		lenient().when(userDtoMapper.getRoleStrings(user)).thenReturn(List.of("ProjectUserRole"));
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization", "Bearer " + PLAINTEXT);
+		filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+		return SecurityContextHolder.getContext().getAuthentication();
+	}
+
+	@Test
+	void validTokenAuthenticatesAsOwnerWithLiveAuthorities() throws Exception {
+		ApiToken active = new ApiToken(7L, "ci", HASH, Instant.now(), null);
+
+		Authentication auth = runWith(active);
+
+		assertThat(auth).isNotNull();
+		assertThat(auth.getName()).isEqualTo("alice");
+		assertThat(auth.getAuthorities()).extracting(Object::toString)
+				.contains("ROLE_ProjectUserRole");
+	}
+
+	@Test
+	void revokedTokenIsRejected() throws Exception {
+		ApiToken revoked = new ApiToken(7L, "ci", HASH, Instant.now(), null);
+		revoked.setRevoked(true);
+
+		assertThat(runWith(revoked)).isNull();
+	}
+
+	@Test
+	void expiredTokenIsRejected() throws Exception {
+		ApiToken expired = new ApiToken(7L, "ci", HASH, Instant.now().minus(2, ChronoUnit.DAYS),
+				Instant.now().minus(1, ChronoUnit.DAYS));
+
+		assertThat(runWith(expired)).isNull();
+	}
+
+	@Test
+	void unknownTokenIsRejected() throws Exception {
+		assertThat(runWith(null)).isNull();
+	}
+}

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/ApiToken.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/ApiToken.java
@@ -1,0 +1,130 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.auth;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+/**
+ * A user-minted personal access token (PAT) for non-interactive / static-bearer clients (issue
+ * #73). The token is an opaque high-entropy string returned to the user once at creation; only its
+ * SHA-256 hash is stored here, so the plaintext cannot be recovered. {@code JwtAuthenticationFilter}
+ * (Slice 3) hashes a presented PAT, looks it up by {@link #getTokenHash()} on every request — giving
+ * immediate revocation — checks {@link #isRevoked()} / {@link #getExpiresAt()}, then resolves the
+ * owning user and loads authorities live (so role changes take effect immediately). The token only
+ * establishes the triggering user; authorization (stakeholder permissions) and audit are unchanged.
+ */
+@Entity
+@Table(name = "api_tokens")
+public class ApiToken {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	/** Owning user's id. No DB FK (mirrors command_audit_log.user_id); resolved via the user store. */
+	@Column(name = "owner_user_id", nullable = false)
+	private Long ownerUserId;
+
+	@Column(name = "name", nullable = false, length = 120)
+	private String name;
+
+	/** SHA-256 hex of the opaque token (64 chars). Unique so lookup is a single indexed hit. */
+	@Column(name = "token_hash", nullable = false, unique = true, length = 64)
+	private String tokenHash;
+
+	@Column(name = "created_at", nullable = false)
+	private Instant createdAt;
+
+	@Column(name = "last_used_at")
+	private Instant lastUsedAt;
+
+	/** Null = never expires. */
+	@Column(name = "expires_at")
+	private Instant expiresAt;
+
+	@Column(name = "revoked", nullable = false)
+	private boolean revoked;
+
+	protected ApiToken() {
+		// for JPA
+	}
+
+	public ApiToken(Long ownerUserId, String name, String tokenHash, Instant createdAt,
+			Instant expiresAt) {
+		this.ownerUserId = ownerUserId;
+		this.name = name;
+		this.tokenHash = tokenHash;
+		this.createdAt = createdAt;
+		this.expiresAt = expiresAt;
+		this.revoked = false;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public Long getOwnerUserId() {
+		return ownerUserId;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public String getTokenHash() {
+		return tokenHash;
+	}
+
+	public Instant getCreatedAt() {
+		return createdAt;
+	}
+
+	public Instant getLastUsedAt() {
+		return lastUsedAt;
+	}
+
+	public void setLastUsedAt(Instant lastUsedAt) {
+		this.lastUsedAt = lastUsedAt;
+	}
+
+	public Instant getExpiresAt() {
+		return expiresAt;
+	}
+
+	public boolean isRevoked() {
+		return revoked;
+	}
+
+	public void setRevoked(boolean revoked) {
+		this.revoked = revoked;
+	}
+
+	/** True if the token is currently usable (not revoked and not past its expiry). */
+	public boolean isActive(Instant now) {
+		return !revoked && (expiresAt == null || expiresAt.isAfter(now));
+	}
+}

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/ApiTokenController.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/ApiTokenController.java
@@ -1,0 +1,109 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.auth;
+
+import com.rreganjr.requel.service.api.dto.ErrorResponse;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Personal-access-token management (issue #73, Slice 2): a user creates, lists, and revokes their
+ * own tokens. Conventional REST, not command dispatch, and strictly "own tokens only" — the owner
+ * is always the authenticated caller (via {@link CurrentUserResolver}), never a path/body parameter,
+ * so this is token self-service, not user administration. Mounted under {@code /api/auth/**}; the
+ * existing security chain requires authentication for everything except {@code /api/auth/login}.
+ */
+@RestController
+@RequestMapping("/api/auth/tokens")
+public class ApiTokenController {
+
+	private final ApiTokenService tokenService;
+	private final CurrentUserResolver currentUserResolver;
+
+	public ApiTokenController(ApiTokenService tokenService, CurrentUserResolver currentUserResolver) {
+		this.tokenService = tokenService;
+		this.currentUserResolver = currentUserResolver;
+	}
+
+	/** Create request: a display name and optional expiry in days (null/0 = never expires). */
+	public record CreateApiTokenRequest(String name, Integer expiresInDays) {
+	}
+
+	/** Token metadata (never the secret); status is derived REVOKED / EXPIRED / ACTIVE. */
+	public record ApiTokenDto(Long id, String name, Instant createdAt, Instant lastUsedAt,
+			Instant expiresAt, String status) {
+	}
+
+	/** Create response: the one-time plaintext token plus its metadata. */
+	public record CreateApiTokenResponse(String token, ApiTokenDto tokenInfo) {
+	}
+
+	@PostMapping
+	public ResponseEntity<?> create(@RequestBody(required = false) CreateApiTokenRequest request) {
+		if (request == null || request.name() == null || request.name().isBlank()) {
+			return ResponseEntity.badRequest()
+					.body(ErrorResponse.of("BAD_REQUEST", "Token name is required"));
+		}
+		Long ownerId = currentUserResolver.resolve().getId();
+		ApiTokenService.IssuedToken issued = tokenService.create(ownerId, request.name().trim(),
+				request.expiresInDays());
+		return ResponseEntity.status(HttpStatus.CREATED)
+				.body(new CreateApiTokenResponse(issued.plaintext(), toDto(issued.token())));
+	}
+
+	@GetMapping
+	public List<ApiTokenDto> list() {
+		Long ownerId = currentUserResolver.resolve().getId();
+		return tokenService.list(ownerId).stream().map(this::toDto).toList();
+	}
+
+	@DeleteMapping("/{id}")
+	public ResponseEntity<?> revoke(@PathVariable("id") Long id) {
+		Long ownerId = currentUserResolver.resolve().getId();
+		if (tokenService.revoke(ownerId, id)) {
+			return ResponseEntity.noContent().build();
+		}
+		return ResponseEntity.status(HttpStatus.NOT_FOUND)
+				.body(ErrorResponse.of("NOT_FOUND", "Token not found"));
+	}
+
+	private ApiTokenDto toDto(ApiToken token) {
+		String status;
+		if (token.isRevoked()) {
+			status = "REVOKED";
+		} else if (token.getExpiresAt() != null && !token.getExpiresAt().isAfter(Instant.now())) {
+			status = "EXPIRED";
+		} else {
+			status = "ACTIVE";
+		}
+		return new ApiTokenDto(token.getId(), token.getName(), token.getCreatedAt(),
+				token.getLastUsedAt(), token.getExpiresAt(), status);
+	}
+}

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/ApiTokenRepository.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/ApiTokenRepository.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.auth;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Store for personal access tokens (issue #73). Lookup is by token hash (per-request validation in
+ * the auth filter) or by owner (the token-management API, scoped to "own tokens only").
+ */
+@Repository
+public interface ApiTokenRepository extends JpaRepository<ApiToken, Long> {
+
+	Optional<ApiToken> findByTokenHash(String tokenHash);
+
+	List<ApiToken> findByOwnerUserIdOrderByCreatedAtDesc(Long ownerUserId);
+}

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/ApiTokenService.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/ApiTokenService.java
@@ -1,0 +1,116 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.auth;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Mints, lists, and revokes personal access tokens (issue #73, Slice 2), and provides the shared
+ * token-format/hashing helpers the auth filter reuses (Slice 3). Tokens are opaque high-entropy
+ * strings with a fixed prefix so the filter can distinguish a PAT from a login JWT; only the
+ * SHA-256 hash is persisted, so the plaintext is shown once at creation and never recoverable.
+ */
+@Service
+public class ApiTokenService {
+
+	/** Identifies a Requel PAT (vs a login JWT) by the Authorization bearer value's prefix. */
+	public static final String PREFIX = "reqpat_";
+
+	private static final SecureRandom RANDOM = new SecureRandom();
+	private static final int RANDOM_BYTES = 32;
+
+	private final ApiTokenRepository repository;
+
+	public ApiTokenService(ApiTokenRepository repository) {
+		this.repository = repository;
+	}
+
+	/** The plaintext token (shown once) plus the persisted record. */
+	public record IssuedToken(String plaintext, ApiToken token) {
+	}
+
+	/**
+	 * Mint a new token for {@code ownerUserId}. The plaintext is returned once; only its hash is
+	 * stored. {@code expiresInDays} null = never expires.
+	 */
+	@Transactional
+	public IssuedToken create(Long ownerUserId, String name, Integer expiresInDays) {
+		byte[] bytes = new byte[RANDOM_BYTES];
+		RANDOM.nextBytes(bytes);
+		String plaintext = PREFIX + Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+		Instant now = Instant.now();
+		Instant expiresAt = (expiresInDays != null && expiresInDays > 0)
+				? now.plus(expiresInDays, ChronoUnit.DAYS)
+				: null;
+		ApiToken token = new ApiToken(ownerUserId, name, hash(plaintext), now, expiresAt);
+		return new IssuedToken(plaintext, repository.save(token));
+	}
+
+	@Transactional(readOnly = true)
+	public List<ApiToken> list(Long ownerUserId) {
+		return repository.findByOwnerUserIdOrderByCreatedAtDesc(ownerUserId);
+	}
+
+	/**
+	 * Revoke a token the caller owns. Returns false (not found / not owned) so the caller can map to
+	 * 404 — never reveals another user's token. Revocation takes effect on the token's next request.
+	 */
+	@Transactional
+	public boolean revoke(Long ownerUserId, Long tokenId) {
+		Optional<ApiToken> found = repository.findById(tokenId);
+		if (found.isEmpty() || !found.get().getOwnerUserId().equals(ownerUserId)) {
+			return false;
+		}
+		ApiToken token = found.get();
+		if (!token.isRevoked()) {
+			token.setRevoked(true);
+			repository.save(token);
+		}
+		return true;
+	}
+
+	/** @return true if a bearer credential is a Requel PAT (by prefix), not a login JWT. */
+	public static boolean isApiToken(String credential) {
+		return credential != null && credential.startsWith(PREFIX);
+	}
+
+	/** SHA-256 hex of the token plaintext; the only form persisted/compared. */
+	public static String hash(String plaintext) {
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			byte[] hashed = digest.digest(plaintext.getBytes(StandardCharsets.UTF_8));
+			return HexFormat.of().formatHex(hashed);
+		} catch (NoSuchAlgorithmException e) {
+			throw new IllegalStateException("SHA-256 not available", e);
+		}
+	}
+}

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/JwtAuthenticationFilter.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/JwtAuthenticationFilter.java
@@ -20,6 +20,8 @@
  */
 package com.rreganjr.requel.service.auth;
 
+import com.rreganjr.requel.user.User;
+import com.rreganjr.requel.user.UserRepository;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
@@ -32,22 +34,44 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 /**
- * JWT authentication filter. Extracts the Bearer token from the Authorization header,
- * validates it, and sets the Spring Security authentication context.
- * Placed before UsernamePasswordAuthenticationFilter in the filter chain.
+ * Authentication filter for the bearer token in the Authorization header. Branches on credential
+ * type and sets the Spring Security context. Placed before UsernamePasswordAuthenticationFilter.
+ *
+ * <p>Two credential kinds (issue #73):
+ * <ul>
+ *   <li><b>Login JWT</b> — short-lived, self-contained; validated statelessly (signature/expiry)
+ *       with authorities from its claims. No DB hit.</li>
+ *   <li><b>Personal access token (PAT)</b> — opaque, prefixed {@code reqpat_}; hashed and looked up
+ *       in the token store on <em>every</em> request (so revocation/expiry take effect immediately),
+ *       the owning user is resolved, and authorities are loaded <em>live</em> from that user (so
+ *       role changes take effect immediately). {@code last_used_at} is updated, throttled.</li>
+ * </ul>
+ * A PAT only establishes the triggering user; command authorization (stakeholder permissions) and
+ * audit are unchanged.
  */
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final String BEARER_PREFIX = "Bearer ";
+    /** Update last_used_at at most once per this many seconds, to avoid a write per request. */
+    private static final long LAST_USED_THROTTLE_SECONDS = 60L;
 
     private final JwtService jwtService;
+    private final ApiTokenRepository apiTokenRepository;
+    private final UserRepository userRepository;
+    private final UserDtoMapper userDtoMapper;
 
-    public JwtAuthenticationFilter(JwtService jwtService) {
+    public JwtAuthenticationFilter(JwtService jwtService, ApiTokenRepository apiTokenRepository,
+            UserRepository userRepository, UserDtoMapper userDtoMapper) {
         this.jwtService = jwtService;
+        this.apiTokenRepository = apiTokenRepository;
+        this.userRepository = userRepository;
+        this.userDtoMapper = userDtoMapper;
     }
 
     @Override
@@ -57,30 +81,82 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (authHeader != null && authHeader.startsWith(BEARER_PREFIX)) {
             String token = authHeader.substring(BEARER_PREFIX.length());
-            try {
-                Claims claims = jwtService.parseToken(token);
-                String username = claims.getSubject();
-                @SuppressWarnings("unchecked")
-                List<String> roles = claims.get("roles", List.class);
-
-                List<SimpleGrantedAuthority> authorities = roles != null
-                        ? roles.stream()
-                            .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
-                            .toList()
-                        : List.of();
-
-                var auth = new UsernamePasswordAuthenticationToken(username, null, authorities);
-                // Store JWT expiry epoch-ms as details so controllers can schedule server-side expiry
-                Date exp = claims.getExpiration();
-                auth.setDetails(exp != null ? exp.getTime() : 0L);
-                SecurityContextHolder.getContext().setAuthentication(auth);
-            } catch (JwtException e) {
-                // Invalid or expired token — don't set authentication, let Spring Security
-                // return 401 for protected endpoints
-                SecurityContextHolder.clearContext();
+            if (ApiTokenService.isApiToken(token)) {
+                authenticateApiToken(token);
+            } else {
+                authenticateJwt(token);
             }
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private void authenticateJwt(String token) {
+        try {
+            Claims claims = jwtService.parseToken(token);
+            String username = claims.getSubject();
+            @SuppressWarnings("unchecked")
+            List<String> roles = claims.get("roles", List.class);
+
+            List<SimpleGrantedAuthority> authorities = roles != null
+                    ? roles.stream()
+                        .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
+                        .toList()
+                    : List.of();
+
+            var auth = new UsernamePasswordAuthenticationToken(username, null, authorities);
+            // Store JWT expiry epoch-ms as details so controllers can schedule server-side expiry
+            Date exp = claims.getExpiration();
+            auth.setDetails(exp != null ? exp.getTime() : 0L);
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        } catch (JwtException e) {
+            // Invalid or expired token — don't set authentication, let Spring Security
+            // return 401 for protected endpoints
+            SecurityContextHolder.clearContext();
+        }
+    }
+
+    /**
+     * Validate a personal access token: hash, look up, check active (not revoked / not expired),
+     * resolve the owning user, and set the security context with authorities loaded live from the
+     * user. Any failure leaves the context unauthenticated so protected endpoints return 401.
+     */
+    private void authenticateApiToken(String token) {
+        try {
+            Optional<ApiToken> found = apiTokenRepository.findByTokenHash(ApiTokenService.hash(token));
+            Instant now = Instant.now();
+            if (found.isEmpty() || !found.get().isActive(now)) {
+                SecurityContextHolder.clearContext();
+                return;
+            }
+            ApiToken pat = found.get();
+            User user = userRepository.findUserById(pat.getOwnerUserId());
+            if (user == null) {
+                SecurityContextHolder.clearContext();
+                return;
+            }
+            List<SimpleGrantedAuthority> authorities = userDtoMapper.getRoleStrings(user).stream()
+                    .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
+                    .toList();
+            var auth = new UsernamePasswordAuthenticationToken(user.getUsername(), null, authorities);
+            auth.setDetails(pat.getExpiresAt() != null ? pat.getExpiresAt().toEpochMilli() : 0L);
+            SecurityContextHolder.getContext().setAuthentication(auth);
+            touchLastUsed(pat, now);
+        } catch (RuntimeException e) {
+            SecurityContextHolder.clearContext();
+        }
+    }
+
+    /** Best-effort, throttled last-used bookkeeping; never fails the request. */
+    private void touchLastUsed(ApiToken pat, Instant now) {
+        Instant last = pat.getLastUsedAt();
+        if (last == null || last.isBefore(now.minusSeconds(LAST_USED_THROTTLE_SECONDS))) {
+            try {
+                pat.setLastUsedAt(now);
+                apiTokenRepository.save(pat);
+            } catch (RuntimeException ignored) {
+                // last-used is non-critical; don't break auth over a bookkeeping write
+            }
+        }
     }
 }

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/config/ApiSecurityConfig.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/config/ApiSecurityConfig.java
@@ -83,6 +83,11 @@ public class ApiSecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/auth/login").permitAll()
                 .requestMatchers("/api/dev/**").permitAll()
+                // Personal access token management (#73): project users only. PATs act against
+                // project data, so a pure system admin (no project role) has no use for one; an
+                // admin who also holds ProjectUserRole still qualifies through that role.
+                .requestMatchers("/api/auth/tokens", "/api/auth/tokens/**")
+                    .hasRole("ProjectUserRole")
                 .requestMatchers("/api/users/organizations").authenticated()
                 .requestMatchers("/api/users/**").hasRole("SystemAdminUserRole")
                 .requestMatchers("/api/commands/NewUser").hasRole("SystemAdminUserRole")

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/config/ApiSecurityConfig.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/config/ApiSecurityConfig.java
@@ -20,8 +20,11 @@
  */
 package com.rreganjr.requel.service.config;
 
+import com.rreganjr.requel.service.auth.ApiTokenRepository;
 import com.rreganjr.requel.service.auth.JwtAuthenticationFilter;
 import com.rreganjr.requel.service.auth.JwtService;
+import com.rreganjr.requel.service.auth.UserDtoMapper;
+import com.rreganjr.requel.user.UserRepository;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -49,6 +52,9 @@ import java.util.List;
 public class ApiSecurityConfig {
 
     private final JwtService jwtService;
+    private final ApiTokenRepository apiTokenRepository;
+    private final UserRepository userRepository;
+    private final UserDtoMapper userDtoMapper;
 
     /**
      * Additional CORS allowed origins beyond same-origin (e.g. http://localhost:4200 for the
@@ -58,8 +64,12 @@ public class ApiSecurityConfig {
     @Value("${spring.cors.allowed-origins:}")
     private List<String> additionalAllowedOrigins;
 
-    public ApiSecurityConfig(JwtService jwtService) {
+    public ApiSecurityConfig(JwtService jwtService, ApiTokenRepository apiTokenRepository,
+            UserRepository userRepository, UserDtoMapper userDtoMapper) {
         this.jwtService = jwtService;
+        this.apiTokenRepository = apiTokenRepository;
+        this.userRepository = userRepository;
+        this.userDtoMapper = userDtoMapper;
     }
 
     @Bean
@@ -81,7 +91,8 @@ public class ApiSecurityConfig {
             )
             .exceptionHandling(ex -> ex
                 .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)))
-            .addFilterBefore(new JwtAuthenticationFilter(jwtService),
+            .addFilterBefore(new JwtAuthenticationFilter(jwtService, apiTokenRepository,
+                    userRepository, userDtoMapper),
                     UsernamePasswordAuthenticationFilter.class)
             .anonymous(AbstractHttpConfigurer::disable);
 

--- a/modules/user-domain/src/main/java/com/rreganjr/requel/user/UserRepository.java
+++ b/modules/user-domain/src/main/java/com/rreganjr/requel/user/UserRepository.java
@@ -40,6 +40,14 @@ public interface UserRepository extends com.rreganjr.repository.Repository {
 
     User findUserByUsername(String username) throws NoSuchUserException;
 
+    /**
+     * Look up a user by id. Returns {@code null} if no such user exists (unlike
+     * {@link #findUserByUsername}, which throws) so callers that resolve a stored owner id — e.g.
+     * the personal-access-token auth path (#73) — can treat absence as "not authenticated" without
+     * exception handling.
+     */
+    User findUserById(Long id);
+
     UserSet findUsers();
 
     UserSet findUsersForRole(Class<? extends UserRole> roleType);

--- a/modules/user-jpa/src/main/java/com/rreganjr/requel/user/impl/repository/jpa/JpaUserRepository.java
+++ b/modules/user-jpa/src/main/java/com/rreganjr/requel/user/impl/repository/jpa/JpaUserRepository.java
@@ -122,6 +122,15 @@ public class JpaUserRepository extends AbstractJpaRepository implements UserRepo
 		}
 	}
 
+	@Override
+	public User findUserById(Long id) {
+		if (id == null) {
+			return null;
+		}
+		// Returns null when absent (per the interface contract) — used by the PAT auth path (#73).
+		return getEntityManager().find(com.rreganjr.requel.user.impl.UserImpl.class, id);
+	}
+
 	public UserSet findUsers() {
 		try {
 			// TODO: use named query so it can be configured externally

--- a/requel-angular/src/app/core/token.service.ts
+++ b/requel-angular/src/app/core/token.service.ts
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { environment } from '../../environments/environment';
+import { ApiTokenDto, CreateApiTokenRequest, CreateApiTokenResponse } from '../models/api-token';
+
+/**
+ * Personal access token self-service (#73): list, create, and revoke the current user's tokens via
+ * /api/auth/tokens. The auth interceptor attaches the bearer credential.
+ */
+@Injectable({ providedIn: 'root' })
+export class TokenService {
+
+  constructor(private http: HttpClient) {}
+
+  async list(): Promise<ApiTokenDto[]> {
+    return firstValueFrom(
+      this.http.get<ApiTokenDto[]>(`${environment.apiBaseUrl}/auth/tokens`)
+    );
+  }
+
+  async create(request: CreateApiTokenRequest): Promise<CreateApiTokenResponse> {
+    return firstValueFrom(
+      this.http.post<CreateApiTokenResponse>(`${environment.apiBaseUrl}/auth/tokens`, request)
+    );
+  }
+
+  async revoke(id: number): Promise<void> {
+    return firstValueFrom(
+      this.http.delete<void>(`${environment.apiBaseUrl}/auth/tokens/${id}`)
+    );
+  }
+}

--- a/requel-angular/src/app/features/users/api-tokens.ts
+++ b/requel-angular/src/app/features/users/api-tokens.ts
@@ -1,0 +1,236 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import { DatePipe } from '@angular/common';
+import { Component, OnInit, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ButtonModule } from 'primeng/button';
+import { DialogModule } from 'primeng/dialog';
+import { InputTextModule } from 'primeng/inputtext';
+import { MessageModule } from 'primeng/message';
+import { SelectModule } from 'primeng/select';
+import { TokenService } from '../../core/token.service';
+import { ApiTokenDto } from '../../models/api-token';
+
+/**
+ * Personal access token management (#73, Slice 6): list, create (showing the one-time plaintext),
+ * and revoke the current user's tokens. Hosted as a section of the Settings page, rendered only for
+ * users with the ProjectUserRole (gated by the host).
+ */
+@Component({
+  selector: 'app-api-tokens',
+  standalone: true,
+  imports: [DatePipe, FormsModule, ButtonModule, DialogModule, InputTextModule, MessageModule,
+    SelectModule],
+  template: `
+    <div class="api-tokens" data-testid="api-tokens">
+      <div class="section-header">
+        <h3>Personal Access Tokens</h3>
+        <p-button label="New token" icon="pi pi-plus" data-testid="pat-new"
+                  (onClick)="openCreate()" />
+      </div>
+      <p class="hint">
+        Use a token as a bearer credential for MCP/API clients (e.g. mcp-remote). It acts as you and
+        can be revoked at any time.
+      </p>
+
+      @if (errorMessage()) { <p-message severity="error" [text]="errorMessage()" /> }
+      @if (successMessage()) { <p-message severity="success" [text]="successMessage()" /> }
+
+      @if (loading()) {
+        <p>Loading…</p>
+      } @else if (tokens().length === 0) {
+        <p class="empty">No tokens yet.</p>
+      } @else {
+        <table class="pat-table" data-testid="pat-table">
+          <thead>
+            <tr><th>Name</th><th>Status</th><th>Created</th><th>Last used</th><th>Expires</th><th></th></tr>
+          </thead>
+          <tbody>
+            @for (t of tokens(); track t.id) {
+              <tr>
+                <td>{{ t.name }}</td>
+                <td><span class="status status-{{ t.status.toLowerCase() }}">{{ t.status }}</span></td>
+                <td>{{ t.createdAt | date:'short' }}</td>
+                <td>{{ t.lastUsedAt ? (t.lastUsedAt | date:'short') : '—' }}</td>
+                <td>{{ t.expiresAt ? (t.expiresAt | date:'short') : 'Never' }}</td>
+                <td>
+                  @if (t.status === 'ACTIVE') {
+                    <p-button label="Revoke" severity="danger" [text]="true"
+                              (onClick)="revoke(t)" />
+                  }
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      }
+
+      <p-dialog header="New personal access token" [(visible)]="createDialogVisible"
+                [modal]="true" [style]="{ width: '32rem' }" (onHide)="onDialogHide()">
+        @if (createdToken() === null) {
+          <div class="field">
+            <label for="patName">Name</label>
+            <input id="patName" pInputText [(ngModel)]="newName" data-testid="pat-name"
+                   placeholder="e.g. claude-desktop" />
+          </div>
+          <div class="field">
+            <label for="patExpiry">Expires in</label>
+            <p-select inputId="patExpiry" [options]="expiryOptions" optionLabel="label"
+                      optionValue="value" [(ngModel)]="newExpiresInDays" data-testid="pat-expiry" />
+          </div>
+          <div class="dialog-actions">
+            <p-button label="Create" icon="pi pi-check" data-testid="pat-create"
+                      [loading]="creating()" [disabled]="!newName.trim()" (onClick)="submitCreate()" />
+          </div>
+        } @else {
+          <p-message severity="warn"
+                     text="Copy this token now — it will not be shown again." />
+          <div class="token-display">
+            <code data-testid="pat-plaintext">{{ createdToken() }}</code>
+            <p-button label="Copy" icon="pi pi-copy" [text]="true" (onClick)="copy()" />
+          </div>
+          <div class="dialog-actions">
+            <p-button label="Done" data-testid="pat-done" (onClick)="closeCreated()" />
+          </div>
+        }
+      </p-dialog>
+    </div>
+  `,
+  styles: [`
+    .api-tokens { margin-top: 2rem; }
+    .section-header { display: flex; align-items: center; justify-content: space-between; }
+    .section-header h3 { margin: 0; }
+    .hint { color: var(--p-text-muted-color); margin: 0.25rem 0 1rem; }
+    .pat-table { width: 100%; border-collapse: collapse; }
+    .pat-table th, .pat-table td { text-align: left; padding: 0.5rem; border-bottom: 1px solid var(--p-content-border-color); }
+    .status { font-size: 0.8rem; font-weight: 600; }
+    .status-active { color: var(--p-green-600, #16a34a); }
+    .status-expired { color: var(--p-text-muted-color); }
+    .status-revoked { color: var(--p-red-600, #dc2626); }
+    .field { display: flex; flex-direction: column; gap: 0.25rem; margin-bottom: 1rem; }
+    .field label { font-weight: 600; }
+    .token-display { display: flex; align-items: center; gap: 0.5rem; margin: 0.75rem 0; }
+    .token-display code { flex: 1; padding: 0.5rem; background: var(--p-content-hover-background, #f1f5f9); border-radius: 4px; word-break: break-all; }
+    .dialog-actions { display: flex; justify-content: flex-end; margin-top: 0.5rem; }
+    .empty { color: var(--p-text-muted-color); }
+  `]
+})
+export class ApiTokensComponent implements OnInit {
+
+  readonly tokens = signal<ApiTokenDto[]>([]);
+  readonly loading = signal(false);
+  readonly creating = signal(false);
+  readonly errorMessage = signal('');
+  readonly successMessage = signal('');
+  /** The one-time plaintext after a successful create; null while filling the form. */
+  readonly createdToken = signal<string | null>(null);
+
+  /** Fixed expiry choices (days); no "never" option for tokens minted from the UI. */
+  readonly expiryOptions = [
+    { label: '30 days', value: 30 },
+    { label: '90 days', value: 90 },
+    { label: '180 days', value: 180 },
+    { label: '365 days', value: 365 }
+  ];
+
+  createDialogVisible = false;
+  newName = '';
+  newExpiresInDays = 90;
+
+  constructor(private tokenService: TokenService) {}
+
+  async ngOnInit(): Promise<void> {
+    await this.load();
+  }
+
+  async load(): Promise<void> {
+    this.loading.set(true);
+    this.errorMessage.set('');
+    try {
+      this.tokens.set(await this.tokenService.list());
+    } catch {
+      this.errorMessage.set('Failed to load tokens.');
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  openCreate(): void {
+    this.newName = '';
+    this.newExpiresInDays = 90;
+    this.createdToken.set(null);
+    this.successMessage.set('');
+    this.createDialogVisible = true;
+  }
+
+  async submitCreate(): Promise<void> {
+    if (!this.newName.trim()) {
+      return;
+    }
+    this.creating.set(true);
+    this.errorMessage.set('');
+    try {
+      const response = await this.tokenService.create({
+        name: this.newName.trim(),
+        expiresInDays: this.newExpiresInDays
+      });
+      this.createdToken.set(response.token);
+      await this.load();
+    } catch {
+      this.errorMessage.set('Failed to create token.');
+    } finally {
+      this.creating.set(false);
+    }
+  }
+
+  closeCreated(): void {
+    this.createDialogVisible = false;
+    this.createdToken.set(null);
+    this.successMessage.set('Token created.');
+  }
+
+  onDialogHide(): void {
+    this.createdToken.set(null);
+  }
+
+  async revoke(token: ApiTokenDto): Promise<void> {
+    this.errorMessage.set('');
+    this.successMessage.set('');
+    try {
+      await this.tokenService.revoke(token.id);
+      this.successMessage.set('Token revoked.');
+      await this.load();
+    } catch {
+      this.errorMessage.set('Failed to revoke token.');
+    }
+  }
+
+  async copy(): Promise<void> {
+    const token = this.createdToken();
+    if (token) {
+      try {
+        await navigator.clipboard.writeText(token);
+      } catch {
+        // clipboard may be unavailable (non-secure context); the token stays visible to copy manually
+      }
+    }
+  }
+}

--- a/requel-angular/src/app/features/users/settings.ts
+++ b/requel-angular/src/app/features/users/settings.ts
@@ -25,12 +25,15 @@ import { InputNumberModule } from 'primeng/inputnumber';
 import { SelectModule } from 'primeng/select';
 import { MessageModule } from 'primeng/message';
 import { PreferencesService } from '../../core/preferences.service';
+import { AuthService } from '../../core/auth.service';
 import { UserPreferencesDto, STALENESS_OPTIONS } from '../../models/preferences';
+import { ApiTokensComponent } from './api-tokens';
 
 @Component({
   selector: 'app-settings',
   standalone: true,
-  imports: [FormsModule, ButtonModule, InputNumberModule, SelectModule, MessageModule],
+  imports: [FormsModule, ButtonModule, InputNumberModule, SelectModule, MessageModule,
+    ApiTokensComponent],
   template: `
     <div class="settings" data-testid="settings-page">
       <div class="page-header">
@@ -70,6 +73,10 @@ import { UserPreferencesDto, STALENESS_OPTIONS } from '../../models/preferences'
                     [outlined]="true" (onClick)="onReset()" [loading]="saving()" />
         </div>
       </div>
+
+      @if (canManageTokens()) {
+        <app-api-tokens />
+      }
     </div>
   `,
   styles: [`
@@ -95,8 +102,17 @@ export class SettingsComponent implements OnInit {
 
   constructor(
     private preferencesService: PreferencesService,
+    private authService: AuthService,
     private cdr: ChangeDetectorRef
   ) {}
+
+  /**
+   * PATs act against project data, so only project users see the section. A pure system admin has
+   * no use for one; an admin who also holds ProjectUserRole still qualifies through that role.
+   */
+  canManageTokens(): boolean {
+    return this.authService.user()?.roles?.includes('ProjectUserRole') ?? false;
+  }
 
   async ngOnInit(): Promise<void> {
     try {

--- a/requel-angular/src/app/models/api-token.ts
+++ b/requel-angular/src/app/models/api-token.ts
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/** Personal access token metadata (never the secret). Mirrors the server ApiTokenDto (#73). */
+export interface ApiTokenDto {
+  id: number;
+  name: string;
+  createdAt: string;
+  lastUsedAt: string | null;
+  expiresAt: string | null;
+  status: 'ACTIVE' | 'EXPIRED' | 'REVOKED';
+}
+
+export interface CreateApiTokenRequest {
+  name: string;
+  expiresInDays?: number | null;
+}
+
+/** The one-time plaintext token plus its metadata, returned by create. */
+export interface CreateApiTokenResponse {
+  token: string;
+  tokenInfo: ApiTokenDto;
+}


### PR DESCRIPTION
Closes #73.

Adds opaque, user-minted, revocable Personal Access Tokens so static-header MCP/API clients (e.g. `mcp-remote --header`, Cursor) can authenticate as a user with a durable credential instead of pasting a short-lived login JWT. Complements the interactive OAuth 2.1 track (#83) — see doc/mcp_remote_connection.md.

## What's included (by slice)

**Slice 1 — store**
- `ApiToken` entity (`api_tokens`): owner user id, name, SHA-256 `tokenHash` (unique), createdAt/lastUsedAt/expiresAt, revoked flag; `isActive(now)` = not revoked and not expired.
- `ApiTokenRepository` (findByTokenHash, findByOwnerUserIdOrderByCreatedAtDesc).
- Flyway `V11__api_tokens.sql`.

**Slice 2 — REST (`/api/auth/tokens`)**
- `ApiTokenService`: mint `reqpat_` + base64url(32 bytes), store only the SHA-256 hash, list, own-only revoke. Plaintext is returned **once**.
- `ApiTokenController`: P01, one-time plaintext), GET (list with derived ACTIVE/EXPIRED/REVOKED status), DELETE (revoke). Blank name → 400.

**Slice 3 — auth filter**
- `JwtAuthenticationFilter` branches on `ApiTokenService.isApiToken(token)`: hash → lookup → active check → load user → authorities from the user's roles. Throttled last-used update. Revocation/expiry take effect immediately (per-request lookup, authorities loaded live).

**Slices 4/5 — e2e + docs**
- `ApiTokenIT` (MockMvc): mint → use as bearer → list → revoke → 401; own-tokens-only (404); unauth create → 401; blank name → 400.
- doc/mcp_remote_connection.md: PAT is now the recommended durable credential.

**Slice 6 — Angular UI + endpoint gate**
- Settings-page "Personal Access Tokens" section (list with status badges + per-row revoke; New-token dialog with name + expiry preset 30/90/180/365 days, default 90; one-time copy-to-clipboard plaintext with a "won't be shown again" warning).
- `ApiSecurityConfig` role-gates `/api/auth/tokens(/**ense-in-depth). PATs act against project data, so a pure system admin has no use for one; an admin who also holds `ProjectUserRole` still qualifies.
- v1 is role-gated; a finer-grained `ManageApiTokens` `UserRolePermission` is a tracked fast-follow (see doc/pat_ui_plan.md).

## Security notes
- Only the SHA-256 hash is stored; plaintext is shown once and is never re-fetchable.
- Revocation is immediate (validated per request).
- A PAT only authenticates as its owner; what it can do is governed by the owner's roles + stakeholder permissions at request time.

## Testing
- `ApiTokenServiceTest`, `JwtAuthenticationFilterPatTest`, `ApiTokenIT` (backend).
- Manual end-to-end verified: minted via UI → used from Cursor → revoked → next request failed → new PAT → worked again.