### PR TITLE
MCP OAuth 2.1: embedded authorization server + resource server on /api/mcp (#83)

### DIFF
--- a/doc/83-oauth-verification.md
+++ b/doc/83-oauth-verification.md
@@ -78,7 +78,7 @@ CC=$(printf '%s' "$CV" | openssl dgst -sha256 -binary | openssl base64 | tr '+/'
 echo "http://localhost:8080/oauth2/authorize?response_type=code&client_id=requel-dev-client\
 &redirect_uri=http://127.0.0.1:8080/login/oauth2/code/requel-dev-client&scope=mcp\
 &code_challenge=$CC&code_challenge_method=S256&state=verify123"
-#   expect: redirect to /login -> Requel login form -> consent page naming the client + 'mcp'
+#   expect: redirect to /oauth2/login -> Requel login form -> consent page naming the client + 'mcp'
 #   scope -> redirect to the (handler-less) redirect URI with ?code=…&state=verify123
 
 # 3) Exchange the code (paste it) for tokens

--- a/doc/83-oauth-verification.md
+++ b/doc/83-oauth-verification.md
@@ -1,0 +1,219 @@
+# Issue #83 — MCP OAuth 2.1 end-to-end verification runbook (Slice 5)
+
+Manual verification for the embedded OAuth 2.1 authorization server (Slice 1), the `/api/mcp/**`
+resource server (Slice 2), RFC 9728 metadata (Slice 3), and Dynamic Client Registration (Slice 4).
+The unit/integration suites already pass; this runbook covers the parts that need a running server
+and, for the final part, a real MCP client — which can't be automated in CI.
+
+Run each part in order; record outcomes in the **Findings** table at the bottom. Part D is the
+**DCR client-behavior gate** the plan calls for — its result decides whether an anonymous
+registration shim is needed.
+
+## 0. Start the server with the AS enabled
+
+Local MySQL, dev profile (CORS for the SPA), AS signing key ephemeral (fine for verification),
+dev client + DCR registrar seeded:
+
+```bash
+java -jar modules/requel-app/target/requel-app-2.0.0-dev.jar \
+  --spring.profiles.active=dev --server.port=8080 \
+  '--spring.datasource.url=jdbc:mysql://127.0.0.1:3306/requel?createDatabaseIfNotExist=true&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC' \
+  --spring.datasource.username=root --spring.datasource.password=password \
+  --requel.oauth.seed-dev-client=true \
+  --requel.oauth.dcr.enabled=true \
+  --requel.oauth.dcr.registrar-client-secret=registrar-secret
+```
+
+Expected in the log: `Seeded OAuth dev client 'requel-dev-client' …` and
+`Seeded DCR registrar client 'requel-registrar' …`, plus the ephemeral-signing-key warning.
+
+## A. Discovery metadata + 401 (deterministic; curl only)
+
+```bash
+# RFC 8414 — authorization server metadata
+curl -s http://localhost:8080/.well-known/oauth-authorization-server | jq .
+#   expect: issuer, authorization_endpoint (/oauth2/authorize), token_endpoint (/oauth2/token),
+#           jwks_uri (/oauth2/jwks), code_challenge_methods_supported ["S256"]
+#   note: registration_endpoint is NOT in this document — it appears in the OIDC discovery doc:
+#     curl -s http://localhost:8080/.well-known/openid-configuration | jq .registration_endpoint
+#     -> "http://localhost:8080/connect/register"
+
+# RFC 9728 — protected resource metadata (both forms should return the same document)
+curl -s http://localhost:8080/.well-known/oauth-protected-resource | jq .
+curl -s http://localhost:8080/.well-known/oauth-protected-resource/api/mcp | jq .
+#   expect: resource=…/api/mcp, authorization_servers=[issuer], scopes_supported=["mcp"],
+#           bearer_methods_supported=["header"]
+
+# MCP 401 must advertise the resource metadata (Slice 3) — show the status line AND the header
+curl -s -i http://localhost:8080/api/mcp/sse | grep -iE '^HTTP/|www-authenticate'
+#   expect: HTTP/1.1 401
+#           WWW-Authenticate: Bearer resource_metadata="…/.well-known/oauth-protected-resource"
+```
+
+**Pass:** all three documents are correct and the 401 carries `resource_metadata`.
+
+## B. Authorization code + PKCE with the seeded dev client (proves the AS issues a user token)
+
+The seeded `requel-dev-client` is public (PKCE), scope `mcp`, consent required, with loopback
+redirect URIs. Its redirect URI is fixed to `http://127.0.0.1:8080/login/oauth2/code/requel-dev-client`,
+which has **no handler** in Requel (Requel is the auth server, not an OAuth client).
+
+> **The 404 after login/consent is expected — it is the success case, not an error.** There is NO
+> page that displays a token. The authorization `code` comes back in the browser **address bar** as a
+> query parameter: `…/requel-dev-client?code=<CODE>&state=…`. Read the address bar, ignore the 404
+> page body. Copy the `code=` value (up to `&state`). Real clients use their own loopback callback via
+> DCR (Part C/D); this handler-less redirect is only for manual testing.
+>
+> **`$CV` and `$CC` must be from the same pair, in the same shell.** Generate CV/CC, build the
+> authorize URL with **that** `$CC`, and exchange with **that** `$CV`. If you regenerate CV/CC, you
+> must rebuild the authorize URL and log in again, or the exchange fails with `invalid_grant`. The
+> code is also single-use and expires in ~1 minute — exchange it immediately.
+
+```bash
+# 1) PKCE pair
+CV=$(openssl rand -base64 60 | tr -d '\n=+/' | cut -c1-64)
+CC=$(printf '%s' "$CV" | openssl dgst -sha256 -binary | openssl base64 | tr '+/' '-_' | tr -d '=')
+
+# 2) Open this in a browser (logged out), log in with a Requel user, approve consent:
+echo "http://localhost:8080/oauth2/authorize?response_type=code&client_id=requel-dev-client\
+&redirect_uri=http://127.0.0.1:8080/login/oauth2/code/requel-dev-client&scope=mcp\
+&code_challenge=$CC&code_challenge_method=S256&state=verify123"
+#   expect: redirect to /login -> Requel login form -> consent page naming the client + 'mcp'
+#   scope -> redirect to the (handler-less) redirect URI with ?code=…&state=verify123
+
+# 3) Exchange the code (paste it) for tokens
+CODE=<paste code from the redirect URL>
+curl -s -X POST http://localhost:8080/oauth2/token \
+  -d grant_type=authorization_code \
+  -d client_id=requel-dev-client \
+  -d "redirect_uri=http://127.0.0.1:8080/login/oauth2/code/requel-dev-client" \
+  -d "code=$CODE" -d "code_verifier=$CV" | jq .
+#   expect: access_token (JWT, alg RS256, sub=<your username>), refresh_token, expires_in≈3600
+
+# 4) Call an MCP tool as that user (SSE handshake should succeed with the access token)
+ACCESS=<paste access_token>
+curl -N -H "Authorization: Bearer $ACCESS" http://localhost:8080/api/mcp/sse
+#   expect: 'event: endpoint' with a session message URL (same as the PAT path)
+```
+
+**Pass:** token issued with `sub` = the Requel username; the access token authenticates against
+`/api/mcp/sse`; consent screen appeared. Decode the JWT (`jwt.io` or `cut`+base64) and confirm
+`sub` and `scope=mcp`.
+
+## C. Dynamic Client Registration (gated; proves DCR + policy stamping)
+
+```bash
+# 1) Mint the single-use initial access token from the registrar (client.create ONLY)
+INIT=$(curl -s -u requel-registrar:registrar-secret -X POST http://localhost:8080/oauth2/token \
+  -d grant_type=client_credentials -d scope=client.create | jq -r .access_token)
+
+# 2) Register a client with a loopback callback (this is what a real client does).
+#    NOTE: do NOT send a "scope" field. Spring AS validates the *requested* registration scope
+#    against the initial access token, which only carries client.create -> requesting "mcp" fails
+#    with invalid_scope. Omit scope; our DcrRegisteredClientConverter forces scope=mcp on the
+#    registered client regardless, so the response still comes back with "scope":"mcp".
+curl -s -X POST http://localhost:8080/connect/register \
+  -H "Authorization: Bearer $INIT" -H 'Content-Type: application/json' \
+  -d '{"client_name":"my-agent","redirect_uris":["http://127.0.0.1:7777/callback"],
+       "grant_types":["authorization_code","refresh_token"]}' | jq .
+#   expect: client_id issued; response shows scope "mcp", token_endpoint_auth_method "none"
+#           (public/PKCE). registration_access_token + registration_client_uri returned.
+
+# 3) Non-loopback redirect must be rejected (mint a fresh INIT — the token is single-use)
+INIT2=$(curl -s -u requel-registrar:registrar-secret -X POST http://localhost:8080/oauth2/token \
+  -d grant_type=client_credentials -d scope=client.create | jq -r .access_token)
+curl -s -X POST http://localhost:8080/connect/register \
+  -H "Authorization: Bearer $INIT2" -H 'Content-Type: application/json' \
+  -d '{"client_name":"bad","redirect_uris":["https://evil.example.com/cb"],
+       "grant_types":["authorization_code"]}' | jq .
+#   expect: error invalid_redirect_uri
+```
+
+**Pass:** loopback client registers and comes back forced to scope `mcp` + public/PKCE; a
+non-loopback redirect is rejected; the initial token is single-use (a second `/connect/register`
+with the same token fails).
+
+## D. Real client behavior gate (decides the anonymous-DCR question)
+
+Connect each client you care about and record **how it registers**. `mcp-remote` (used by most
+desktop clients) supports OAuth discovery and, in recent versions, static client info via
+`--static-oauth-client-info` — so a client that can't be handed an initial token can still use a
+pre-registered `client_id`.
+
+For each client, try in this order and note which works:
+
+1. **OAuth, pre-registered client_id** — register a client via Part C using the client's own loopback
+   callback URL as `redirect_uris`, then point the client at `http://localhost:8080/api/mcp/sse`
+   with its OAuth client_id (e.g. `mcp-remote … --static-oauth-client-info '{"client_id":"…"}'`).
+   Verify the browser login + consent, then tool calls run as the user.
+2. **OAuth, anonymous DCR** — point the client at the endpoint with no client_id and let it
+   self-register. This will **fail** against our gated `/connect/register` (needs an initial access
+   token). If the client has no way to supply one, record that.
+3. **Static bearer (PAT)** — fallback, still supported (see `mcp_remote_connection.md`).
+
+### Claude Code (VS Code) — step by step
+
+The VS Code extension shares the `claude mcp` config and the `/mcp` UI. Steps marked **(verify)** are
+not confirmed in the Claude Code docs — establishing them is the point of Part D; record what
+actually happens. Check `claude mcp add --help` for the exact flags on your version.
+
+**D1 — Disconnect the existing PAT server.**
+- List: `claude mcp list` (or run `/mcp` in Claude Code).
+- Remove: `claude mcp remove requel` (use the name you configured).
+- If it still shows in `/mcp` (a known quirk when a server exists at both user and project scope),
+  delete the `requel` entry by hand from `~/.claude.json` (user) and/or the project `.mcp.json`, then
+  restart Claude Code. Confirm `/mcp` no longer lists it.
+
+**D2 — Add Requel as a remote OAuth server (no token).**
+```
+claude mcp add --transport sse requel http://localhost:8080/api/mcp/sse
+```
+SSE is the transport Requel serves today (`--transport http`/Streamable HTTP is not served yet). Do
+NOT pass an `Authorization` header — the point is to let OAuth drive.
+
+**D3 — Authenticate.** `claude mcp login requel` (Claude Code ≥ v2.1.186) or authenticate from the
+`/mcp` UI. Claude Code hits `/api/mcp/sse`, gets the 401 + `resource_metadata`, discovers the AS, and
+opens a browser; log in as your Requel user and approve consent. On success it returns to Claude
+Code's loopback callback and `/mcp` shows the server connected.
+
+**D4 — The DCR gate (the crux).** Before the browser step Claude Code needs an OAuth `client_id`, and
+current Claude Code performs **anonymous** Dynamic Client Registration against `/connect/register`.
+Requel's DCR is **gated** (needs an initial access token), so the anonymous attempt is expected to be
+**rejected**. Record which of these holds:
+- **Pre-registered client + fixed callback port (CONFIRMED available in Claude Code)** — `claude mcp
+  add` supports `--callback-port` and `--client-id` (and `--client-secret`, which our public/PKCE
+  clients don't need). Pick a port, register a client via Part C using that callback as loopback
+  redirect URI(s) — register BOTH host forms, since Spring AS matches `redirect_uri` exactly:
+  `redirect_uris:["http://127.0.0.1:8899/callback","http://localhost:8899/callback"]`. Then:
+  `claude mcp add --transport sse requel http://localhost:8080/api/mcp/sse --callback-port 8899 --client-id <client_id> --scope user`
+  and `claude mcp login requel`. If login fails with `invalid_redirect_uri`, Claude Code used a
+  different callback path/host — read the exact `redirect_uri` from the browser URL and re-register
+  the client with it (the converter accepts any loopback URI). This is the gated-DCR-compatible path,
+  so no anonymous-registration support is required for Claude Code.
+- **Anonymous-only, no static client option** (some other clients) — if a client can only self-register
+  anonymously and cannot take a `client_id`, the OAuth connect fails at Requel's gated
+  `/connect/register`. That would be the trigger for an anonymous-DCR shim follow-up; use the PAT path
+  (D5) meanwhile. (Not the case for Claude Code, which accepts a pre-registered client_id.)
+
+**D5 — PAT fallback (always works).** Re-add with a static header (see `mcp_remote_connection.md`):
+`claude mcp add --transport sse requel http://localhost:8080/api/mcp/sse --header "Authorization: Bearer reqpat_…"`.
+
+**Decision:** if every client of interest works via (1) or (3), gated DCR is sufficient — done.
+If a required client only does (2) anonymous registration and can't supply an initial token or a
+static client_id, open a follow-up to add a **loopback-restricted anonymous `/connect/register`
+path** (permit unauthenticated POST for loopback redirect URIs only, same policy stamping). Do not
+build it unless a client forces it.
+
+## Findings
+
+| Part | Client / check | Result | Notes |
+|------|----------------|--------|-------|
+| A | metadata + 401 | ✅ pass | RFC 8414 + 9728 docs correct; 401 carries resource_metadata |
+| B | dev-client code+PKCE → SSE handshake | ✅ pass | access_token sub=admin, scope=mcp; /api/mcp/sse accepted it |
+| C | DCR register + loopback reject | ✅ pass | register (no scope in request → forced mcp); non-loopback → invalid_redirect_uri |
+| D | Claude Code (VS Code) | ✅ (1) pre-registered client | `claude mcp add --client-id --callback-port 8899`; `/mcp` authenticate → browser login+consent → connected |
+| D | Cursor | ☐ (1) / ☐ (2) / ☐ (3) | not yet tested |
+| D | Claude Desktop / Cowork | ☐ (1) / ☐ (2) / ☐ (3) | not yet tested |
+
+**Anonymous-DCR shim needed?** ✅ no — Claude Code accepts a pre-registered client_id, so gated DCR is
+sufficient; PAT remains for headless. (Re-evaluate only if a future client can do anonymous DCR *only*.)

--- a/doc/mcp_remote_connection.md
+++ b/doc/mcp_remote_connection.md
@@ -14,15 +14,20 @@ Claude / Codex  --stdio-->  mcp-remote  --HTTP+SSE (JWT)-->  Requel  /api/mcp/ss
 ```
 
 Most desktop MCP clients only speak **stdio** (they spawn a server process and talk over its
-pipes). Requel exposes MCP over **HTTP** (SSE / Streamable HTTP) under `/api/mcp`, behind the same
-JWT auth as the rest of `/api/**`. `mcp-remote` is a tiny stdio-to-HTTP proxy the client launches;
-it forwards MCP traffic to the server and attaches the `Authorization` header. The server runs the
-calls through the gateway, so **per-stakeholder permissions and auditing apply exactly as they do
-in the UI** — the client acts as whichever Requel user the token belongs to.
+pipes). Requel exposes MCP over **HTTP** (SSE / Streamable HTTP) under `/api/mcp`. `mcp-remote` is a
+tiny stdio-to-HTTP proxy the client launches; it forwards MCP traffic to the server and either drives
+the OAuth flow or attaches a static `Authorization` header. The server runs the calls through the
+gateway, so **per-stakeholder permissions and auditing apply exactly as they do in the UI** — the
+client acts as whichever Requel user authenticated.
+
+`/api/mcp/**` is an **OAuth 2.1 protected resource** (issue #83): on a 401 it advertises the
+authorization server via RFC 9728 metadata, and a compliant client runs the discovery →
+authorization-code + PKCE flow to obtain a token — no pre-shared secret. **Personal access tokens
+(PATs) and the SPA login JWT are still accepted** on the same endpoints, for headless/CI use and
+quick tests. Pick the auth style in "Authentication" below.
 
 There is intentionally no Requel-built stdio bridge and no separate REST client library: the HTTP
-transport plus `mcp-remote` covers local access, and the per-client-identity work (durable tokens)
-is tracked separately (see "Durable credentials" below).
+transport plus `mcp-remote` covers local access.
 
 ## Prerequisites
 
@@ -32,11 +37,81 @@ is tracked separately (see "Durable credentials" below).
 - Write tools: enabled by default (`requel.gateway.write.enabled=true`). To run the MCP server
   read-only, start Requel with `--requel.gateway.write.enabled=false`.
 
-## 1. Get a token
+## Authentication
 
-The MCP endpoints require a bearer credential, same as any `/api/**` call. Two options:
+Two ways to authenticate the MCP endpoints; choose by how the client runs:
 
-**Recommended — a personal access token (PAT, #73):** a durable, revocable token you mint once and
+- **OAuth 2.1 (preferred for interactive clients — Cursor, Claude Code, Claude Desktop/Cowork).**
+  The client discovers the authorization server from the 401 and runs authorization-code + PKCE; you
+  log in with your Requel credentials in the browser and approve a consent screen once. No token to
+  paste or store. See "OAuth 2.1 connection" below. The full end-to-end walkthrough (and how to
+  enable the AS + register a client) is in `doc/83-oauth-verification.md`.
+- **Personal access token (PAT) — preferred for headless / CI / scripts, and fine for a quick test.**
+  A durable, revocable bearer you mint once and put in the `Authorization` header. See "1. Get a
+  token (PAT)".
+
+Either way the client acts as **one Requel user**, and that user's per-stakeholder permissions govern
+what the tools can read and write. Scope the user to what the assistant should do.
+
+## OAuth 2.1 connection (preferred for interactive clients)
+
+The MCP server (issue #83) is an OAuth 2.1 protected resource with an embedded authorization server
+backed by the Requel user store. A client connects with no pre-shared token: it reads the RFC 9728
+metadata from the 401, discovers the AS, and runs authorization-code + PKCE (you log in + consent in
+the browser).
+
+**Enabling and client registration** are covered step-by-step in `doc/83-oauth-verification.md`
+(start the server with the AS enabled, mint an initial access token from the registrar client, and
+register the client — or use `mcp-remote --static-oauth-client-info` with a pre-registered
+`client_id`). Requel uses Spring Authorization Server's OIDC Dynamic Client Registration, which is
+**gated by an initial access token** (not anonymous); registered clients are forced to loopback
+redirect URIs, PKCE, consent, and the `mcp` scope.
+
+> Because DCR is gated, a client must either accept a **pre-registered `client_id`** (register one
+> per the recipe below) or supply an initial access token — Requel does not allow anonymous
+> registration. If a client can *only* self-register anonymously and can't be configured otherwise,
+> use the PAT path below. (Claude Code accepts a pre-registered `client_id`; see the recipe.)
+
+### Claude Code (VS Code) over OAuth — confirmed recipe
+
+Verified end to end (issue #83, Part D). Claude Code accepts a pre-registered `client_id` and a fixed
+callback port, so it works with Requel's gated DCR without anonymous registration.
+
+1. Start Requel with the AS + DCR enabled and a registrar secret:
+   `--requel.oauth.seed-dev-client=true --requel.oauth.dcr.enabled=true --requel.oauth.dcr.registrar-client-secret=<secret>`
+
+2. Mint a single-use initial access token and register a client whose redirect URIs are Claude Code's
+   loopback callback (register **both** host forms — Spring AS matches `redirect_uri` exactly):
+
+   ```bash
+   INIT=$(curl -s -u requel-registrar:<secret> -X POST http://localhost:8080/oauth2/token \
+     -d grant_type=client_credentials -d scope=client.create | jq -r .access_token)
+   curl -s -X POST http://localhost:8080/connect/register \
+     -H "Authorization: Bearer $INIT" -H 'Content-Type: application/json' \
+     -d '{"client_name":"claude-code","redirect_uris":["http://127.0.0.1:8899/callback","http://localhost:8899/callback"],"grant_types":["authorization_code","refresh_token"]}' | jq -r .client_id
+   ```
+   Do NOT send a `scope` field — Spring AS validates it against the initial token (`client.create`
+   only); the client is stamped with scope `mcp` automatically.
+
+3. Add the server (public/PKCE client — no secret) and authenticate:
+
+   ```bash
+   claude mcp add --transport sse requel http://localhost:8080/api/mcp/sse \
+     --callback-port 8899 --client-id <client_id> --scope user
+   ```
+   Then in an interactive Claude Code session run `/mcp`, select `requel`, and **Authenticate**
+   (`claude mcp login requel` also works on Claude Code ≥ v2.1.186). A browser opens for Requel login
+   + consent; on success the server shows connected and the tools appear.
+
+If **Authenticate** fails with `invalid_redirect_uri`, Claude Code used a different callback path/host
+— read it from the browser URL and re-register the client with that exact loopback URI, then re-add
+with the new `client_id`.
+
+## 1. Get a token (PAT — headless / quick test)
+
+The MCP endpoints accept a bearer credential, same as any `/api/**` call. For a PAT:
+
+**A personal access token (PAT, #73):** a durable, revocable token you mint once and
 leave configured. First log in to get a short-lived JWT, then use it to mint the PAT:
 
 ```bash
@@ -90,8 +165,9 @@ Restart Claude Desktop. The Requel tools (`listProjects`, `getProject`, `createG
 …) appear in the tools list. Write tools only appear when the server has writes enabled.
 
 `--transport sse-only` is important: `mcp-remote` defaults to Streamable HTTP and probes it first;
-since Requel currently serves only SSE, the probe fails and `mcp-remote` falls into an OAuth flow our
-server doesn't expose. Forcing SSE avoids that. (Tool names are bare — no `requel.` prefix — because
+since Requel currently serves only SSE, forcing SSE avoids a wasted Streamable-HTTP probe. This is a
+**transport** setting, not auth — it is independent of whether you authenticate via OAuth or a static
+header (the example above passes a static PAT). (Tool names are bare — no `requel.` prefix — because
 MCP tool names must match `^[a-zA-Z0-9_-]{1,64}$`; dots are rejected by spec-compliant clients.)
 
 ### Codex (or any stdio MCP client)
@@ -173,4 +249,5 @@ revocable `reqpat_…` token for a chosen user (step 1), drop it in the `Authori
 manage it via `GET`/`DELETE /api/auth/tokens` (revocation takes effect on the token's next request,
 and only the SHA-256 hash is stored server-side). Token *scoping* (read-only vs write-set) is a
 later enhancement; today a PAT carries its owner's full rights. Interactive OAuth 2.1 for agent
-clients that drive the discovery flow is a separate track (#83).
+clients that drive the discovery flow is implemented (#83) — see "OAuth 2.1 connection" above and
+`doc/83-oauth-verification.md`; PATs remain the headless/CI path.

--- a/doc/oauth_mcp_plan.md
+++ b/doc/oauth_mcp_plan.md
@@ -209,14 +209,29 @@ form login must serve `/login`, which is outside the AS endpoints matcher).
   mode if needed).
 - RFC 8414 metadata (`/.well-known/oauth-authorization-server`) is provided by the AS chain.
 
-### Slice 2 — MCP resource server
-- Add `spring-boot-starter-oauth2-resource-server`.
-- New `McpResourceServerConfig` (`service/config/`): `@Order(2)` chain as specified above; renumber
-  `ApiSecurityConfig` to `@Order(3)`.
-- Subject→user mapping + live authorities via a small `JwtAuthenticationConverter`; confirm
-  `CommandGateway`/`AuthorizingCommandHandler` per-stakeholder checks run as the mapped user
-  (they already read `CurrentUserResolver`, so this should be transparent).
-- CORS: extend the config so `/api/mcp/**` is covered (browser-based agent clients may preflight).
+### Slice 2 — MCP resource server (done)
+- Added `spring-boot-starter-oauth2-resource-server`.
+- New `McpResourceServerConfig` (`service/config/`): `@Order(3)` chain on `/api/mcp/**`, `STATELESS`,
+  CORS via the shared source, `oauth2ResourceServer(jwt)` validating AS tokens with the AS's own
+  `JwtDecoder` bean. `ApiSecurityConfig` was renumbered to `@Order(4)` back in Slice 1.
+- **Credential routing refinement (beyond the original note).** Rather than relying only on the
+  HS256-vs-RS256 parse-failure fall-through, a custom `McpBearerTokenResolver` inspects the JWS
+  header `alg` and routes the credential: PAT (`reqpat_`) and HS256 login JWTs return `null` (so the
+  resource server ignores them and the pre-positioned `JwtAuthenticationFilter` handles them),
+  while asymmetric-signed (RS/PS/ES) AS tokens go to the resource server. This preserves PAT **and**
+  login-JWT on MCP (no regression) instead of rejecting login JWTs, and avoids the double-authenticate
+  conflict where the bearer filter would otherwise try to validate a PAT/login-JWT as an AS token.
+  The alg is read only to route; the actual signature check is done by the chosen authenticator.
+- Subject→user mapping + live authorities via `McpJwtAuthenticationConverter`: token `sub` →
+  `UserRepository.findUserByUsername`, authorities = `ROLE_<role>` (from `UserDtoMapper`) + `SCOPE_*`
+  (from the token). A subject that doesn't resolve to a user is rejected
+  (`InvalidBearerTokenException`). `CurrentUserResolver` then resolves the same user, so the gateway's
+  per-stakeholder checks run transparently as that user.
+- Existing MCP integration tests (`McpCallAuditIT`, `RequelMcpEndToEndIT`) drive the handler/gateway
+  in-process (they set the `SecurityContext` directly), so they are unaffected by the HTTP chain.
+- CORS covered via the shared `corsConfigurationSource` (`/api/**` includes `/api/mcp/**`).
+- Audience/issuer validation on the resource-server `JwtDecoder` is deferred to Slice 3 / hardening
+  (same-app AS + RS means signature validation is sufficient for now).
 
 ### Slice 3 — RFC 9728 Protected Resource Metadata
 - New controller serving `/.well-known/oauth-protected-resource` (JSON: `resource`,

--- a/doc/oauth_mcp_plan.md
+++ b/doc/oauth_mcp_plan.md
@@ -166,9 +166,12 @@ form login must serve `/login`, which is outside the AS endpoints matcher).
    `getEndpointsMatcher()` (`/oauth2/**`, `/.well-known/oauth-authorization-server`,
    `/connect/register` for DCR), OIDC enabled, custom consent page at `/oauth2/consent`, and a
    `LoginUrlAuthenticationEntryPoint("/login")` for unauthenticated `text/html` requests.
-2. **`@Order(2)` — interactive login/consent chain.** `securityMatcher("/login",
-   "/oauth2/consent", "/logout")` with `formLogin` (Spring's generated login page) backed by
-   `RequelUserAuthenticationProvider` (reuses `User.isPassword` + `UserDtoMapper.getRoleStrings`).
+2. **`@Order(2)` — interactive login/consent chain.** `securityMatcher("/oauth2/login",
+   "/oauth2/consent")` with `formLogin` backed by `RequelUserAuthenticationProvider` (reuses
+   `User.isPassword` + `UserDtoMapper.getRoleStrings`). **The AS login page is at `/oauth2/login`, NOT
+   `/login`** — `/login` is the Angular SPA's own client route (`LoginComponent`), and putting the
+   AS form login there would shadow it with Spring's login page (this broke the auth e2e tests once;
+   don't reintroduce it). A small `OAuth2LoginPageController` renders the `/oauth2/login` page.
    Scoped so it never touches the SPA routes or `/api/**`. Sessions + CSRF are on (defaults) and
    shared with chain 1 via the session, so the consent form's CSRF token and the saved
    `/oauth2/authorize` request both carry across.

--- a/doc/oauth_mcp_plan.md
+++ b/doc/oauth_mcp_plan.md
@@ -261,6 +261,9 @@ form login must serve `/login`, which is outside the AS endpoints matcher).
 - **Not** anonymous — see the revised DCR decision above. The empirical client check is Slice 5.
 
 ### Slice 5 — End-to-end verification & docs
+- **Runbook: `doc/83-oauth-verification.md`** (the manual steps that can't run in CI) and the
+  `mcp_remote_connection.md` updates are done; the actual client runs (Part D) are executed by the
+  developer against a running server, with outcomes recorded in the runbook's Findings table.
 - Connect a real client (Cursor / Claude Code / Cowork) with **no** static token: discovery →
   authorization-code + PKCE → token → tool calls execute as the authenticated Requel user.
 - **DCR client-behavior gate (added after Slice 4).** Slice 4 shipped Spring-AS-native *gated* DCR

--- a/doc/oauth_mcp_plan.md
+++ b/doc/oauth_mcp_plan.md
@@ -233,12 +233,17 @@ form login must serve `/login`, which is outside the AS endpoints matcher).
 - Audience/issuer validation on the resource-server `JwtDecoder` is deferred to Slice 3 / hardening
   (same-app AS + RS means signature validation is sufficient for now).
 
-### Slice 3 — RFC 9728 Protected Resource Metadata
-- New controller serving `/.well-known/oauth-protected-resource` (JSON: `resource`,
-  `authorization_servers`, `bearer_methods_supported`, `scopes_supported`). Spring AS does not
-  provide this — it's a resource-server concern.
-- Emit `WWW-Authenticate: Bearer resource_metadata="<url>"` on MCP 401s via a custom
-  `AuthenticationEntryPoint` on chain 2.
+### Slice 3 — RFC 9728 Protected Resource Metadata (done)
+- New `ProtectedResourceMetadataController` serving `/.well-known/oauth-protected-resource` (JSON:
+  `resource`, `authorization_servers`, `scopes_supported: ["mcp"]`, `bearer_methods_supported:
+  ["header"]`). Spring AS does not provide this — it's a resource-server concern. Public (matched by
+  no security chain). Both the bare well-known path and the RFC 9728 resource-path-suffixed variant
+  (`/.well-known/oauth-protected-resource/api/mcp`) map to the same document. `resource` and the
+  issuer are derived from the request base URL when no explicit `requel.oauth.issuer` is configured.
+- New `McpAuthenticationEntryPoint` wired onto the MCP resource-server chain (Slice 2 chain, not the
+  AS chain): delegates to `BearerTokenAuthenticationEntryPoint` for standard status +
+  `error`/`error_description` formatting, then appends `resource_metadata="<url>"` to the
+  `WWW-Authenticate` header so agent clients can auto-discover the AS on a 401.
 
 ### Slice 4 — Dynamic Client Registration
 - Enable Spring AS's client-registration endpoint (OIDC `/connect/register`), gated per the DCR

--- a/doc/oauth_mcp_plan.md
+++ b/doc/oauth_mcp_plan.md
@@ -146,7 +146,7 @@ config. Decide whether registered clients are seeded or created via DCR.
 
 | Question | Decision for this ticket |
 |----------|--------------------------|
-| DCR policy | **Enable RFC 7591 DCR, gated.** Allow **loopback** redirect URIs (`http://127.0.0.1[:*]`, `http://localhost[:*]`) for desktop clients out of the box. Registration is open by default for loopback-only clients (self-hosted, single-tenant), with an optional initial-access-token requirement toggled by `requel.oauth.dcr.require-initial-token` for exposed deployments. |
+| DCR policy | **Revised in Slice 4 (see note).** Original intent: open registration, loopback redirect URIs only. Reality: Spring Authorization Server implements **OIDC Dynamic Client Registration**, whose `/connect/register` endpoint is a protected resource requiring a short-lived, single-use **initial access token** (`client_credentials` + scope `client.create`); it does **not** do anonymous RFC 7591 registration natively. **Decision:** ship Slice 4 as Spring-AS-native **gated** DCR (initial access token + loopback-only redirect URIs + default client settings), which is the supported, secure, lower-effort path. Whether real MCP clients (Claude Code/Cursor) accept an initial token or require anonymous registration is unknown and is verified empirically in Slice 5; if they require anonymous, add a loopback-restricted anonymous shim then (with evidence), not speculatively. |
 | Consent screen | **Require consent for all MCP clients, no auto-approve** (custom minimal consent page showing a readable client name + scope descriptions). Agent clients are third-party; consent is the human gate that pairs with open DCR and is the phishing backstop. Remembered per client+scope, so it's a one-time prompt per tool. |
 | OAuth scopes | **Single coarse `mcp` scope** — "act as me through Requel's MCP tools." The real limits stay in the per-stakeholder gateway authorization; the token never grants more than the user already has. Finer `read`/`write` scopes deferred until a concrete need appears (additive, non-breaking later). |
 | Unify SPA auth onto OAuth? | **No — out of scope.** Keep the username/password → JWT chain (`/api/auth/login` + `JwtAuthenticationFilter`) for the SPA and scripts indefinitely. |
@@ -245,14 +245,36 @@ form login must serve `/login`, which is outside the AS endpoints matcher).
   `error`/`error_description` formatting, then appends `resource_metadata="<url>"` to the
   `WWW-Authenticate` header so agent clients can auto-discover the AS on a 401.
 
-### Slice 4 — Dynamic Client Registration
-- Enable Spring AS's client-registration endpoint (OIDC `/connect/register`), gated per the DCR
-  decision (loopback redirect URIs allowed; optional initial-access-token).
-- Configure default scopes for MCP clients and rotating refresh tokens.
+### Slice 4 — Dynamic Client Registration (Spring-AS-native, gated)
+- Enable Spring AS's OIDC client-registration endpoint via
+  `.oidc(o -> o.clientRegistrationEndpoint(...))` (`/connect/register` + `/connect/register` read).
+- **Initial access token** is required by Spring AS (it does not do anonymous DCR): register a
+  confidential **registrar client** (`client_credentials`, scope `client.create` only) that an admin
+  uses to mint the short-lived, single-use initial access token, which is then handed to the agent
+  client to register itself. Keeping the registrar's secret with the admin makes registration
+  admin-gated (secure); it can be loosened later if needed.
+- Apply defaults to newly-registered clients via the endpoint's authentication/registration
+  converter customization: **loopback-only redirect URIs** (`http://127.0.0.1[:*]`,
+  `http://localhost[:*]`), scope `mcp`, `requireProofKey(true)`, `requireAuthorizationConsent(true)`,
+  and the shared `defaultTokenSettings()` (1h access, 30d rotating refresh). Reject non-loopback
+  redirect URIs.
+- **Not** anonymous — see the revised DCR decision above. The empirical client check is Slice 5.
 
 ### Slice 5 — End-to-end verification & docs
 - Connect a real client (Cursor / Claude Code / Cowork) with **no** static token: discovery →
   authorization-code + PKCE → token → tool calls execute as the authenticated Requel user.
+- **DCR client-behavior gate (added after Slice 4).** Slice 4 shipped Spring-AS-native *gated* DCR
+  (initial access token required), because Spring AS does not do anonymous registration. Verify how
+  each real client actually registers:
+  - If the client can be given an **initial access token** (or a pre-registered `client_id`), the
+    gated flow is sufficient — document how to mint the initial access token from the registrar
+    client and hand it to the client.
+  - If a client **requires anonymous RFC 7591 registration** (no initial token, self-registers on
+    first connect) and cannot be configured otherwise, add a **loopback-restricted anonymous
+    registration path** then: permit unauthenticated `POST /connect/register` only for loopback
+    redirect URIs, still stamping the default settings (PKCE, consent, scope `mcp`, 1h/30d). Track as
+    a follow-up ticket if it materializes; do not build speculatively.
+  - Record which clients need which mode in `doc/mcp_remote_connection.md`.
 - Update `doc/mcp_remote_connection.md`: make OAuth the primary recipe; mark the static-bearer/PAT
   recipe dev-only or headless-only.
 

--- a/doc/oauth_mcp_plan.md
+++ b/doc/oauth_mcp_plan.md
@@ -1,4 +1,6 @@
-# MCP OAuth 2.1 authorization — design plan
+# MCP OAuth 2.1 Authorization 
+
+# Design
 
 > Plan for spec-compliant authorization on the MCP endpoints so AI agent clients (Cursor, Claude
 > Code, Claude Cowork/desktop) authenticate via the OAuth flow they expect, instead of a static
@@ -106,3 +108,162 @@ config. Decide whether registered clients are seeded or created via DCR.
   track spec changes.
 - Complexity/footprint of standing up an AS in a single-maintainer app — mitigated by it being
   embedded and config-driven.
+
+# Implementation Plan
+
+> Concrete, code-grounded plan for issue #83 (branch `83-oauth-2`). Maps the design slices above onto
+> the current codebase, resolves the open questions with recommended decisions, and specifies the
+> filter-chain ordering — the highest-risk part. Work lands on `83-oauth-2` per the standard
+> branch/PR/verify workflow in `CLAUDE.md`.
+
+## Current state (confirmed by reading the code)
+
+- **One security chain today.** `ApiSecurityConfig` (`modules/service-impl/.../service/config/`)
+  defines a single `SecurityFilterChain` at `@Order(1)` with `securityMatcher("/api/**")`,
+  `STATELESS`, `anonymous` disabled, and `HttpStatusEntryPoint(401)`. It adds
+  `JwtAuthenticationFilter` before `UsernamePasswordAuthenticationFilter`.
+- **The MCP endpoints live under `/api/**` and inherit that chain today.**
+  `McpJsonRpcController` is `@RequestMapping("/api/mcp")` (hand-rolled JSON-RPC POST, kept per #82),
+  and `RequelMcpServerConfig` exposes the Spring AI transport at `/api/mcp/sse`. Neither has its own
+  security config, so both currently require a Requel login JWT or PAT.
+- **`JwtAuthenticationFilter` already branches on credential kind:** `ApiTokenService.isApiToken()`
+  (prefix `reqpat_`) → PAT path (hash lookup, live authorities, `last_used_at`); otherwise
+  `JwtService.parseToken()` → login-JWT path (HS256, authorities from `roles` claim). On any parse
+  failure it clears the context so Spring returns 401.
+- **User resolution is name-based.** `CurrentUserResolver.resolve()` reads the
+  `SecurityContextHolder` `Authentication`, takes `auth.getName()`, and calls
+  `userRepository.findUserByUsername(name)`. **This is the key integration seam:** any chain that
+  sets an `Authentication` whose name is a valid Requel username makes the whole gateway/authorization
+  stack work unchanged. The OAuth path only has to map the token `sub` → Requel username.
+- **`McpClientContextFilter`** is scoped to `/api/mcp` via `shouldNotFilter` and is independent of
+  which security chain runs — no change needed.
+- **Flyway:** migrations in `modules/requel-app/src/main/resources/db/migration/`, latest is
+  `V11__api_tokens.sql`; **next is `V12`**. H2 test schema mirrors MySQL.
+- **Deps:** `service-impl/pom.xml` has `spring-boot-starter-security` + jjwt. OAuth starters are
+  **not** yet present.
+
+## Decisions on the open questions
+
+| Question | Decision for this ticket |
+|----------|--------------------------|
+| DCR policy | **Enable RFC 7591 DCR, gated.** Allow **loopback** redirect URIs (`http://127.0.0.1[:*]`, `http://localhost[:*]`) for desktop clients out of the box. Registration is open by default for loopback-only clients (self-hosted, single-tenant), with an optional initial-access-token requirement toggled by `requel.oauth.dcr.require-initial-token` for exposed deployments. |
+| Consent screen | **Require consent for all MCP clients, no auto-approve** (custom minimal consent page showing a readable client name + scope descriptions). Agent clients are third-party; consent is the human gate that pairs with open DCR and is the phishing backstop. Remembered per client+scope, so it's a one-time prompt per tool. |
+| OAuth scopes | **Single coarse `mcp` scope** — "act as me through Requel's MCP tools." The real limits stay in the per-stakeholder gateway authorization; the token never grants more than the user already has. Finer `read`/`write` scopes deferred until a concrete need appears (additive, non-breaking later). |
+| Unify SPA auth onto OAuth? | **No — out of scope.** Keep the username/password → JWT chain (`/api/auth/login` + `JwtAuthenticationFilter`) for the SPA and scripts indefinitely. |
+| Token lifetimes / refresh | **Access token 1h; refresh token 30d, rotating**, reuse-detection on. Configurable via `requel.oauth.*`. Long-lived desktop configs rely on refresh, not long access tokens. |
+| Does Spring AS DCR satisfy Cursor/Claude Code? | **Verify empirically in Slice 4/5.** Spring AS implements OIDC-flavored client registration; treat exact interop as a test gate, not an assumption. |
+| PAT (#73) vs OAuth on MCP | **Keep both.** OAuth for interactive agent clients; PAT for headless/CI. The MCP chain accepts both (see ordering below). |
+
+## Filter-chain ordering (the risky part)
+
+Spring selects the **first** `SecurityFilterChain` whose `securityMatcher` matches, in `@Order`
+sequence. `/api/mcp/**` is a subset of `/api/**`, so the MCP chain must come **before** the existing
+API chain. Target: **four chains** (a dedicated interactive login/consent chain is required because
+form login must serve `/login`, which is outside the AS endpoints matcher).
+
+1. **`@Order(1)` — Authorization Server chain.** Built with
+   `OAuth2AuthorizationServerConfigurer.authorizationServer()`, matched to its
+   `getEndpointsMatcher()` (`/oauth2/**`, `/.well-known/oauth-authorization-server`,
+   `/connect/register` for DCR), OIDC enabled, custom consent page at `/oauth2/consent`, and a
+   `LoginUrlAuthenticationEntryPoint("/login")` for unauthenticated `text/html` requests.
+2. **`@Order(2)` — interactive login/consent chain.** `securityMatcher("/login",
+   "/oauth2/consent", "/logout")` with `formLogin` (Spring's generated login page) backed by
+   `RequelUserAuthenticationProvider` (reuses `User.isPassword` + `UserDtoMapper.getRoleStrings`).
+   Scoped so it never touches the SPA routes or `/api/**`. Sessions + CSRF are on (defaults) and
+   shared with chain 1 via the session, so the consent form's CSRF token and the saved
+   `/oauth2/authorize` request both carry across.
+3. **`@Order(3)` — MCP resource-server chain (Slice 2).** `securityMatcher("/api/mcp/**")`,
+   `STATELESS`, `oauth2ResourceServer(jwt(...))` validating **AS-issued** JWTs via the AS issuer/JWK
+   set. Add the existing `JwtAuthenticationFilter` **before** the bearer filter so **PATs still
+   work** on MCP: a `reqpat_` token is handled by the PAT path; a real AS JWT fails
+   `JwtService.parseToken()` (HS256 vs the AS's RS256/JWK), leaves the context empty, and falls
+   through to the resource-server bearer filter. Set a `BearerTokenAuthenticationEntryPoint` so 401s
+   carry `WWW-Authenticate: Bearer`, then augment it with the `resource_metadata` param (Slice 3).
+   Map `jwt.subject` → username so `CurrentUserResolver` resolves the Requel user; load authorities
+   live from that user (reuse `UserDtoMapper.getRoleStrings`) rather than trusting token claims.
+4. **`@Order(4)` — existing `/api/**` chain.** The current `ApiSecurityConfig` chain, renumbered
+   from `@Order(1)` to `@Order(4)`. Unchanged otherwise; it no longer sees `/api/mcp/**` because
+   chain 3 matches first.
+
+> `@Order` values must be unique across chains. The AS chain is the highest precedence and is safe
+> as long as its matcher is limited to AS endpoints and does not overlap `/api/**`. Add an
+> integration test asserting a request to `/api/mcp` with no token hits chain 3 (401 +
+> `WWW-Authenticate`), and `/api/projects` still hits chain 4.
+
+## Slice-by-slice work
+
+### Slice 1 — Embedded Authorization Server
+- Add `spring-boot-starter-oauth2-authorization-server` to `service-impl/pom.xml`.
+- New `AuthorizationServerConfig` (`service/config/`): `@Order(1)` chain (above),
+  `RegisteredClientRepository`, `AuthorizationServerSettings` (issuer from `requel.oauth.issuer`),
+  RSA `JWKSource` (generated at startup for dev; **document a keystore/persistent-key option** for
+  prod so tokens survive restarts), `JwtDecoder` from the JWK source.
+- Back interactive login with the **Requel user store**: expose a `UserDetailsService` (or an
+  `AuthenticationProvider`) over `UserRepository` + the existing password hashing from
+  `platform-identity`, so users log in with Requel credentials. Issue tokens with **`sub` = Requel
+  username** to match `CurrentUserResolver`.
+- Persistence: use `JdbcRegisteredClientRepository`, `JdbcOAuth2AuthorizationService`,
+  `JdbcOAuth2AuthorizationConsentService`. Add `V12__oauth2_authorization_server.sql` from the
+  official Spring AS schema (registered client / authorization / consent tables); verify H2
+  compatibility in the test schema (the AS schema uses `blob`/`timestamp`; adjust types for H2 MySQL
+  mode if needed).
+- RFC 8414 metadata (`/.well-known/oauth-authorization-server`) is provided by the AS chain.
+
+### Slice 2 — MCP resource server
+- Add `spring-boot-starter-oauth2-resource-server`.
+- New `McpResourceServerConfig` (`service/config/`): `@Order(2)` chain as specified above; renumber
+  `ApiSecurityConfig` to `@Order(3)`.
+- Subject→user mapping + live authorities via a small `JwtAuthenticationConverter`; confirm
+  `CommandGateway`/`AuthorizingCommandHandler` per-stakeholder checks run as the mapped user
+  (they already read `CurrentUserResolver`, so this should be transparent).
+- CORS: extend the config so `/api/mcp/**` is covered (browser-based agent clients may preflight).
+
+### Slice 3 — RFC 9728 Protected Resource Metadata
+- New controller serving `/.well-known/oauth-protected-resource` (JSON: `resource`,
+  `authorization_servers`, `bearer_methods_supported`, `scopes_supported`). Spring AS does not
+  provide this — it's a resource-server concern.
+- Emit `WWW-Authenticate: Bearer resource_metadata="<url>"` on MCP 401s via a custom
+  `AuthenticationEntryPoint` on chain 2.
+
+### Slice 4 — Dynamic Client Registration
+- Enable Spring AS's client-registration endpoint (OIDC `/connect/register`), gated per the DCR
+  decision (loopback redirect URIs allowed; optional initial-access-token).
+- Configure default scopes for MCP clients and rotating refresh tokens.
+
+### Slice 5 — End-to-end verification & docs
+- Connect a real client (Cursor / Claude Code / Cowork) with **no** static token: discovery →
+  authorization-code + PKCE → token → tool calls execute as the authenticated Requel user.
+- Update `doc/mcp_remote_connection.md`: make OAuth the primary recipe; mark the static-bearer/PAT
+  recipe dev-only or headless-only.
+
+## Testing strategy (maps to `RELEASE_20_TEST_PLAN.md` conventions)
+- **Metadata:** `/.well-known/oauth-authorization-server` (RFC 8414) and
+  `/.well-known/oauth-protected-resource` (RFC 9728) return correct documents.
+- **Chain routing:** unauthenticated `/api/mcp` → 401 + `WWW-Authenticate: Bearer …resource_metadata=…`;
+  `/api/projects` still uses the login-JWT chain; a PAT still authenticates on `/api/mcp`.
+- **Resource server:** a valid AS-issued token authenticates and runs a tool as the mapped user;
+  per-stakeholder authorization is still enforced (reuse an `AuthorizationIT`-style scenario).
+- **End-to-end:** authorization-code + PKCE against the embedded AS in an integration test.
+- **DCR:** a loopback client self-registers within policy; a disallowed redirect URI is rejected.
+- Backend gate: `mvn clean verify` green before commit. No Angular changes expected in this ticket.
+
+## Out of scope / follow-ups
+- #85 (`ManageApiTokens` per-user permission) and #75 (stakeholder permission coherence) are
+  independent and not required here.
+- Persistent signing-key management hardening beyond the documented keystore option.
+- **SPA auth unification (future ticket).** Move the Angular app off the custom `/api/auth/login`
+  → HS256 JWT path onto authorization-code + PKCE against the embedded AS, so there is one
+  standards-based token system instead of two. Requel remains the identity source; users still log
+  in with Requel credentials. This is a mostly-frontend effort (Angular auth surface: redirect/
+  callback, token storage, silent refresh, logout, guards, interceptor), plus making the `/api/**`
+  chain accept AS-issued tokens, reconciling the SSE JWT-expiry scheduling with OAuth refresh, and
+  reworking the Playwright login/e2e flows. It also reintroduces a **first-party auto-approve**
+  consent path (no consent screen for Requel's own SPA). Deferred from #83 to keep scope contained;
+  #83's resource-server foundation is the stepping stone (applying the same resource-server pattern
+  to `/api/**`).
+- **External IdP support (future ticket).** Let a deploying org delegate authentication to their
+  *existing* OAuth/OIDC provider (Okta, Keycloak, Auth0, corporate SSO) instead of Requel being the
+  identity source — the "Requel plugs into your existing auth server" capability. Distinct from SPA
+  unification (which stays on the embedded AS) and largely independent of it: adds an external issuer
+  + login-federation / user-provisioning step. #83's standard `oauth2-resource-server` foundation
+  makes this an extension rather than a rewrite.

--- a/modules/requel-app/src/main/resources/application.properties
+++ b/modules/requel-app/src/main/resources/application.properties
@@ -139,3 +139,14 @@ spring.ai.mcp.server.sse-message-endpoint=/api/mcp/message
 # Seed a loopback PKCE dev client ("requel-dev-client", scope=mcp, consent required) so the OAuth
 # flow is testable before Dynamic Client Registration (Slice 4) lands. Off by default; dev only.
 requel.oauth.seed-dev-client=false
+#
+# Dynamic Client Registration (Slice 4). The OIDC client-registration endpoint (/connect/register)
+# is always enabled but is UNUSABLE until a registrar client exists: Spring AS requires an initial
+# access token (client_credentials + scope client.create), single-use, ~5 min TTL. Set
+# requel.oauth.dcr.enabled=true and a registrar secret to seed a confidential registrar client the
+# admin uses to mint that token. Dynamically-registered clients are forced to loopback-only redirect
+# URIs, PKCE, consent, scope=mcp, and the 1h/30d rotating token policy. (Anonymous registration is
+# NOT supported by Spring AS; whether real MCP clients need it is verified in Slice 5.)
+requel.oauth.dcr.enabled=false
+requel.oauth.dcr.registrar-client-id=requel-registrar
+# requel.oauth.dcr.registrar-client-secret=   (required when dcr.enabled=true; set via env/secret)

--- a/modules/requel-app/src/main/resources/application.properties
+++ b/modules/requel-app/src/main/resources/application.properties
@@ -100,9 +100,11 @@ management.endpoints.web.exposure.include=health,info,metrics,prometheus
 # The Spring AI MCP server boot starter (spring-ai-starter-mcp-server-webmvc) serves Requel's
 # gateway-backed tools (RequelMcpServerConfig.requelToolCallbackProvider) over Spring MVC.
 #
-# Endpoints are deliberately mounted under /api/mcp/* so the existing /api/** Spring Security
-# JWT chain authenticates them and CurrentUserResolver populates the user the CommandGateway runs
-# as — no separate security matcher needed. If these paths change, update the security config too.
+# Endpoints are mounted under /api/mcp/*. As of issue #83 Slice 2 they have a DEDICATED security
+# chain (McpResourceServerConfig, @Order(3)): an OAuth2 resource server validating AS-issued tokens,
+# with the existing JwtAuthenticationFilter also present so PATs (#73) and the SPA login JWT keep
+# working. CurrentUserResolver still populates the user the CommandGateway runs as, regardless of
+# credential kind. If these paths change, update BOTH McpResourceServerConfig and ApiSecurityConfig.
 #
 # Write tools are gated by requel.gateway.write.enabled. Shipped default is true so a locally-run
 # server exposes the write tools out of the box; set it to false to run the MCP server read-only.

--- a/modules/requel-app/src/main/resources/application.properties
+++ b/modules/requel-app/src/main/resources/application.properties
@@ -122,3 +122,18 @@ spring.ai.mcp.server.sse-endpoint=/api/mcp/sse
 spring.ai.mcp.server.sse-message-endpoint=/api/mcp/message
 # spring.ai.mcp.server.protocol=STREAMABLE
 # spring.ai.mcp.server.streamable-http.mcp-endpoint=/api/mcp
+
+# ---------------------------------------------------------------------------
+# OAuth 2.1 Authorization Server (issue #83) — MCP client authentication
+# ---------------------------------------------------------------------------
+# Embedded authorization server backed by the Requel user store. Slice 1 stands up the AS
+# (authorization-code + PKCE, token/JWK endpoints, RFC 8414 metadata, login + consent). The MCP
+# resource server on /api/mcp/** and DCR arrive in later slices. See doc/oauth_mcp_plan.md.
+#
+# Optional explicit issuer. Leave blank to derive the issuer per-request from the current host
+# (correct for same-host self-hosted deployments). Set behind a reverse proxy / fixed public URL:
+#   requel.oauth.issuer=https://requel.example.com
+#
+# Seed a loopback PKCE dev client ("requel-dev-client", scope=mcp, consent required) so the OAuth
+# flow is testable before Dynamic Client Registration (Slice 4) lands. Off by default; dev only.
+requel.oauth.seed-dev-client=false

--- a/modules/requel-app/src/main/resources/db/migration/V12__oauth2_authorization_server.sql
+++ b/modules/requel-app/src/main/resources/db/migration/V12__oauth2_authorization_server.sql
@@ -1,0 +1,72 @@
+-- OAuth 2.1 Authorization Server persistence (issue #83, Slice 1).
+--
+-- Tables for Spring Authorization Server's JDBC services:
+--   * oauth2_registered_client         -> JdbcRegisteredClientRepository (incl. DCR-created clients)
+--   * oauth2_authorization             -> JdbcOAuth2AuthorizationService (auth codes, access/refresh
+--                                         tokens, OIDC id tokens, device/user codes)
+--   * oauth2_authorization_consent     -> JdbcOAuth2AuthorizationConsentService (per user+client)
+--
+-- Schema follows the canonical Spring Authorization Server DDL (1.5.x), adjusted for MySQL:
+-- BLOB/TEXT columns carry no explicit DEFAULT (MySQL rejects defaults on BLOB/TEXT; NULL is the
+-- implicit default for nullable columns). Valid on H2 in MySQL mode as well.
+
+CREATE TABLE oauth2_registered_client (
+    id VARCHAR(100) NOT NULL,
+    client_id VARCHAR(100) NOT NULL,
+    client_id_issued_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    client_secret VARCHAR(200) DEFAULT NULL,
+    client_secret_expires_at TIMESTAMP DEFAULT NULL,
+    client_name VARCHAR(200) NOT NULL,
+    client_authentication_methods VARCHAR(1000) NOT NULL,
+    authorization_grant_types VARCHAR(1000) NOT NULL,
+    redirect_uris VARCHAR(1000) DEFAULT NULL,
+    post_logout_redirect_uris VARCHAR(1000) DEFAULT NULL,
+    scopes VARCHAR(1000) NOT NULL,
+    client_settings VARCHAR(2000) NOT NULL,
+    token_settings VARCHAR(2000) NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE oauth2_authorization (
+    id VARCHAR(100) NOT NULL,
+    registered_client_id VARCHAR(100) NOT NULL,
+    principal_name VARCHAR(200) NOT NULL,
+    authorization_grant_type VARCHAR(100) NOT NULL,
+    authorized_scopes VARCHAR(1000) DEFAULT NULL,
+    attributes BLOB,
+    state VARCHAR(500) DEFAULT NULL,
+    authorization_code_value BLOB,
+    authorization_code_issued_at TIMESTAMP DEFAULT NULL,
+    authorization_code_expires_at TIMESTAMP DEFAULT NULL,
+    authorization_code_metadata BLOB,
+    access_token_value BLOB,
+    access_token_issued_at TIMESTAMP DEFAULT NULL,
+    access_token_expires_at TIMESTAMP DEFAULT NULL,
+    access_token_metadata BLOB,
+    access_token_type VARCHAR(100) DEFAULT NULL,
+    access_token_scopes VARCHAR(1000) DEFAULT NULL,
+    oidc_id_token_value BLOB,
+    oidc_id_token_issued_at TIMESTAMP DEFAULT NULL,
+    oidc_id_token_expires_at TIMESTAMP DEFAULT NULL,
+    oidc_id_token_metadata BLOB,
+    refresh_token_value BLOB,
+    refresh_token_issued_at TIMESTAMP DEFAULT NULL,
+    refresh_token_expires_at TIMESTAMP DEFAULT NULL,
+    refresh_token_metadata BLOB,
+    user_code_value BLOB,
+    user_code_issued_at TIMESTAMP DEFAULT NULL,
+    user_code_expires_at TIMESTAMP DEFAULT NULL,
+    user_code_metadata BLOB,
+    device_code_value BLOB,
+    device_code_issued_at TIMESTAMP DEFAULT NULL,
+    device_code_expires_at TIMESTAMP DEFAULT NULL,
+    device_code_metadata BLOB,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE oauth2_authorization_consent (
+    registered_client_id VARCHAR(100) NOT NULL,
+    principal_name VARCHAR(200) NOT NULL,
+    authorities VARCHAR(1000) NOT NULL,
+    PRIMARY KEY (registered_client_id, principal_name)
+);

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/service/auth/OAuthLoginRouteIT.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/service/auth/OAuthLoginRouteIT.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.auth;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.forwardedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.rreganjr.AbstractIntegrationTestCase;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Guards the SPA-vs-authorization-server login routing (issue #83).
+ *
+ * <p>The Angular SPA owns the client-side route {@code /login} (its {@code LoginComponent}); the
+ * authorization server's login page lives at {@code /oauth2/login}. An earlier version of the OAuth
+ * work put the AS form login on {@code /login}, which shadowed the SPA page with Spring Security's
+ * generated login form and broke the auth Playwright e2e tests. That collision was invisible to
+ * {@code mvn verify} (it only runs the backend, not the browser suite). These MockMvc checks run in
+ * the normal build, so the regression can't come back silently:
+ *
+ * <ul>
+ *   <li>{@code GET /login} must NOT be intercepted by a security chain — it forwards to the SPA's
+ *       {@code index.html} via {@code SpaController} (asserted on the forwarded URL, so it holds even
+ *       when the Angular build isn't present in the test classpath).</li>
+ *   <li>{@code GET /oauth2/login} serves the authorization server's own login page.</li>
+ * </ul>
+ */
+@AutoConfigureMockMvc
+public class OAuthLoginRouteIT extends AbstractIntegrationTestCase {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void loginRouteFallsThroughToTheAngularSpa() throws Exception {
+        // No security chain matches /login, so SpaController forwards it to the SPA shell.
+        // (Asserting the forwarded URL rather than a 200 keeps this independent of whether the
+        // Angular build produced index.html in the test classpath.)
+        mockMvc.perform(get("/login"))
+                .andExpect(forwardedUrl("/index.html"));
+    }
+
+    @Test
+    void authorizationServerLoginPageIsServedAtOauth2Login() throws Exception {
+        mockMvc.perform(get("/oauth2/login"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("Sign in to Requel")));
+    }
+}

--- a/modules/requel-app/src/test/resources/db/oauth2-schema-h2.sql
+++ b/modules/requel-app/src/test/resources/db/oauth2-schema-h2.sql
@@ -1,0 +1,75 @@
+-- OAuth 2.1 Authorization Server schema for H2 tests (issue #83).
+--
+-- Tests run on H2 (MySQL mode) with Flyway DISABLED and Hibernate ddl-auto=create-drop
+-- (see application-test.properties). The oauth2_* tables are managed by Spring Authorization
+-- Server via JdbcTemplate, NOT by JPA, so Hibernate does not create them and Flyway does not run.
+-- Slice 5's AS integration tests must therefore create these tables explicitly, e.g.:
+--
+--   @Sql(scripts = "/db/oauth2-schema-h2.sql", executionPhase = BEFORE_TEST_CLASS)
+--
+-- or by pointing a test slice at spring.sql.init.schema-locations. This script is intentionally
+-- NOT wired into the global test properties so it cannot affect the existing suite.
+--
+-- DDL mirrors V12__oauth2_authorization_server.sql (canonical Spring AS 1.5.x schema); it is
+-- valid on H2 in MySQL mode.
+
+CREATE TABLE IF NOT EXISTS oauth2_registered_client (
+    id VARCHAR(100) NOT NULL,
+    client_id VARCHAR(100) NOT NULL,
+    client_id_issued_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    client_secret VARCHAR(200) DEFAULT NULL,
+    client_secret_expires_at TIMESTAMP DEFAULT NULL,
+    client_name VARCHAR(200) NOT NULL,
+    client_authentication_methods VARCHAR(1000) NOT NULL,
+    authorization_grant_types VARCHAR(1000) NOT NULL,
+    redirect_uris VARCHAR(1000) DEFAULT NULL,
+    post_logout_redirect_uris VARCHAR(1000) DEFAULT NULL,
+    scopes VARCHAR(1000) NOT NULL,
+    client_settings VARCHAR(2000) NOT NULL,
+    token_settings VARCHAR(2000) NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS oauth2_authorization (
+    id VARCHAR(100) NOT NULL,
+    registered_client_id VARCHAR(100) NOT NULL,
+    principal_name VARCHAR(200) NOT NULL,
+    authorization_grant_type VARCHAR(100) NOT NULL,
+    authorized_scopes VARCHAR(1000) DEFAULT NULL,
+    attributes BLOB,
+    state VARCHAR(500) DEFAULT NULL,
+    authorization_code_value BLOB,
+    authorization_code_issued_at TIMESTAMP DEFAULT NULL,
+    authorization_code_expires_at TIMESTAMP DEFAULT NULL,
+    authorization_code_metadata BLOB,
+    access_token_value BLOB,
+    access_token_issued_at TIMESTAMP DEFAULT NULL,
+    access_token_expires_at TIMESTAMP DEFAULT NULL,
+    access_token_metadata BLOB,
+    access_token_type VARCHAR(100) DEFAULT NULL,
+    access_token_scopes VARCHAR(1000) DEFAULT NULL,
+    oidc_id_token_value BLOB,
+    oidc_id_token_issued_at TIMESTAMP DEFAULT NULL,
+    oidc_id_token_expires_at TIMESTAMP DEFAULT NULL,
+    oidc_id_token_metadata BLOB,
+    refresh_token_value BLOB,
+    refresh_token_issued_at TIMESTAMP DEFAULT NULL,
+    refresh_token_expires_at TIMESTAMP DEFAULT NULL,
+    refresh_token_metadata BLOB,
+    user_code_value BLOB,
+    user_code_issued_at TIMESTAMP DEFAULT NULL,
+    user_code_expires_at TIMESTAMP DEFAULT NULL,
+    user_code_metadata BLOB,
+    device_code_value BLOB,
+    device_code_issued_at TIMESTAMP DEFAULT NULL,
+    device_code_expires_at TIMESTAMP DEFAULT NULL,
+    device_code_metadata BLOB,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS oauth2_authorization_consent (
+    registered_client_id VARCHAR(100) NOT NULL,
+    principal_name VARCHAR(200) NOT NULL,
+    authorities VARCHAR(1000) NOT NULL,
+    PRIMARY KEY (registered_client_id, principal_name)
+);

--- a/modules/service-impl/pom.xml
+++ b/modules/service-impl/pom.xml
@@ -86,6 +86,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-authorization-server</artifactId>
         </dependency>
+        <!-- OAuth 2.1 resource server for /api/mcp/** (issue #83, Slice 2): validates the AS-issued
+             JWTs so MCP agent clients authenticate via OAuth. PAT (#73) and login-JWT still work on
+             MCP via the existing JwtAuthenticationFilter (see McpResourceServerConfig). -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
         <!-- JWT -->
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/modules/service-impl/pom.xml
+++ b/modules/service-impl/pom.xml
@@ -78,6 +78,14 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+        <!-- OAuth 2.1 authorization server for MCP client auth (issue #83). Provides the embedded
+             AS (authorization-code + PKCE, token/JWK endpoints, RFC 8414 metadata, DCR) backed by
+             the Requel user store. The MCP resource server (Slice 2) uses spring-security's
+             oauth2-resource-server, pulled in transitively; add the starter explicitly there. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-authorization-server</artifactId>
+        </dependency>
         <!-- JWT -->
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/McpAuthenticationEntryPoint.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/McpAuthenticationEntryPoint.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationEntryPoint;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.io.IOException;
+
+/**
+ * 401 entry point for the MCP resource server that adds the RFC 9728 {@code resource_metadata}
+ * parameter to the {@code WWW-Authenticate} header (issue #83, Slice 3).
+ *
+ * <p>MCP agent clients follow the MCP authorization spec: on a 401 they read {@code resource_metadata}
+ * from {@code WWW-Authenticate}, fetch that document
+ * ({@link ProtectedResourceMetadataController#WELL_KNOWN_PATH}), discover the authorization server,
+ * and run the OAuth flow. This entry point delegates to the standard
+ * {@link BearerTokenAuthenticationEntryPoint} (so status and any {@code error}/{@code error_description}
+ * details are formatted exactly as Spring's resource server would) and then appends the
+ * {@code resource_metadata} parameter pointing at this server's metadata document.
+ */
+public class McpAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final BearerTokenAuthenticationEntryPoint delegate = new BearerTokenAuthenticationEntryPoint();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+            AuthenticationException authException) throws IOException {
+        // Let the standard bearer entry point set the status and the base WWW-Authenticate header.
+        delegate.commence(request, response, authException);
+
+        String base = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString();
+        String metadataUrl = base + ProtectedResourceMetadataController.WELL_KNOWN_PATH;
+        String param = "resource_metadata=\"" + metadataUrl + "\"";
+
+        String existing = response.getHeader(HttpHeaders.WWW_AUTHENTICATE);
+        String updated;
+        if (existing == null || existing.isBlank()) {
+            updated = "Bearer " + param;
+        } else if (existing.equals("Bearer")) {
+            // No params yet (missing-token case) — RFC 7235 auth-param is space-separated here.
+            updated = "Bearer " + param;
+        } else {
+            // Existing params (e.g. error="invalid_token", ...) — append comma-separated.
+            updated = existing + ", " + param;
+        }
+        response.setHeader(HttpHeaders.WWW_AUTHENTICATE, updated);
+    }
+}

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/McpBearerTokenResolver.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/McpBearerTokenResolver.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
+import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/**
+ * Routes a {@code Bearer} credential to the MCP OAuth2 resource server <em>only</em> when it is an
+ * authorization-server-issued JWT (issue #83, Slice 2). This lets three credential kinds coexist on
+ * {@code /api/mcp/**} without conflicting:
+ *
+ * <ul>
+ *   <li><b>OAuth access token</b> — an AS-issued JWS signed with an asymmetric key (RS/PS/ES). This
+ *       resolver returns it, so the resource server's bearer filter validates it.</li>
+ *   <li><b>Personal access token (#73)</b> — opaque, prefixed {@code reqpat_}. Returned as
+ *       {@code null} here so the resource server ignores it; {@link JwtAuthenticationFilter}
+ *       (placed before the bearer filter) handles the PAT.</li>
+ *   <li><b>SPA login JWT</b> — a symmetric {@code HS*} JWS. Returned as {@code null} here so the
+ *       resource server ignores it; {@link JwtAuthenticationFilter} validates it as before.</li>
+ * </ul>
+ *
+ * <p>The alg family is read from the (unverified) JWS header purely to <em>route</em> the token to
+ * the correct authenticator; the actual signature/validity check is done downstream by the chosen
+ * authenticator, so a forged header only changes which validator rejects the token.
+ */
+public class McpBearerTokenResolver implements BearerTokenResolver {
+
+    private final DefaultBearerTokenResolver delegate = new DefaultBearerTokenResolver();
+
+    @Override
+    public String resolve(HttpServletRequest request) {
+        String token = delegate.resolve(request);
+        if (token == null) {
+            return null;
+        }
+        if (ApiTokenService.isApiToken(token)) {
+            return null; // PAT — handled by JwtAuthenticationFilter.
+        }
+        // Only AS-issued (asymmetric-signed) JWTs go to the resource server; HS* login JWTs do not.
+        return isAsymmetricJws(token) ? token : null;
+    }
+
+    private static boolean isAsymmetricJws(String token) {
+        int dot = token.indexOf('.');
+        if (dot <= 0) {
+            return false;
+        }
+        try {
+            byte[] headerBytes = Base64.getUrlDecoder().decode(token.substring(0, dot));
+            String header = new String(headerBytes, StandardCharsets.UTF_8);
+            // AS access tokens use RS256 by default; accept the asymmetric JWS families (RS/PS/ES).
+            return header.matches("(?s).*\"alg\"\\s*:\\s*\"(RS|PS|ES)\\d+\".*");
+        } catch (RuntimeException e) {
+            return false;
+        }
+    }
+}

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/McpJwtAuthenticationConverter.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/McpJwtAuthenticationConverter.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.auth;
+
+import com.rreganjr.requel.user.User;
+import com.rreganjr.requel.user.UserRepository;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+
+/**
+ * Turns an authorization-server-issued access token into an authentication for the MCP resource
+ * server (issue #83, Slice 2), mapping the token subject to a Requel user and loading that user's
+ * authorities <em>live</em> from the user store rather than trusting role claims in the token.
+ *
+ * <p>The token {@code sub} is the Requel username (set at issuance), so the resulting
+ * {@link JwtAuthenticationToken}'s name matches what {@link CurrentUserResolver} expects — the
+ * gateway then runs per-stakeholder authorization as that user, exactly as the JWT and PAT paths do.
+ * Authorities combine the user's roles ({@code ROLE_<role>}, via {@link UserDtoMapper}) with the
+ * token's scopes ({@code SCOPE_<scope>}), so both role- and scope-based checks are available.
+ *
+ * <p>If the subject does not resolve to a user, the token is rejected
+ * ({@link InvalidBearerTokenException}) rather than authenticating an unknown principal.
+ */
+public class McpJwtAuthenticationConverter implements Converter<Jwt, AbstractAuthenticationToken> {
+
+    private final UserRepository userRepository;
+    private final UserDtoMapper userDtoMapper;
+    private final JwtGrantedAuthoritiesConverter scopeAuthoritiesConverter =
+            new JwtGrantedAuthoritiesConverter();
+
+    public McpJwtAuthenticationConverter(UserRepository userRepository, UserDtoMapper userDtoMapper) {
+        this.userRepository = userRepository;
+        this.userDtoMapper = userDtoMapper;
+    }
+
+    @Override
+    public AbstractAuthenticationToken convert(Jwt jwt) {
+        String username = jwt.getSubject();
+        User user;
+        try {
+            user = (username != null) ? userRepository.findUserByUsername(username) : null;
+        } catch (RuntimeException e) {
+            throw new InvalidBearerTokenException("Token subject does not map to a Requel user");
+        }
+        if (user == null) {
+            throw new InvalidBearerTokenException("Token subject does not map to a Requel user");
+        }
+
+        Collection<GrantedAuthority> authorities = new LinkedHashSet<>();
+        for (String role : userDtoMapper.getRoleStrings(user)) {
+            authorities.add(new SimpleGrantedAuthority("ROLE_" + role));
+        }
+        Collection<GrantedAuthority> scopeAuthorities = scopeAuthoritiesConverter.convert(jwt);
+        if (scopeAuthorities != null) {
+            authorities.addAll(scopeAuthorities);
+        }
+
+        return new JwtAuthenticationToken(jwt, authorities, user.getUsername());
+    }
+}

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/OAuth2ConsentController.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/OAuth2ConsentController.java
@@ -1,0 +1,170 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.core.oidc.OidcScopes;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsent;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsentService;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.stereotype.Controller;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.security.Principal;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Renders the OAuth 2.1 consent screen (issue #83, Slice 1). Consent is required for all MCP
+ * clients (no auto-approve), so after login the authorization endpoint redirects here; the user
+ * sees which client is connecting and which scopes it wants, and approves or denies.
+ *
+ * <p>The page is emitted as a small self-contained HTML document (no template engine dependency).
+ * Its form posts back to the authorization endpoint ({@code /oauth2/authorize}) with the standard
+ * parameters ({@code client_id}, {@code state}, and one {@code scope} value per approved scope) plus
+ * the CSRF token. Approving with no scopes selected results in an access-denied response from the
+ * authorization server — that is the "Deny" path.
+ */
+@Controller
+public class OAuth2ConsentController {
+
+    /** Path of the consent page; referenced by the authorization-server chain configuration. */
+    public static final String CONSENT_PAGE_URI = "/oauth2/consent";
+
+    /** Human-readable descriptions for the scopes Requel issues. */
+    private static final Map<String, String> SCOPE_DESCRIPTIONS = Map.of(
+            "mcp", "Act as you through Requel's MCP tools — read and modify the project data you "
+                    + "already have access to. Requel still enforces your per-project permissions.");
+
+    private final RegisteredClientRepository registeredClientRepository;
+    private final OAuth2AuthorizationConsentService authorizationConsentService;
+
+    public OAuth2ConsentController(RegisteredClientRepository registeredClientRepository,
+            OAuth2AuthorizationConsentService authorizationConsentService) {
+        this.registeredClientRepository = registeredClientRepository;
+        this.authorizationConsentService = authorizationConsentService;
+    }
+
+    @GetMapping(CONSENT_PAGE_URI)
+    @ResponseBody
+    public String consent(Principal principal,
+            @RequestParam(OAuth2ParameterNames.CLIENT_ID) String clientId,
+            @RequestParam(OAuth2ParameterNames.SCOPE) String scope,
+            @RequestParam(OAuth2ParameterNames.STATE) String state,
+            HttpServletRequest request) {
+
+        Set<String> scopesToApprove = new LinkedHashSet<>();
+        Set<String> previouslyApprovedScopes = new LinkedHashSet<>();
+        RegisteredClient registeredClient = registeredClientRepository.findByClientId(clientId);
+        OAuth2AuthorizationConsent currentConsent = (registeredClient != null)
+                ? authorizationConsentService.findById(registeredClient.getId(), principal.getName())
+                : null;
+        Set<String> authorizedScopes = (currentConsent != null)
+                ? currentConsent.getScopes() : Collections.emptySet();
+        for (String requestedScope : StringUtils.delimitedListToStringArray(scope, " ")) {
+            if (OidcScopes.OPENID.equals(requestedScope)) {
+                continue;
+            }
+            if (authorizedScopes.contains(requestedScope)) {
+                previouslyApprovedScopes.add(requestedScope);
+            } else {
+                scopesToApprove.add(requestedScope);
+            }
+        }
+
+        String clientName = (registeredClient != null) ? registeredClient.getClientName() : clientId;
+        CsrfToken csrfToken = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
+        return renderPage(clientName, clientId, state, scopesToApprove, previouslyApprovedScopes,
+                csrfToken);
+    }
+
+    private String renderPage(String clientName, String clientId, String state,
+            Set<String> scopesToApprove, Set<String> previouslyApproved, CsrfToken csrfToken) {
+        StringBuilder scopeItems = new StringBuilder();
+        for (String s : scopesToApprove) {
+            scopeItems.append("<label class=\"scope\">")
+                    .append("<input type=\"checkbox\" name=\"scope\" value=\"").append(attr(s))
+                    .append("\" checked> <strong>").append(esc(s)).append("</strong>")
+                    .append("<div class=\"desc\">")
+                    .append(esc(SCOPE_DESCRIPTIONS.getOrDefault(s, s)))
+                    .append("</div></label>");
+        }
+        StringBuilder priorItems = new StringBuilder();
+        for (String s : previouslyApproved) {
+            priorItems.append("<li>").append(esc(s)).append("</li>");
+        }
+        String priorBlock = previouslyApproved.isEmpty() ? ""
+                : "<p class=\"prior\">Already approved: <ul>" + priorItems + "</ul></p>";
+        String csrfField = (csrfToken == null) ? ""
+                : "<input type=\"hidden\" name=\"" + attr(csrfToken.getParameterName())
+                        + "\" value=\"" + attr(csrfToken.getToken()) + "\">";
+
+        return "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\">"
+                + "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"
+                + "<title>Requel — Authorize</title><style>"
+                + "body{font-family:system-ui,Arial,sans-serif;max-width:34rem;margin:3rem auto;"
+                + "padding:0 1rem;color:#1a1a1a}h1{font-size:1.25rem}"
+                + ".client{font-weight:600}.scope{display:block;border:1px solid #ddd;border-radius:6px;"
+                + "padding:.75rem;margin:.5rem 0}.desc{color:#555;font-size:.9rem;margin-top:.25rem}"
+                + ".actions{margin-top:1.25rem;display:flex;gap:.75rem}"
+                + "button{padding:.5rem 1rem;border-radius:6px;border:1px solid #ccc;cursor:pointer}"
+                + "button.allow{background:#2563eb;color:#fff;border-color:#2563eb}"
+                + ".prior{color:#555;font-size:.9rem}</style></head><body>"
+                + "<h1>Authorize access</h1>"
+                + "<p><span class=\"client\">" + esc(clientName) + "</span> is requesting access to "
+                + "your Requel account. Review what it can do:</p>"
+                + "<form method=\"post\" action=\"/oauth2/authorize\">"
+                + csrfField
+                + "<input type=\"hidden\" name=\"client_id\" value=\"" + attr(clientId) + "\">"
+                + "<input type=\"hidden\" name=\"state\" value=\"" + attr(state) + "\">"
+                + scopeItems
+                + priorBlock
+                + "<div class=\"actions\">"
+                + "<button type=\"submit\" class=\"allow\">Allow</button>"
+                + "<button type=\"submit\" formnovalidate onclick=\"this.form.querySelectorAll("
+                + "'input[name=scope]').forEach(c=>c.checked=false)\">Deny</button>"
+                + "</div></form></body></html>";
+    }
+
+    /** Escape for HTML text content. */
+    private static String esc(String v) {
+        if (v == null) {
+            return "";
+        }
+        return v.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+    }
+
+    /** Escape for a double-quoted HTML attribute value. */
+    private static String attr(String v) {
+        if (v == null) {
+            return "";
+        }
+        return esc(v).replace("\"", "&quot;");
+    }
+}

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/OAuth2LoginPageController.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/OAuth2LoginPageController.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+/**
+ * Login page for the OAuth 2.1 authorization server (issue #83).
+ *
+ * <p><b>Why its own path.</b> The Angular SPA owns the client-side route {@code /login} (its
+ * {@code LoginComponent}); if the authorization server's form login also lived at {@code /login} it
+ * would shadow the SPA's page with Spring Security's generated form. So the AS login page is served
+ * at {@link #LOGIN_PAGE_URI} instead, and the AS filter chain uses it as both the login page and the
+ * form-login processing URL. Credentials are checked by {@link RequelUserAuthenticationProvider}
+ * against the Requel user store.
+ *
+ * <p>Rendered as a small self-contained HTML page (no template-engine dependency), matching
+ * {@link OAuth2ConsentController}.
+ */
+@Controller
+public class OAuth2LoginPageController {
+
+    /** Path of the authorization-server login page (NOT the SPA's {@code /login}). */
+    public static final String LOGIN_PAGE_URI = "/oauth2/login";
+
+    @GetMapping(LOGIN_PAGE_URI)
+    @ResponseBody
+    public String loginPage(@RequestParam(required = false) String error,
+            @RequestParam(required = false) String logout, HttpServletRequest request) {
+        CsrfToken csrfToken = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
+        String csrfField = (csrfToken == null) ? ""
+                : "<input type=\"hidden\" name=\"" + attr(csrfToken.getParameterName())
+                        + "\" value=\"" + attr(csrfToken.getToken()) + "\">";
+        String banner = "";
+        if (error != null) {
+            banner = "<p class=\"msg err\">Invalid username or password.</p>";
+        } else if (logout != null) {
+            banner = "<p class=\"msg\">You have been signed out.</p>";
+        }
+
+        return "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\">"
+                + "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"
+                + "<title>Requel — Sign in</title><style>"
+                + "body{font-family:system-ui,Arial,sans-serif;max-width:22rem;margin:4rem auto;"
+                + "padding:0 1rem;color:#1a1a1a}h1{font-size:1.25rem}"
+                + "label{display:block;margin:.75rem 0 .25rem;font-size:.9rem}"
+                + "input[type=text],input[type=password]{width:100%;padding:.5rem;border:1px solid #ccc;"
+                + "border-radius:6px;box-sizing:border-box}"
+                + "button{margin-top:1.25rem;padding:.5rem 1rem;border-radius:6px;border:1px solid #2563eb;"
+                + "background:#2563eb;color:#fff;cursor:pointer}"
+                + ".msg{font-size:.9rem}.err{color:#b91c1c}</style></head><body>"
+                + "<h1>Sign in to Requel</h1>"
+                + "<p class=\"msg\">An application is requesting access to your Requel account.</p>"
+                + banner
+                + "<form method=\"post\" action=\"" + LOGIN_PAGE_URI + "\">"
+                + csrfField
+                + "<label for=\"username\">Username</label>"
+                + "<input type=\"text\" id=\"username\" name=\"username\" autofocus>"
+                + "<label for=\"password\">Password</label>"
+                + "<input type=\"password\" id=\"password\" name=\"password\">"
+                + "<button type=\"submit\">Sign in</button>"
+                + "</form></body></html>";
+    }
+
+    private static String attr(String v) {
+        if (v == null) {
+            return "";
+        }
+        return v.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;");
+    }
+}

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/ProtectedResourceMetadataController.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/ProtectedResourceMetadataController.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.auth;
+
+import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * RFC 9728 Protected Resource Metadata for the MCP resource (issue #83, Slice 3).
+ *
+ * <p>Serves {@code /.well-known/oauth-protected-resource} so an MCP agent client, on a 401 from
+ * {@code /api/mcp/**}, can discover which authorization server protects the resource and then run
+ * the OAuth discovery + authorization-code/PKCE flow — no pre-shared token or manual config.
+ * {@link McpAuthenticationEntryPoint} points the {@code WWW-Authenticate: Bearer resource_metadata}
+ * parameter at this document.
+ *
+ * <p>The endpoint is intentionally public: it is matched by no security chain (not {@code /api/**},
+ * not an AS endpoint, not {@code /login}), so it is served without authentication. Both the bare
+ * well-known path and the RFC 9728 resource-path-suffixed variant are mapped to the same document,
+ * for clients that use either form.
+ */
+@RestController
+public class ProtectedResourceMetadataController {
+
+    /** Well-known path for the MCP protected-resource metadata document. */
+    public static final String WELL_KNOWN_PATH = "/.well-known/oauth-protected-resource";
+
+    /** Path (relative to the app base) of the MCP resource this metadata describes. */
+    private static final String MCP_RESOURCE_PATH = "/api/mcp";
+
+    private final AuthorizationServerSettings authorizationServerSettings;
+
+    public ProtectedResourceMetadataController(AuthorizationServerSettings authorizationServerSettings) {
+        this.authorizationServerSettings = authorizationServerSettings;
+    }
+
+    @GetMapping({WELL_KNOWN_PATH, WELL_KNOWN_PATH + MCP_RESOURCE_PATH})
+    public Map<String, Object> metadata() {
+        String base = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString();
+        String issuer = (authorizationServerSettings.getIssuer() != null)
+                ? authorizationServerSettings.getIssuer()
+                : base;
+
+        Map<String, Object> document = new LinkedHashMap<>();
+        document.put("resource", base + MCP_RESOURCE_PATH);
+        document.put("authorization_servers", List.of(issuer));
+        document.put("scopes_supported", List.of("mcp"));
+        document.put("bearer_methods_supported", List.of("header"));
+        return document;
+    }
+}

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/RequelUserAuthenticationProvider.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/RequelUserAuthenticationProvider.java
@@ -1,0 +1,91 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.auth;
+
+import com.rreganjr.requel.user.User;
+import com.rreganjr.requel.user.UserRepository;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Authenticates the OAuth 2.1 authorization server's interactive login form against the Requel user
+ * store (issue #83, Slice 1). The embedded authorization server issues tokens for a Requel user, so
+ * the human who logs in during the authorization-code flow must present real Requel credentials.
+ *
+ * <p>This is the OAuth login-page counterpart to {@link AuthController#login}: it reuses the same
+ * domain credential check ({@link User#isPassword(String)}) and the same role mapping
+ * ({@link UserDtoMapper#getRoleStrings(User)} → {@code ROLE_<role>}) as the SPA's JWT login and the
+ * PAT path, so all three authentication surfaces resolve identical principals and authorities.
+ *
+ * <p>Registered as a single {@link AuthenticationProvider} bean; Spring Security's
+ * auto-configuration wires it into the global {@code AuthenticationManager} used by the form-login
+ * filter chain. It does not affect the stateless JWT chain on {@code /api/**}, which never invokes
+ * {@code authenticate()}.
+ */
+@Component
+public class RequelUserAuthenticationProvider implements AuthenticationProvider {
+
+    private final UserRepository userRepository;
+    private final UserDtoMapper userDtoMapper;
+
+    public RequelUserAuthenticationProvider(UserRepository userRepository, UserDtoMapper userDtoMapper) {
+        this.userRepository = userRepository;
+        this.userDtoMapper = userDtoMapper;
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        String username = authentication.getName();
+        String password = authentication.getCredentials() == null
+                ? null : authentication.getCredentials().toString();
+
+        User user;
+        try {
+            user = userRepository.findUserByUsername(username);
+        } catch (RuntimeException e) {
+            // NoSuchUserException (or any lookup failure) — do not disclose which; treat as bad creds.
+            throw new BadCredentialsException("Invalid username or password");
+        }
+        if (user == null || password == null || !user.isPassword(password)) {
+            throw new BadCredentialsException("Invalid username or password");
+        }
+
+        List<SimpleGrantedAuthority> authorities = userDtoMapper.getRoleStrings(user).stream()
+                .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
+                .toList();
+
+        // Credentials are erased; principal name is the Requel username so CurrentUserResolver and
+        // the token 'sub' resolve back to this user.
+        return new UsernamePasswordAuthenticationToken(user.getUsername(), null, authorities);
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/config/ApiSecurityConfig.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/config/ApiSecurityConfig.java
@@ -72,8 +72,13 @@ public class ApiSecurityConfig {
         this.userDtoMapper = userDtoMapper;
     }
 
+    // @Order(4): after the OAuth chains (see AuthorizationServerConfig). This chain's matcher is
+    // /api/**, which is broader than the MCP resource-server chain's /api/mcp/** (Slice 2), so it
+    // must have a HIGHER order number (lower precedence) than that chain. Chain layering:
+    //   1 = AS endpoints, 2 = interactive login/consent, 3 = /api/mcp/** resource server (Slice 2),
+    //   4 = this /api/** JWT chain.
     @Bean
-    @Order(1)
+    @Order(4)
     public SecurityFilterChain apiSecurityFilterChain(HttpSecurity http) throws Exception {
         http
             .securityMatcher("/api/**")

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/config/AuthorizationServerConfig.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/config/AuthorizationServerConfig.java
@@ -39,8 +39,14 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.server.authorization.oidc.OidcClientRegistration;
+import org.springframework.security.oauth2.server.authorization.oidc.authentication.OidcClientRegistrationAuthenticationProvider;
 import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationConsentService;
 import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationService;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsentService;
@@ -62,8 +68,12 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
+import java.net.URI;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
+import java.util.function.Consumer;
 
 /**
  * Embedded OAuth 2.1 Authorization Server for MCP client authentication (issue #83, Slice 1).
@@ -107,6 +117,21 @@ public class AuthorizationServerConfig {
     @Value("${requel.oauth.seed-dev-client:false}")
     private boolean seedDevClient;
 
+    /**
+     * Seed the DCR registrar client (issue #83, Slice 4). The client-registration endpoint is always
+     * enabled but is unusable until a registrar exists, since Spring AS requires an initial access
+     * token minted by a client holding the {@code client.create} scope. Off by default.
+     */
+    @Value("${requel.oauth.dcr.enabled:false}")
+    private boolean dcrEnabled;
+
+    @Value("${requel.oauth.dcr.registrar-client-id:requel-registrar}")
+    private String registrarClientId;
+
+    /** Registrar client secret (raw); required when {@code requel.oauth.dcr.enabled=true}. */
+    @Value("${requel.oauth.dcr.registrar-client-secret:}")
+    private String registrarClientSecret;
+
     // ---- Chain 1: authorization-server endpoints -------------------------------------------------
 
     @Bean
@@ -118,8 +143,12 @@ public class AuthorizationServerConfig {
         http
             .securityMatcher(authorizationServerConfigurer.getEndpointsMatcher())
             .with(authorizationServerConfigurer, (authorizationServer) -> authorizationServer
-                // OpenID Connect (userinfo, client-registration for DCR in Slice 4).
-                .oidc(Customizer.withDefaults())
+                // OpenID Connect: userinfo + Dynamic Client Registration (Slice 4). The registration
+                // endpoint requires an initial access token (client_credentials + client.create),
+                // minted by the seeded registrar client; see the DCR notes in doc/oauth_mcp_plan.md.
+                .oidc(oidc -> oidc
+                    .clientRegistrationEndpoint(clientRegistration ->
+                        clientRegistration.authenticationProviders(applyDcrClientDefaults())))
                 // Custom consent page (issue #83: consent required for all MCP clients).
                 .authorizationEndpoint(authorizationEndpoint ->
                         authorizationEndpoint.consentPage(OAuth2ConsentController.CONSENT_PAGE_URI))
@@ -281,6 +310,112 @@ public class AuthorizationServerConfig {
             registeredClientRepository.save(devClient);
             log.info("Seeded OAuth dev client '{}' (loopback PKCE, scope=mcp, consent required).",
                     clientId);
+        };
+    }
+
+    // ---- Dynamic Client Registration policy (Slice 4) -------------------------------------------
+
+    /**
+     * Stamps Requel's policy onto every dynamically-registered client (issue #83, Slice 4): rejects
+     * non-loopback redirect URIs, forces PKCE + consent, restricts scope to {@code mcp}, and applies
+     * the shared 1h/30d rotating token settings. Wraps Spring AS's default
+     * {@code OidcClientRegistration -> RegisteredClient} conversion.
+     */
+    private Consumer<List<AuthenticationProvider>> applyDcrClientDefaults() {
+        return authenticationProviders -> {
+            for (AuthenticationProvider provider : authenticationProviders) {
+                if (provider instanceof OidcClientRegistrationAuthenticationProvider registrationProvider) {
+                    registrationProvider.setRegisteredClientConverter(new DcrRegisteredClientConverter());
+                }
+            }
+        };
+    }
+
+    private static final class DcrRegisteredClientConverter
+            implements Converter<OidcClientRegistration, RegisteredClient> {
+
+        @Override
+        public RegisteredClient convert(OidcClientRegistration clientRegistration) {
+            // Spring AS's built-in OidcClientRegistration -> RegisteredClient converter is not public
+            // API, so build the client directly and impose Requel's policy: public (PKCE) loopback
+            // native-app client, consent required, scope=mcp, 1h/30d rotating tokens.
+            List<String> redirectUris = clientRegistration.getRedirectUris();
+            if (redirectUris == null || redirectUris.isEmpty()) {
+                throw new OAuth2AuthenticationException(new OAuth2Error(
+                        "invalid_redirect_uri",
+                        "At least one loopback redirect URI is required", null));
+            }
+            for (String redirectUri : redirectUris) {
+                if (!isLoopbackRedirectUri(redirectUri)) {
+                    throw new OAuth2AuthenticationException(new OAuth2Error(
+                            "invalid_redirect_uri",
+                            "Only loopback redirect URIs (127.0.0.1, [::1], localhost) are allowed",
+                            null));
+                }
+            }
+            String clientName = clientRegistration.getClientName();
+            RegisteredClient.Builder builder = RegisteredClient.withId(UUID.randomUUID().toString())
+                    .clientId(UUID.randomUUID().toString())
+                    .clientIdIssuedAt(Instant.now())
+                    .clientName(clientName != null ? clientName : "mcp-client")
+                    // Public, PKCE-only (loopback native app) — no client secret issued.
+                    .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+                    .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                    .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
+                    .scope("mcp")
+                    .clientSettings(ClientSettings.builder()
+                            .requireProofKey(true)
+                            .requireAuthorizationConsent(true)
+                            .build())
+                    .tokenSettings(defaultTokenSettings());
+            redirectUris.forEach(builder::redirectUri);
+            return builder.build();
+        }
+    }
+
+    /** Loopback per OAuth 2.1 native-app guidance: 127.0.0.1, [::1]/::1, or localhost. */
+    private static boolean isLoopbackRedirectUri(String redirectUri) {
+        try {
+            String host = URI.create(redirectUri).getHost();
+            return host != null && (host.equals("127.0.0.1") || host.equals("[::1]")
+                    || host.equals("::1") || host.equalsIgnoreCase("localhost"));
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Seeds the DCR registrar client (client_credentials + client.create/client.read) when
+     * {@code requel.oauth.dcr.enabled=true} and a secret is configured. An admin uses it to mint the
+     * single-use initial access token required to register new clients. Idempotent.
+     */
+    @Bean
+    public ApplicationRunner seedDcrRegistrarClient(RegisteredClientRepository registeredClientRepository,
+            PasswordEncoder passwordEncoder) {
+        return args -> {
+            if (!dcrEnabled) {
+                return;
+            }
+            if (registrarClientSecret == null || registrarClientSecret.isBlank()) {
+                log.warn("requel.oauth.dcr.enabled=true but requel.oauth.dcr.registrar-client-secret "
+                        + "is not set; DCR registrar client NOT seeded, so client registration is "
+                        + "unusable until a registrar exists.");
+                return;
+            }
+            if (registeredClientRepository.findByClientId(registrarClientId) != null) {
+                return;
+            }
+            RegisteredClient registrar = RegisteredClient.withId(UUID.randomUUID().toString())
+                    .clientId(registrarClientId)
+                    .clientSecret(passwordEncoder.encode(registrarClientSecret))
+                    .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+                    .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+                    .scope("client.create")
+                    .scope("client.read")
+                    .build();
+            registeredClientRepository.save(registrar);
+            log.info("Seeded DCR registrar client '{}' (client_credentials; scopes client.create, "
+                    + "client.read).", registrarClientId);
         };
     }
 }

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/config/AuthorizationServerConfig.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/config/AuthorizationServerConfig.java
@@ -21,6 +21,7 @@
 package com.rreganjr.requel.service.config;
 
 import com.rreganjr.requel.service.auth.OAuth2ConsentController;
+import com.rreganjr.requel.service.auth.OAuth2LoginPageController;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
@@ -174,10 +175,11 @@ public class AuthorizationServerConfig {
                         authorizationEndpoint.consentPage(OAuth2ConsentController.CONSENT_PAGE_URI))
             )
             .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
-            // Unauthenticated browser requests to AS endpoints redirect to the login page.
+            // Unauthenticated browser requests to AS endpoints redirect to the AS login page.
+            // NOTE: /oauth2/login, NOT /login — /login belongs to the Angular SPA's own route.
             .exceptionHandling(exceptions -> exceptions
                 .defaultAuthenticationEntryPointFor(
-                    new LoginUrlAuthenticationEntryPoint("/login"),
+                    new LoginUrlAuthenticationEntryPoint(OAuth2LoginPageController.LOGIN_PAGE_URI),
                     new MediaTypeRequestMatcher(MediaType.TEXT_HTML)))
             // Accept the AS's own JWTs at the OIDC userinfo endpoint.
             .oauth2ResourceServer(resourceServer -> resourceServer.jwt(Customizer.withDefaults()));
@@ -191,15 +193,18 @@ public class AuthorizationServerConfig {
     @Order(2)
     public SecurityFilterChain authorizationServerLoginFilterChain(HttpSecurity http) throws Exception {
         http
-            // Scoped to the interactive pages only, so the SPA routes and the /api/** chain are
-            // untouched. Everything here is browser form flow.
-            .securityMatcher("/login", OAuth2ConsentController.CONSENT_PAGE_URI, "/logout")
+            // Scoped to the AS interactive pages only (NOT /login — that is the SPA's route), so the
+            // SPA routes and the /api/** chain are untouched. Everything here is browser form flow.
+            .securityMatcher(OAuth2LoginPageController.LOGIN_PAGE_URI, OAuth2ConsentController.CONSENT_PAGE_URI)
             .authorizeHttpRequests(authorize -> authorize
-                .requestMatchers("/login").permitAll()
+                .requestMatchers(OAuth2LoginPageController.LOGIN_PAGE_URI).permitAll()
                 .anyRequest().authenticated())
-            // Spring Security's generated login page renders at GET /login; POST /login authenticates
-            // via the RequelUserAuthenticationProvider bean.
-            .formLogin(Customizer.withDefaults());
+            // Custom login page at /oauth2/login (OAuth2LoginPageController); the same URL is the
+            // form-login processing URL. Credentials are checked by RequelUserAuthenticationProvider.
+            .formLogin(form -> form
+                .loginPage(OAuth2LoginPageController.LOGIN_PAGE_URI)
+                .loginProcessingUrl(OAuth2LoginPageController.LOGIN_PAGE_URI)
+                .permitAll());
 
         return http.build();
     }

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/config/AuthorizationServerConfig.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/config/AuthorizationServerConfig.java
@@ -28,8 +28,8 @@ import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.env.Environment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -106,31 +106,51 @@ public class AuthorizationServerConfig {
     private static final Duration REFRESH_TOKEN_TTL = Duration.ofDays(30);
 
     /**
-     * Optional explicit issuer. When blank, {@link AuthorizationServerSettings} derives the issuer
-     * per request from the current context, which is correct for same-host self-hosted deployments.
-     * Set {@code requel.oauth.issuer} when Requel sits behind a proxy/!
+     * OAuth runtime flags are read from the {@link Environment} at point of use rather than via
+     * {@code @Value} fields. This class contributes {@code SecurityFilterChain} beans and is
+     * instantiated early enough that {@code @Value} placeholders resolved to their defaults (missing
+     * the command-line / external values). The Environment always carries the full, correctly-ordered
+     * property sources, so reading it at runtime binds correctly (issue #83).
      */
-    @Value("${requel.oauth.issuer:}")
-    private String issuer;
+    private final Environment environment;
 
-    /** Seed a loopback PKCE dev client so the flow is testable before DCR (Slice 4) lands. */
-    @Value("${requel.oauth.seed-dev-client:false}")
-    private boolean seedDevClient;
+    public AuthorizationServerConfig(Environment environment) {
+        this.environment = environment;
+    }
 
-    /**
-     * Seed the DCR registrar client (issue #83, Slice 4). The client-registration endpoint is always
-     * enabled but is unusable until a registrar exists, since Spring AS requires an initial access
-     * token minted by a client holding the {@code client.create} scope. Off by default.
-     */
-    @Value("${requel.oauth.dcr.enabled:false}")
-    private boolean dcrEnabled;
+    /** Optional explicit issuer; blank = derive per-request from the current context. */
+    private String issuer() {
+        return environment.getProperty("requel.oauth.issuer", "");
+    }
 
-    @Value("${requel.oauth.dcr.registrar-client-id:requel-registrar}")
-    private String registrarClientId;
+    /** Seed a loopback PKCE dev client so the flow is testable before/without DCR (Slice 4). */
+    private boolean seedDevClient() {
+        return environment.getProperty("requel.oauth.seed-dev-client", Boolean.class, false);
+    }
+
+    /** Seed the DCR registrar client. The registration endpoint is unusable until a registrar exists. */
+    private boolean dcrEnabled() {
+        return environment.getProperty("requel.oauth.dcr.enabled", Boolean.class, false);
+    }
+
+    private String registrarClientId() {
+        return environment.getProperty("requel.oauth.dcr.registrar-client-id", "requel-registrar");
+    }
 
     /** Registrar client secret (raw); required when {@code requel.oauth.dcr.enabled=true}. */
-    @Value("${requel.oauth.dcr.registrar-client-secret:}")
-    private String registrarClientSecret;
+    private String registrarClientSecret() {
+        return environment.getProperty("requel.oauth.dcr.registrar-client-secret", "");
+    }
+
+    /** Log the resolved OAuth flags at startup so seeding behavior is diagnosable (issue #83). */
+    @jakarta.annotation.PostConstruct
+    void logResolvedOAuthConfig() {
+        String secret = registrarClientSecret();
+        log.info("OAuth AS config resolved: seed-dev-client={}, dcr.enabled={}, "
+                + "dcr.registrar-client-id={}, registrar-secret-set={}, issuer='{}'",
+                seedDevClient(), dcrEnabled(), registrarClientId(),
+                (secret != null && !secret.isBlank()), issuer());
+    }
 
     // ---- Chain 1: authorization-server endpoints -------------------------------------------------
 
@@ -254,6 +274,7 @@ public class AuthorizationServerConfig {
     @Bean
     public AuthorizationServerSettings authorizationServerSettings() {
         AuthorizationServerSettings.Builder builder = AuthorizationServerSettings.builder();
+        String issuer = issuer();
         if (issuer != null && !issuer.isBlank()) {
             builder.issuer(issuer);
         }
@@ -284,7 +305,7 @@ public class AuthorizationServerConfig {
     @Bean
     public ApplicationRunner seedOAuthDevClient(RegisteredClientRepository registeredClientRepository) {
         return args -> {
-            if (!seedDevClient) {
+            if (!seedDevClient()) {
                 return;
             }
             String clientId = "requel-dev-client";
@@ -393,21 +414,23 @@ public class AuthorizationServerConfig {
     public ApplicationRunner seedDcrRegistrarClient(RegisteredClientRepository registeredClientRepository,
             PasswordEncoder passwordEncoder) {
         return args -> {
-            if (!dcrEnabled) {
+            if (!dcrEnabled()) {
                 return;
             }
-            if (registrarClientSecret == null || registrarClientSecret.isBlank()) {
+            String registrarSecret = registrarClientSecret();
+            if (registrarSecret == null || registrarSecret.isBlank()) {
                 log.warn("requel.oauth.dcr.enabled=true but requel.oauth.dcr.registrar-client-secret "
                         + "is not set; DCR registrar client NOT seeded, so client registration is "
                         + "unusable until a registrar exists.");
                 return;
             }
-            if (registeredClientRepository.findByClientId(registrarClientId) != null) {
+            String registrarId = registrarClientId();
+            if (registeredClientRepository.findByClientId(registrarId) != null) {
                 return;
             }
             RegisteredClient registrar = RegisteredClient.withId(UUID.randomUUID().toString())
-                    .clientId(registrarClientId)
-                    .clientSecret(passwordEncoder.encode(registrarClientSecret))
+                    .clientId(registrarId)
+                    .clientSecret(passwordEncoder.encode(registrarSecret))
                     .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
                     .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
                     .scope("client.create")
@@ -415,7 +438,7 @@ public class AuthorizationServerConfig {
                     .build();
             registeredClientRepository.save(registrar);
             log.info("Seeded DCR registrar client '{}' (client_credentials; scopes client.create, "
-                    + "client.read).", registrarClientId);
+                    + "client.read).", registrarId);
         };
     }
 }

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/config/AuthorizationServerConfig.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/config/AuthorizationServerConfig.java
@@ -1,0 +1,286 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.config;
+
+import com.rreganjr.requel.service.auth.OAuth2ConsentController;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationConsentService;
+import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsentService;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.client.JdbcRegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.config.annotation.web.configuration.OAuth2AuthorizationServerConfiguration;
+import org.springframework.security.oauth2.server.authorization.config.annotation.web.configurers.OAuth2AuthorizationServerConfigurer;
+import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
+import org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat;
+import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
+import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Duration;
+import java.util.UUID;
+
+/**
+ * Embedded OAuth 2.1 Authorization Server for MCP client authentication (issue #83, Slice 1).
+ *
+ * <p>Requel runs its own authorization server (Spring Authorization Server) against its existing
+ * user store; {@code /api/mcp/**} becomes an OAuth2 resource server (Slice 2) validating the tokens
+ * this server issues. See {@code doc/oauth_mcp_plan.md} → "Implementation Plan".
+ *
+ * <p><b>Filter-chain layering</b> (unique {@code @Order}; more specific matchers get lower numbers):
+ * <ol>
+ *   <li>{@code @Order(1)} — this AS-endpoints chain ({@code /oauth2/**}, {@code /connect/**},
+ *       {@code /.well-known/oauth-authorization-server}).</li>
+ *   <li>{@code @Order(2)} — the interactive login/consent chain ({@code /login},
+ *       {@code /oauth2/consent}) with form login backed by {@link RequelUserAuthenticationProvider}.</li>
+ *   <li>{@code @Order(3)} — MCP resource server on {@code /api/mcp/**} (Slice 2, not yet added).</li>
+ *   <li>{@code @Order(4)} — the existing stateless JWT chain on {@code /api/**}
+ *       ({@code ApiSecurityConfig}).</li>
+ * </ol>
+ * The AS and login chains use sessions + CSRF (defaults) for the browser flow; the {@code /api/**}
+ * chain stays stateless. Session policy and CSRF are per-chain, so they do not interfere.
+ */
+@Configuration
+public class AuthorizationServerConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(AuthorizationServerConfig.class);
+
+    /** Access-token TTL (short — clients silently refresh). */
+    private static final Duration ACCESS_TOKEN_TTL = Duration.ofHours(1);
+    /** Refresh-token TTL (long — rotating, with reuse detection; see TokenSettings below). */
+    private static final Duration REFRESH_TOKEN_TTL = Duration.ofDays(30);
+
+    /**
+     * Optional explicit issuer. When blank, {@link AuthorizationServerSettings} derives the issuer
+     * per request from the current context, which is correct for same-host self-hosted deployments.
+     * Set {@code requel.oauth.issuer} when Requel sits behind a proxy/!
+     */
+    @Value("${requel.oauth.issuer:}")
+    private String issuer;
+
+    /** Seed a loopback PKCE dev client so the flow is testable before DCR (Slice 4) lands. */
+    @Value("${requel.oauth.seed-dev-client:false}")
+    private boolean seedDevClient;
+
+    // ---- Chain 1: authorization-server endpoints -------------------------------------------------
+
+    @Bean
+    @Order(1)
+    public SecurityFilterChain authorizationServerSecurityFilterChain(HttpSecurity http) throws Exception {
+        OAuth2AuthorizationServerConfigurer authorizationServerConfigurer =
+                OAuth2AuthorizationServerConfigurer.authorizationServer();
+
+        http
+            .securityMatcher(authorizationServerConfigurer.getEndpointsMatcher())
+            .with(authorizationServerConfigurer, (authorizationServer) -> authorizationServer
+                // OpenID Connect (userinfo, client-registration for DCR in Slice 4).
+                .oidc(Customizer.withDefaults())
+                // Custom consent page (issue #83: consent required for all MCP clients).
+                .authorizationEndpoint(authorizationEndpoint ->
+                        authorizationEndpoint.consentPage(OAuth2ConsentController.CONSENT_PAGE_URI))
+            )
+            .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
+            // Unauthenticated browser requests to AS endpoints redirect to the login page.
+            .exceptionHandling(exceptions -> exceptions
+                .defaultAuthenticationEntryPointFor(
+                    new LoginUrlAuthenticationEntryPoint("/login"),
+                    new MediaTypeRequestMatcher(MediaType.TEXT_HTML)))
+            // Accept the AS's own JWTs at the OIDC userinfo endpoint.
+            .oauth2ResourceServer(resourceServer -> resourceServer.jwt(Customizer.withDefaults()));
+
+        return http.build();
+    }
+
+    // ---- Chain 2: interactive login + consent ---------------------------------------------------
+
+    @Bean
+    @Order(2)
+    public SecurityFilterChain authorizationServerLoginFilterChain(HttpSecurity http) throws Exception {
+        http
+            // Scoped to the interactive pages only, so the SPA routes and the /api/** chain are
+            // untouched. Everything here is browser form flow.
+            .securityMatcher("/login", OAuth2ConsentController.CONSENT_PAGE_URI, "/logout")
+            .authorizeHttpRequests(authorize -> authorize
+                .requestMatchers("/login").permitAll()
+                .anyRequest().authenticated())
+            // Spring Security's generated login page renders at GET /login; POST /login authenticates
+            // via the RequelUserAuthenticationProvider bean.
+            .formLogin(Customizer.withDefaults());
+
+        return http.build();
+    }
+
+    // ---- Persistence (JDBC-backed; tables via Flyway V12) ---------------------------------------
+
+    @Bean
+    public RegisteredClientRepository registeredClientRepository(JdbcTemplate jdbcTemplate) {
+        return new JdbcRegisteredClientRepository(jdbcTemplate);
+    }
+
+    @Bean
+    public OAuth2AuthorizationService authorizationService(JdbcTemplate jdbcTemplate,
+            RegisteredClientRepository registeredClientRepository) {
+        return new JdbcOAuth2AuthorizationService(jdbcTemplate, registeredClientRepository);
+    }
+
+    @Bean
+    public OAuth2AuthorizationConsentService authorizationConsentService(JdbcTemplate jdbcTemplate,
+            RegisteredClientRepository registeredClientRepository) {
+        return new JdbcOAuth2AuthorizationConsentService(jdbcTemplate, registeredClientRepository);
+    }
+
+    /**
+     * Encoder for client secrets (confidential clients / DCR). Loopback PKCE public clients carry no
+     * secret, but the AS requires a {@link PasswordEncoder} bean for client authentication.
+     */
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+    // ---- Signing key + issuer -------------------------------------------------------------------
+
+    /**
+     * RSA signing key for issued JWTs.
+     *
+     * <p><b>Slice 1 caveat:</b> this key is generated at startup, so it changes on every restart and
+     * previously-issued tokens stop validating after a restart. Fine for dev; the hardening
+     * follow-up (see plan "Out of scope / follow-ups") loads a persistent key from a configured
+     * keystore so tokens survive restarts.
+     */
+    @Bean
+    public JWKSource<SecurityContext> jwkSource() {
+        KeyPair keyPair = generateRsaKey();
+        RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
+        RSAPrivateKey privateKey = (RSAPrivateKey) keyPair.getPrivate();
+        RSAKey rsaKey = new RSAKey.Builder(publicKey)
+                .privateKey(privateKey)
+                .keyID(UUID.randomUUID().toString())
+                .build();
+        log.warn("OAuth AS signing key generated at startup (ephemeral). Tokens will not survive a "
+                + "restart; configure a persistent keystore before production (issue #83 hardening).");
+        return new ImmutableJWKSet<>(new JWKSet(rsaKey));
+    }
+
+    private static KeyPair generateRsaKey() {
+        try {
+            KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+            keyPairGenerator.initialize(2048);
+            return keyPairGenerator.generateKeyPair();
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to generate RSA key for OAuth signing", e);
+        }
+    }
+
+    @Bean
+    public org.springframework.security.oauth2.jwt.JwtDecoder jwtDecoder(JWKSource<SecurityContext> jwkSource) {
+        return OAuth2AuthorizationServerConfiguration.jwtDecoder(jwkSource);
+    }
+
+    @Bean
+    public AuthorizationServerSettings authorizationServerSettings() {
+        AuthorizationServerSettings.Builder builder = AuthorizationServerSettings.builder();
+        if (issuer != null && !issuer.isBlank()) {
+            builder.issuer(issuer);
+        }
+        return builder.build();
+    }
+
+    // ---- Default token policy + optional dev-client seeding -------------------------------------
+
+    /**
+     * Token policy applied to registered clients: 1h access token, 30d rotating refresh token with
+     * reuse detection (rotation is on because {@code reuseRefreshTokens(false)}), self-contained JWT
+     * access tokens. Slice 4 (DCR) applies these same defaults to self-registered clients.
+     */
+    static TokenSettings defaultTokenSettings() {
+        return TokenSettings.builder()
+                .accessTokenFormat(OAuth2TokenFormat.SELF_CONTAINED)
+                .accessTokenTimeToLive(ACCESS_TOKEN_TTL)
+                .refreshTokenTimeToLive(REFRESH_TOKEN_TTL)
+                .reuseRefreshTokens(false)
+                .build();
+    }
+
+    /**
+     * Registers a loopback, PKCE, consent-required dev client on startup when
+     * {@code requel.oauth.seed-dev-client=true}, so the authorization-code + PKCE flow can be
+     * exercised end to end before Dynamic Client Registration (Slice 4) exists. Idempotent.
+     */
+    @Bean
+    public ApplicationRunner seedOAuthDevClient(RegisteredClientRepository registeredClientRepository) {
+        return args -> {
+            if (!seedDevClient) {
+                return;
+            }
+            String clientId = "requel-dev-client";
+            if (registeredClientRepository.findByClientId(clientId) != null) {
+                return;
+            }
+            RegisteredClient devClient = RegisteredClient.withId(UUID.randomUUID().toString())
+                    .clientId(clientId)
+                    // Public client (no secret): PKCE-only, matching desktop/CLI agent clients.
+                    .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+                    .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                    .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
+                    // Loopback redirect URIs only (issue #83 DCR decision).
+                    .redirectUri("http://127.0.0.1:8080/login/oauth2/code/requel-dev-client")
+                    .redirectUri("http://localhost:8080/login/oauth2/code/requel-dev-client")
+                    .scope("mcp")
+                    .clientSettings(ClientSettings.builder()
+                            .requireAuthorizationConsent(true)
+                            .requireProofKey(true)
+                            .build())
+                    .tokenSettings(defaultTokenSettings())
+                    .build();
+            registeredClientRepository.save(devClient);
+            log.info("Seeded OAuth dev client '{}' (loopback PKCE, scope=mcp, consent required).",
+                    clientId);
+        };
+    }
+}

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/config/McpResourceServerConfig.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/config/McpResourceServerConfig.java
@@ -1,0 +1,101 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.config;
+
+import com.rreganjr.requel.service.auth.JwtAuthenticationFilter;
+import com.rreganjr.requel.service.auth.JwtService;
+import com.rreganjr.requel.service.auth.McpBearerTokenResolver;
+import com.rreganjr.requel.service.auth.McpJwtAuthenticationConverter;
+import com.rreganjr.requel.service.auth.UserDtoMapper;
+import com.rreganjr.requel.service.auth.ApiTokenRepository;
+import com.rreganjr.requel.user.UserRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * OAuth 2.1 resource server for the MCP endpoints (issue #83, Slice 2). Makes {@code /api/mcp/**}
+ * validate authorization-server-issued access tokens so agent clients (Cursor, Claude Code, Cowork)
+ * authenticate via OAuth, while personal access tokens (#73) and the SPA login JWT continue to work.
+ *
+ * <p>This is chain {@code @Order(3)} in the layering documented on {@link AuthorizationServerConfig}
+ * (1 = AS endpoints, 2 = login/consent, 3 = this MCP chain, 4 = the {@code /api/**} JWT chain). Its
+ * matcher {@code /api/mcp/**} is more specific than the {@code /api/**} chain, so it is evaluated
+ * first and fully owns MCP requests.
+ *
+ * <p><b>Three credential kinds coexist</b> (see {@link McpBearerTokenResolver}): the existing
+ * {@link JwtAuthenticationFilter} runs before the bearer filter and handles PATs and login JWTs; the
+ * bearer-token resolver hands <em>only</em> AS-issued (asymmetric-signed) JWTs to the resource
+ * server, which validates them with the AS's own {@link JwtDecoder} and maps the subject to a Requel
+ * user via {@link McpJwtAuthenticationConverter}. The 401 entry point is the resource server's
+ * {@code BearerTokenAuthenticationEntryPoint} (emits {@code WWW-Authenticate: Bearer}); Slice 3
+ * augments it with the RFC 9728 {@code resource_metadata} parameter.
+ */
+@Configuration
+public class McpResourceServerConfig {
+
+    private final JwtService jwtService;
+    private final ApiTokenRepository apiTokenRepository;
+    private final UserRepository userRepository;
+    private final UserDtoMapper userDtoMapper;
+    private final JwtDecoder jwtDecoder;
+
+    public McpResourceServerConfig(JwtService jwtService, ApiTokenRepository apiTokenRepository,
+            UserRepository userRepository, UserDtoMapper userDtoMapper, JwtDecoder jwtDecoder) {
+        this.jwtService = jwtService;
+        this.apiTokenRepository = apiTokenRepository;
+        this.userRepository = userRepository;
+        this.userDtoMapper = userDtoMapper;
+        this.jwtDecoder = jwtDecoder;
+    }
+
+    @Bean
+    @Order(3)
+    public SecurityFilterChain mcpSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .securityMatcher("/api/mcp/**")
+            .csrf(AbstractHttpConfigurer::disable)
+            .cors(Customizer.withDefaults())
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+            // PAT + login-JWT handling (unchanged behavior) runs before the OAuth bearer filter; for
+            // an AS token this filter's JWT branch fails (HS256 vs the AS's RS256) and clears the
+            // context, so the request falls through to the resource server below.
+            .addFilterBefore(new JwtAuthenticationFilter(jwtService, apiTokenRepository,
+                    userRepository, userDtoMapper), BearerTokenAuthenticationFilter.class)
+            .oauth2ResourceServer(oauth2 -> oauth2
+                .bearerTokenResolver(new McpBearerTokenResolver())
+                .jwt(jwt -> jwt
+                    .decoder(jwtDecoder)
+                    .jwtAuthenticationConverter(
+                        new McpJwtAuthenticationConverter(userRepository, userDtoMapper))))
+            .anonymous(AbstractHttpConfigurer::disable);
+
+        return http.build();
+    }
+}

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/config/McpResourceServerConfig.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/config/McpResourceServerConfig.java
@@ -22,6 +22,7 @@ package com.rreganjr.requel.service.config;
 
 import com.rreganjr.requel.service.auth.JwtAuthenticationFilter;
 import com.rreganjr.requel.service.auth.JwtService;
+import com.rreganjr.requel.service.auth.McpAuthenticationEntryPoint;
 import com.rreganjr.requel.service.auth.McpBearerTokenResolver;
 import com.rreganjr.requel.service.auth.McpJwtAuthenticationConverter;
 import com.rreganjr.requel.service.auth.UserDtoMapper;
@@ -89,6 +90,9 @@ public class McpResourceServerConfig {
             .addFilterBefore(new JwtAuthenticationFilter(jwtService, apiTokenRepository,
                     userRepository, userDtoMapper), BearerTokenAuthenticationFilter.class)
             .oauth2ResourceServer(oauth2 -> oauth2
+                // RFC 9728: 401s carry WWW-Authenticate: Bearer resource_metadata="…" so clients
+                // can discover the authorization server (issue #83, Slice 3).
+                .authenticationEntryPoint(new McpAuthenticationEntryPoint())
                 .bearerTokenResolver(new McpBearerTokenResolver())
                 .jwt(jwt -> jwt
                     .decoder(jwtDecoder)


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/83

MCP OAuth 2.1 — Slice 5: end-to-end verification runbook, connection docs, and the seeding-flag fix it surfaced

Adds the manual end-to-end verification runbook for the OAuth work (the parts that can't run in CI),
rewrites the connection guide to make OAuth the primary recipe, and includes the one code fix that
verification surfaced and depended on: the OAuth seeding flags were being ignored, so the flow could
not be exercised at all until it was fixed. That fix is bundled here (rather than amended into Slice
1/4) because it was found and validated during Slice 5 verification and is inseparable from being
able to run the runbook.

Verified during this slice (Parts A-D all pass): metadata (RFC 8414 + RFC 9728) and the 401
resource_metadata hint; full authorization-code + PKCE issuing a working user access token
(sub=<user>, scope=mcp) that the /api/mcp resource server accepts; gated DCR — a loopback client
registers (scope forced to mcp, public/PKCE) and a non-loopback redirect is rejected with
invalid_redirect_uri; and a real client (Claude Code in VS Code) connecting over OAuth end to end.
Claude Code uses a PRE-REGISTERED client_id + fixed callback port (claude mcp add --client-id
--callback-port), so gated DCR is sufficient and NO anonymous-registration shim is needed.

modules/service-impl/.../service/config/AuthorizationServerConfig.java
- FIX: read the OAuth flags (requel.oauth.seed-dev-client, requel.oauth.dcr.enabled,
  requel.oauth.dcr.registrar-client-id / -secret, requel.oauth.issuer) from the Environment at point
  of use instead of via @Value fields. This class contributes SecurityFilterChain beans and is
  instantiated early enough that @Value placeholders resolved to their defaults, so the command-line
  / external flags were silently ignored (both dev-client and registrar seeding no-oped, and a real
  requel.oauth.issuer would not have bound). Reading the Environment at runtime binds correctly with
  proper source precedence. Without this fix the seeded clients never existed, so the whole OAuth
  flow (login, token, DCR) could not be verified — hence it ships with the Slice 5 docs.
- Add a @PostConstruct that logs the resolved OAuth flags at startup ("OAuth AS config resolved: …")
  so seeding behavior is diagnosable.

doc/83-oauth-verification.md (new)
- Manual runbook: start config; Part A metadata + 401 (deterministic curl); Part B authorization-code
  + PKCE with the seeded dev client through to an MCP tool call; Part C gated DCR (mint initial token,
  register, loopback rejection); Part D real-client behavior gate incl. a step-by-step Claude Code
  (VS Code) walkthrough (disconnect PAT, add SSE server, OAuth login, the anonymous-vs-static-client
  DCR gate, PAT fallback); Findings table + the anonymous-DCR-shim decision.
- Captures two gotchas found while running it: (Part B) the post-login 404 is expected and the code
  is in the browser address bar, not on the page, and $CV/$CC must be the same pair in the same
  shell; (Part C) do NOT send a "scope" field in the DCR request — Spring AS validates the requested
  scope against the initial access token (client.create only), so requesting mcp yields invalid_scope;
  the converter forces scope=mcp regardless.
- Startup command uses the correct artifact name requel-app-2.0.0-dev.jar.

doc/mcp_remote_connection.md
- Make OAuth 2.1 the primary recipe for interactive clients; reframe PAT as the headless/CI path.
- New "Authentication" and "OAuth 2.1 connection" sections; fix the stale note that claimed the
  server exposes no OAuth flow; update the closing #83 note (OAuth is implemented; see the runbook).
- Add a confirmed "Claude Code (VS Code) over OAuth" recipe: start with AS+DCR enabled, register a
  client with the loopback callback, `claude mcp add --client-id --callback-port`, then `/mcp`
  Authenticate.

doc/oauth_mcp_plan.md
- Slice 5 section notes the runbook + doc updates are done and the client runs are developer-executed
  with outcomes recorded in the runbook Findings table.

Closes #83
(Note: this PR targets release/2.0, not the default branch, so merging will not auto-close the issue
— close it manually after merge.)
