### PR TITLE
requel-cli: command-line front-end over the gateway (#70 Phase A)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
     "java.compile.nullAnalysis.mode": "automatic",
-    "java.configuration.updateBuildConfiguration": "interactive"
+    "java.configuration.updateBuildConfiguration": "disabled"
 }

--- a/doc/70-requel-cli-plan.md
+++ b/doc/70-requel-cli-plan.md
@@ -108,11 +108,21 @@ The REST client just needs a bearer token; the CLI manages obtaining/refreshing 
   `4` not-allowed/unauthorized (gateway `NOT_ALLOWED`/`UNAUTHORIZED`); `5` server/execution error;
   `1` unexpected. Map `GatewayException.Kind` → codes.
 
-## Packaging
+## Packaging (done in Milestone 6)
 
-- **Fat jar** via `spring-boot-maven-plugin` repackage (or `maven-shade-plugin`), main = the picocli
-  entry point. Ship a thin `requel` wrapper (`exec java -jar …`). Native image explicitly out of
-  scope (see issue Decisions).
+- **Fat jar via `maven-shade-plugin`** (not the Spring Boot repackager — requel-cli is a plain picocli
+  app, not a boot application): `mvn -pl modules/requel-cli -am package` produces a single executable
+  `modules/requel-cli/target/requel-cli-<version>.jar` with `Main-Class:
+  com.rreganjr.requel.cli.RequelCli`. `ServicesResourceTransformer` merges `META-INF/services` (Jackson
+  module auto-registration / any ServiceLoader wiring); signature files are filtered out so the merged
+  jar stays valid. Plugin version is managed by `spring-boot-starter-parent`.
+- **Thin `requel` wrapper** at `modules/requel-cli/src/main/scripts/requel`: `exec java -jar` over the
+  jar, resolving it from `$REQUEL_CLI_JAR`, next to the script, or `../target` (local build). Requires
+  Java 17+.
+- Native image explicitly out of scope (see issue Decisions).
+- **Manual smoke:** after `package`, `java -jar modules/requel-cli/target/requel-cli-<version>.jar
+  --help` (or `modules/requel-cli/src/main/scripts/requel --help`) lists `run`, `commands`, `login`,
+  `logout`.
 
 ## Server-side additions needed (small, in `service-impl`)
 
@@ -146,7 +156,7 @@ The REST client just needs a bearer token; the CLI manages obtaining/refreshing 
    migration onto the catalog deferred to a separate ticket.)
 5. OAuth `requel login --oauth` (code+PKCE, ephemeral loopback callback, auto-refresh via
    `CliTokenSource`) + the seeded `requel-cli` client. **(done)**
-6. Packaging (fat jar + wrapper) and docs.
+6. Packaging (fat jar via maven-shade + thin `requel` wrapper) and docs. **(done)**
 
 ## Testing strategy
 

--- a/doc/70-requel-cli-plan.md
+++ b/doc/70-requel-cli-plan.md
@@ -51,13 +51,19 @@ Two layers, so the CLI works offline *and* stays in lockstep with the server:
    REST `CommandGateway` to `POST /api/gateway/commands/<CommandType>` (the server-side gateway
    facade — see below), so the allow/deny policy + authorization are enforced server-side. This is
    the reliable, scriptable core and needs no descriptors.
-2. **Typed convenience subcommands (runtime-discovered):** on startup the CLI fetches the descriptor
-   catalog and registers picocli subcommands dynamically (picocli supports programmatic subcommand
-   registration). This reflects exactly what the connected server allows — including the
-   `requel.gateway.write.enabled` flag (write commands absent/marked unavailable) — so it can't drift.
-   - **Server-side addition needed:** `GET /api/commands/descriptors` returning the
-     `GatewayCommandCatalog` as JSON (`commandType, title, description, write, authorizationHint`, and
-     a JSON schema for `inputType`). Small controller in `service-impl` over the existing catalog.
+2. **Runtime catalog discovery (`requel commands`, Milestone 4 — done):** the CLI fetches the
+   descriptor catalog from the server and lists the exposed write commands, so the operator sees
+   exactly what the connected server allows — including the `requel.gateway.write.enabled` flag (the
+   list is **empty** when writes are off, mirroring how the MCP server hides write tools), so it
+   can't drift.
+   - **Server-side addition (done):** `GET /api/gateway/commands/descriptors` returning the
+     `GatewayCommandCatalog` as JSON (`commandType, inputType (simple name), title, description,
+     write, authorizationHint`). Served by `GatewayCommandController`, gated by the write flag.
+   - **Client side (done):** `RestGatewayCatalog` in `gateway-rest-client` fetches it;
+     `requel commands` prints it (text or `--output json`).
+   - **Deferred (richer form):** dynamically *registering picocli subcommands* per command (with
+     per-field flags derived from the input DTO's JSON schema). MVP uses the generic
+     `requel run <CommandType> --input` for invocation; `requel commands` for discovery.
    - Offline / server-unreachable: only `run` + built-ins show in `--help`; that's acceptable.
 
 (This refines the earlier "static-primary" decision: because the catalog is server-side with no
@@ -103,8 +109,14 @@ The REST client just needs a bearer token; the CLI manages obtaining/refreshing 
    allow/deny policy is enforced server-side; returns the exact `GatewayException.Kind` in the error
    body) and `GatewayQueryController` (`GET /api/gateway/query/**`, delegates to the in-process
    `QueryGateway`). The REST client targets these, not the raw `/api/commands` / UI query endpoints.
-2. `GET /api/commands/descriptors` — expose `GatewayCommandCatalog` as JSON (+ input JSON schema).
-   (Milestone 4.)
+2. **Command catalog (done in Milestone 4):** `GatewayCommandCatalogImpl` (`service-impl`) implements
+   the `GatewayCommandCatalog` interface — the previously-unimplemented single source of truth —
+   derived from `GatewayPolicyConfig.ALLOWED` ∩ registered commands (input type via
+   `ApiCommandFactory`), so it can't drift from the allow/deny policy. Exposed at
+   `GET /api/gateway/commands/descriptors` (write-flag-gated). **Follow-up (separate ticket):** the MCP
+   server still generates its typed tools from its own hard-coded list; migrating MCP tool generation
+   onto this catalog (with an `MCP tools ⊆ catalog` lockstep test) changes a shipped tool surface, so
+   it's deliberately out of Milestone 4.
 3. Seed a `requel-cli` public/PKCE/loopback OAuth client in `AuthorizationServerConfig` (guarded by a
    flag, like the dev client), so interactive `requel login` works without a DCR initial token.
    (Milestone 5.)
@@ -116,7 +128,9 @@ The REST client just needs a bearer token; the CLI manages obtaining/refreshing 
 2. `requel-cli` skeleton with picocli, `--url`/config, `requel run` generic dispatch, output + exit
    codes.
 3. Auth: `requel login --token` (PAT) + credential store; wire bearer into the REST client.
-4. `GET /api/commands/descriptors` endpoint + runtime-discovered typed subcommands.
+4. Shared `GatewayCommandCatalog` impl + `GET /api/gateway/commands/descriptors` endpoint +
+   `RestGatewayCatalog` client + `requel commands` discovery subcommand. (MCP tool-generation
+   migration onto the catalog deferred to a separate ticket.)
 5. OAuth `requel login` (code+PKCE, loopback, refresh) + the seeded `requel-cli` client.
 6. Packaging (fat jar + wrapper) and docs.
 
@@ -132,9 +146,13 @@ The REST client just needs a bearer token; the CLI manages obtaining/refreshing 
 
 ## Decided
 
-- **Command discovery: runtime-primary** — fetch descriptors from `GET /api/commands/descriptors` at
-  startup and register subcommands dynamically; generic `run` is the offline fallback. (Build-time
-  static generation deferred.)
+- **Command discovery: runtime-primary** — fetch descriptors from
+  `GET /api/gateway/commands/descriptors` (implemented as the `requel commands` listing); generic
+  `run` is the offline fallback. Build-time static generation and dynamic per-command subcommand
+  registration both deferred.
+- **Shared catalog is authoritative (Milestone 4 decision "B").** `GatewayCommandCatalogImpl` is the
+  single source of truth, built from the same `ALLOWED` set as the gateway policy. Migrating MCP's
+  typed-tool generation onto it is a separate follow-up ticket (it alters a shipped tool surface).
 - **`gateway-rest-client` is its own module** (not inlined in `requel-cli`), for reuse.
 
 ## Open sub-decisions (resolve during implementation)

--- a/doc/70-requel-cli-plan.md
+++ b/doc/70-requel-cli-plan.md
@@ -1,0 +1,150 @@
+# requel-cli — Phase A implementation plan (issue #70)
+
+Phase A of #70: a command-line front-end over the gateway, buildable now (depends only on merged
+#69 gateway + #83/#73 auth). Phase B (remote connector ops) is deferred — see the issue.
+
+## Grounding: what actually exists today (verified in-tree)
+
+Two things the #70 background text implies but the code does **not** yet have — both become Phase A
+work:
+
+- **No REST-backed gateway client.** Only in-process impls exist: `InProcessCommandGateway` /
+  `InProcessQueryGateway` in `service-impl` (package `com.rreganjr.requel.service.gateway`). The
+  `CommandGateway` interface's javadoc anticipates a REST impl that POSTs to
+  `/api/commands/{commandType}`, but it isn't built. The CLI needs it — **build it in Phase A.**
+- **No `mcp-bridge` module.** So there's no bridge front-end to "mirror"; `requel-cli` is its own
+  module.
+- **The command catalog is server-side only.** `GatewayCommandCatalog` (`gateway-api`) →
+  `CommandDescriptor(commandType, inputType, title, description, write, authorizationHint)` is
+  implemented in `service-impl` from the `CommandRegistration` entries. There is **no REST endpoint
+  exposing it**. So a standalone CLI can't do true build-time static generation without new codegen
+  infra; runtime discovery via a small new endpoint is the pragmatic route (below).
+
+What we can lean on: the CQRS write path (`POST /api/commands/{type}`), the existing GET query
+endpoints, `/api/auth/login` + `/api/auth/tokens` (PAT, #73), and the OAuth2 endpoints (#83).
+
+## Module layout
+
+- **New module `gateway-rest-client` (decided: its own module).** A REST-backed `CommandGateway` +
+  `QueryGateway` implementing the `gateway-api` interfaces by calling Requel over HTTP with an
+  injected bearer token. Its own module (not folded into `requel-cli`) so a future remote/other
+  front-end can reuse it. Uses Spring's `RestClient` (already on the classpath via `spring-web`) +
+  Jackson.
+- **New module `requel-cli`**: the CLI app. Depends on `gateway-api` (interfaces + `CommandDescriptor`),
+  `service-api` (input/output DTOs), the REST client above, `picocli`, and Jackson. **No Spring MVC
+  server**; a minimal Spring context (or none) — prefer plain `main()` + picocli, wiring the REST
+  client by hand, to keep startup fast and the jar lean.
+
+## CLI framework: picocli
+
+Nothing CLI-ish is on the classpath today (no picocli/jcommander/args4j). Use **picocli** — mature,
+annotation-driven subcommands, generated `--help`, `@|...|@` styling, shell-completion generation,
+and GraalVM-friendly if we ever want native (we don't for MVP). Add `info.picocli:picocli` to the
+new module.
+
+## Command surface & discovery
+
+Two layers, so the CLI works offline *and* stays in lockstep with the server:
+
+1. **Generic `run` (always available, no server round-trip to invoke):**
+   `requel run <CommandType> --input @file.json` or `--input '{...json...}'`. Dispatches through the
+   REST `CommandGateway` to `POST /api/gateway/commands/<CommandType>` (the server-side gateway
+   facade — see below), so the allow/deny policy + authorization are enforced server-side. This is
+   the reliable, scriptable core and needs no descriptors.
+2. **Typed convenience subcommands (runtime-discovered):** on startup the CLI fetches the descriptor
+   catalog and registers picocli subcommands dynamically (picocli supports programmatic subcommand
+   registration). This reflects exactly what the connected server allows — including the
+   `requel.gateway.write.enabled` flag (write commands absent/marked unavailable) — so it can't drift.
+   - **Server-side addition needed:** `GET /api/commands/descriptors` returning the
+     `GatewayCommandCatalog` as JSON (`commandType, title, description, write, authorizationHint`, and
+     a JSON schema for `inputType`). Small controller in `service-impl` over the existing catalog.
+   - Offline / server-unreachable: only `run` + built-ins show in `--help`; that's acceptable.
+
+(This refines the earlier "static-primary" decision: because the catalog is server-side with no
+static export, discovery is **runtime-primary** with the generic `run` as the offline fallback.
+Build-time static generation stays a possible later enhancement if offline typed help matters.)
+
+## Auth (PAT + OAuth, per #73/#83)
+
+The REST client just needs a bearer token; the CLI manages obtaining/refreshing it.
+
+- **PAT (headless/scripting, simplest):** `requel login --token reqpat_…` (or `REQUEL_TOKEN` env, or
+  read from the credential store). Stored and sent as `Authorization: Bearer`. Mint via the UI or
+  `POST /api/auth/tokens`.
+- **OAuth login (interactive):** `requel login` runs authorization-code + PKCE against the #83 AS with
+  a **loopback callback** (same pattern Claude Code uses), stores the access + refresh tokens, and
+  refreshes automatically (1h access / 30d rotating refresh). On refresh-expiry, prompt to re-login.
+  - **Server-side addition needed (small):** seed a public, loopback, PKCE `requel-cli` OAuth client
+    (like the seeded dev client in `AuthorizationServerConfig`) so `requel login` works out of the box
+    without the operator having to mint a DCR initial token. Gated DCR stays the default for other
+    clients; this is one known first-party client.
+- **Token storage:** per-OS, `chmod 600` file under `~/.config/requel/credentials` (documented), or
+  OS keychain later. Never in checked-in config. Config precedence: flag > env > credential file.
+
+## Config, output, exit codes
+
+- **Server URL:** `--url` / `REQUEL_URL` / config; default `http://localhost:8080`.
+- **Output:** `--output text|json` (default `text`; `json` prints the raw `GatewayResult`/query DTO
+  for scripting).
+- **Exit codes** (for scripting): `0` success; `2` usage error; `3` auth failure (401/expired);
+  `4` not-allowed/unauthorized (gateway `NOT_ALLOWED`/`UNAUTHORIZED`); `5` server/execution error;
+  `1` unexpected. Map `GatewayException.Kind` → codes.
+
+## Packaging
+
+- **Fat jar** via `spring-boot-maven-plugin` repackage (or `maven-shade-plugin`), main = the picocli
+  entry point. Ship a thin `requel` wrapper (`exec java -jar …`). Native image explicitly out of
+  scope (see issue Decisions).
+
+## Server-side additions needed (small, in `service-impl`)
+
+1. **Gateway REST facades (done in Milestone 1):** `GatewayCommandController`
+   (`POST /api/gateway/commands/{type}`, delegates to the in-process `CommandGateway` so the
+   allow/deny policy is enforced server-side; returns the exact `GatewayException.Kind` in the error
+   body) and `GatewayQueryController` (`GET /api/gateway/query/**`, delegates to the in-process
+   `QueryGateway`). The REST client targets these, not the raw `/api/commands` / UI query endpoints.
+2. `GET /api/commands/descriptors` — expose `GatewayCommandCatalog` as JSON (+ input JSON schema).
+   (Milestone 4.)
+3. Seed a `requel-cli` public/PKCE/loopback OAuth client in `AuthorizationServerConfig` (guarded by a
+   flag, like the dev client), so interactive `requel login` works without a DCR initial token.
+   (Milestone 5.)
+
+## Milestones (incremental, each independently testable)
+
+1. `gateway-rest-client`: REST `CommandGateway`/`QueryGateway` + a `RestClient` bearer holder; unit
+   tests against a stubbed server.
+2. `requel-cli` skeleton with picocli, `--url`/config, `requel run` generic dispatch, output + exit
+   codes.
+3. Auth: `requel login --token` (PAT) + credential store; wire bearer into the REST client.
+4. `GET /api/commands/descriptors` endpoint + runtime-discovered typed subcommands.
+5. OAuth `requel login` (code+PKCE, loopback, refresh) + the seeded `requel-cli` client.
+6. Packaging (fat jar + wrapper) and docs.
+
+## Testing strategy
+
+- **Unit:** picocli parsing, `GatewayException.Kind`→exit-code mapping, descriptor→subcommand
+  generation, credential-store round-trip.
+- **Integration:** boot the app with `@SpringBootTest(webEnvironment = RANDOM_PORT)` and drive the CLI
+  `main()` against it (PAT auth) — a real read (`listProjects`), a gated write (`createGoal` on a
+  project the test user can edit), and a denied write → assert output + exit codes. No live network.
+- **Auth:** PAT accepted; expired/invalid → exit 3. OAuth code+PKCE happy path can be an integration
+  test against the embedded AS (reuse the #83 harness).
+
+## Decided
+
+- **Command discovery: runtime-primary** — fetch descriptors from `GET /api/commands/descriptors` at
+  startup and register subcommands dynamically; generic `run` is the offline fallback. (Build-time
+  static generation deferred.)
+- **`gateway-rest-client` is its own module** (not inlined in `requel-cli`), for reuse.
+
+## Open sub-decisions (resolve during implementation)
+
+- Typed subcommand flags derived from the input DTO's JSON schema vs. every typed subcommand also just
+  taking `--input <json>` for MVP (recommend `--input` first; per-field flags later).
+- Credential store: flat `chmod 600` file (MVP) vs. OS keychain (later).
+
+## Out of scope (Phase B — deferred)
+
+Remote MCP connector ops: reachable TLS host/tunnel, Anthropic IP allowlist, Owner-side connector
+registration, and the persistent AS signing key (#83 follow-up) that a remote connector needs. See
+the #70 issue body.

--- a/doc/70-requel-cli-plan.md
+++ b/doc/70-requel-cli-plan.md
@@ -77,13 +77,25 @@ The REST client just needs a bearer token; the CLI manages obtaining/refreshing 
 - **PAT (headless/scripting, simplest):** `requel login --token reqpat_…` (or `REQUEL_TOKEN` env, or
   read from the credential store). Stored and sent as `Authorization: Bearer`. Mint via the UI or
   `POST /api/auth/tokens`.
-- **OAuth login (interactive):** `requel login` runs authorization-code + PKCE against the #83 AS with
-  a **loopback callback** (same pattern Claude Code uses), stores the access + refresh tokens, and
-  refreshes automatically (1h access / 30d rotating refresh). On refresh-expiry, prompt to re-login.
-  - **Server-side addition needed (small):** seed a public, loopback, PKCE `requel-cli` OAuth client
-    (like the seeded dev client in `AuthorizationServerConfig`) so `requel login` works out of the box
-    without the operator having to mint a DCR initial token. Gated DCR stays the default for other
-    clients; this is one known first-party client.
+- **OAuth login (interactive) — done in Milestone 5:** `requel login --oauth` runs authorization-code
+  + PKCE against the #83 AS with a **loopback callback** (same pattern Claude Code uses), stores the
+  access + rotating refresh tokens, and `CliTokenSource` refreshes automatically (1h access / 30d
+  rotating refresh); on refresh failure it returns the stale token so the server rejects it and the
+  user re-runs `requel login`.
+  - **Loopback callback port:** the CLI binds an **ephemeral** `127.0.0.1` port at login time and
+    serves `/callback`. The seeded client registers the port-less redirect `http://127.0.0.1/callback`;
+    Spring Authorization Server relaxes the port when matching loopback redirect URIs (RFC 8252), so
+    any actual port matches. The IP literal (not `localhost`) is required for that relaxation.
+  - **Server-side addition (done):** `AuthorizationServerConfig` seeds a public, loopback, PKCE,
+    consent-required `requel-cli` OAuth client (scope `mcp`, auth-code + refresh) when
+    `requel.oauth.seed-cli-client=true`, so `requel login` works out of the box without the operator
+    minting a DCR initial token. Gated DCR stays the default for third-party clients; this is one known
+    first-party client.
+  - **Manual e2e:** the full browser flow can't run in `mvn test` (needs a browser + running AS), so it
+    is verified via the runbook like #83 Slice 5. Unit tests cover every seam: PKCE (RFC 7636 vector),
+    the loopback callback server (code capture, state-mismatch, AS error), the OAuth client (discover /
+    exchange / refresh against a stubbed server), token precedence + auto-refresh (`CliTokenSource`),
+    and the `login --oauth` orchestration with fakes.
 - **Token storage:** per-OS, `chmod 600` file under `~/.config/requel/credentials` (documented), or
   OS keychain later. Never in checked-in config. Config precedence: flag > env > credential file.
 
@@ -117,9 +129,10 @@ The REST client just needs a bearer token; the CLI manages obtaining/refreshing 
    server still generates its typed tools from its own hard-coded list; migrating MCP tool generation
    onto this catalog (with an `MCP tools ⊆ catalog` lockstep test) changes a shipped tool surface, so
    it's deliberately out of Milestone 4.
-3. Seed a `requel-cli` public/PKCE/loopback OAuth client in `AuthorizationServerConfig` (guarded by a
-   flag, like the dev client), so interactive `requel login` works without a DCR initial token.
-   (Milestone 5.)
+3. **Seeded `requel-cli` OAuth client (done in Milestone 5):** `AuthorizationServerConfig` seeds a
+   public/PKCE/loopback/consent client (scope `mcp`) when `requel.oauth.seed-cli-client=true`, so
+   interactive `requel login` works without a DCR initial token. Registered redirect is the port-less
+   loopback `http://127.0.0.1/callback` (Spring AS relaxes the port per RFC 8252).
 
 ## Milestones (incremental, each independently testable)
 
@@ -131,7 +144,8 @@ The REST client just needs a bearer token; the CLI manages obtaining/refreshing 
 4. Shared `GatewayCommandCatalog` impl + `GET /api/gateway/commands/descriptors` endpoint +
    `RestGatewayCatalog` client + `requel commands` discovery subcommand. (MCP tool-generation
    migration onto the catalog deferred to a separate ticket.)
-5. OAuth `requel login` (code+PKCE, loopback, refresh) + the seeded `requel-cli` client.
+5. OAuth `requel login --oauth` (code+PKCE, ephemeral loopback callback, auto-refresh via
+   `CliTokenSource`) + the seeded `requel-cli` client. **(done)**
 6. Packaging (fat jar + wrapper) and docs.
 
 ## Testing strategy
@@ -153,6 +167,10 @@ The REST client just needs a bearer token; the CLI manages obtaining/refreshing 
 - **Shared catalog is authoritative (Milestone 4 decision "B").** `GatewayCommandCatalogImpl` is the
   single source of truth, built from the same `ALLOWED` set as the gateway policy. Migrating MCP's
   typed-tool generation onto it is a separate follow-up ticket (it alters a shipped tool surface).
+- **Interactive OAuth uses an ephemeral loopback port (Milestone 5).** `requel login --oauth` binds a
+  random `127.0.0.1` port and the seeded client registers the port-less `http://127.0.0.1/callback`,
+  relying on Spring AS's RFC 8252 loopback port relaxation — no fixed port to collide, no per-machine
+  config. Gated behind `requel.oauth.seed-cli-client` server-side; opt-in.
 - **`gateway-rest-client` is its own module** (not inlined in `requel-cli`), for reuse.
 
 ## Open sub-decisions (resolve during implementation)

--- a/doc/70-requel-cli-verification.md
+++ b/doc/70-requel-cli-verification.md
@@ -1,0 +1,151 @@
+# Issue #70 (Phase A) — `requel-cli` end-to-end verification runbook
+
+Manual verification for the CLI's parts that need a running server and, for the OAuth login, a real
+browser — which can't be automated in CI. The unit suites already pass (gateway REST client, catalog,
+PKCE, loopback callback, token source, login orchestration, seeded-client shape); this runbook covers
+the live paths: interactive OAuth login, PAT login, command discovery, a real gateway write, token
+precedence, and logout.
+
+Run each part in order; record outcomes in the **Findings** table at the bottom.
+
+## 0. Build the CLI and start the server
+
+Build the fat jar (also gives the `requel` wrapper a jar to find):
+
+```bash
+mvn -pl modules/requel-cli -am package
+alias requel='modules/requel-cli/src/main/scripts/requel'   # or: java -jar modules/requel-cli/target/requel-cli-2.0.0-dev.jar
+requel --help    # lists run, commands, login, logout
+```
+
+Start the server with the CLI OAuth client seeded **and** gateway writes enabled (so `commands` and a
+write are exercisable). Dev profile for the SPA CORS; AS signing key is ephemeral (fine here).
+
+> **Rebuild `requel-app`, not just `requel-cli`.** The seeded `requel-cli` client lives in
+> `service-impl`/`requel-app`, which is *not* a dependency of `requel-cli` — so
+> `mvn -pl modules/requel-cli -am package` does **not** repackage the app jar. If the app jar predates
+> the M5 server changes you'll get a 400 at `/oauth2/authorize` (unknown `client_id`). Rebuild it:
+> `mvn -pl modules/requel-app -am package -DskipAngularBuild=true -DskipTests=true`. Confirm the
+> startup log shows `seed-cli-client=true` and `Seeded OAuth client 'requel-cli' …`.
+
+```bash
+java -jar modules/requel-app/target/requel-app-2.0.0-dev.jar \
+  --spring.profiles.active=dev --server.port=8080 \
+  '--spring.datasource.url=jdbc:mysql://127.0.0.1:3306/requel?createDatabaseIfNotExist=true&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC' \
+  --spring.datasource.username=root --spring.datasource.password=password \
+  --requel.oauth.seed-cli-client=true \
+  --requel.gateway.write.enabled=true
+```
+
+Expected in the log: `Seeded OAuth client 'requel-cli' (loopback PKCE, scope=mcp, consent required) for
+\`requel login\`.` and the OAuth config line showing `seed-cli-client=true`.
+
+> Credentials are written to `~/.config/requel/credentials` (override with `REQUEL_CONFIG_DIR`). To
+> start each part from a clean slate, `requel logout` or point `REQUEL_CONFIG_DIR` at a temp dir.
+
+## A. Interactive OAuth login (the crux — proves the loopback + PKCE + seeded client)
+
+```bash
+requel --url http://localhost:8080 login --oauth
+```
+
+Expected: the CLI prints `Opening your browser to log in…` with an authorize URL and opens the browser.
+Log in as a Requel user, approve the consent screen (naming "Requel CLI" and the `mcp` scope). The
+browser lands on the CLI's loopback `/callback` showing "Login complete — you can close this tab", and
+the terminal prints `Logged in. Tokens saved for http://localhost:8080 (…/credentials).`
+
+**The assumption this confirms (verified working on Spring Authorization Server 1.x):** login
+succeeds without an `invalid_redirect_uri` error — i.e. Spring AS matched the CLI's ephemeral
+`http://127.0.0.1:<random>/callback` against the seeded port-less `http://127.0.0.1/callback` (RFC
+8252 loopback port relaxation). If a future AS version ever fails here with `invalid_redirect_uri`,
+the fallback is a fixed callback port and a redirect registered with that exact port.
+
+Inspect the stored tokens (optional): the file has `oauth.http://localhost:8080.access`, `.refresh`,
+`.expiresAt`, `.scope` keys.
+
+**Pass:** browser login + consent complete; access + refresh tokens saved; no redirect-URI error.
+
+## B. Use the OAuth session (proves the token authenticates the gateway as the user)
+
+```bash
+# Discover the exposed write commands (server has writes enabled, so this is non-empty)
+requel --url http://localhost:8080 commands
+#   expect: a table of write commands (EditGoal, EditStory, …). No --token needed — the stored OAuth
+#   access token is used automatically.
+
+requel --url http://localhost:8080 --output json commands | jq '.[0]'
+#   expect: {commandType, inputType, title, write:true, …}
+
+# Perform a real write as the logged-in user (use a project the user can edit)
+requel --url http://localhost:8080 run EditGoal --input '{"projectName":"Demo","name":"CLI smoke goal"}'
+#   expect: OK EditGoal: … (id=…). The goal is created/edited as your user, through the gateway
+#   (allow/deny policy + per-stakeholder authorization enforced server-side).
+```
+
+**Pass:** `commands` lists the catalog using the stored token; the write succeeds and is attributed to
+the logged-in user.
+
+## C. Writes-disabled and denylist behavior (optional, restart-gated)
+
+Restart the server **without** `--requel.gateway.write.enabled=true`, then:
+
+```bash
+requel --url http://localhost:8080 commands
+#   expect: "No commands exposed (server writes may be disabled: requel.gateway.write.enabled=false)."
+requel --url http://localhost:8080 run EditUser --input '{}'
+#   expect: Error [NOT_ALLOWED] … (a denied/unknown command → exit code 4), proving the denylist holds
+#   regardless of the client.
+echo $?   # 4 for NOT_ALLOWED, 5 for a request error
+```
+
+**Pass:** empty catalog when writes are off; a denied command returns a NOT_ALLOWED error + exit code.
+
+## D. PAT login + token precedence (headless path still works)
+
+```bash
+# Mint a PAT in the Requel UI (or POST /api/auth/tokens), then:
+requel --url http://localhost:8080 login --token reqpat_XXXXXXXX
+#   expect: Saved credentials for http://localhost:8080 (…/credentials).
+requel --url http://localhost:8080 commands   # authenticates with the PAT
+
+# Precedence: an explicit --token / REQUEL_TOKEN overrides both stored OAuth and stored PAT
+REQUEL_TOKEN=reqpat_OTHER requel --url http://localhost:8080 commands
+```
+
+**Pass:** PAT login stores and authenticates; an explicit flag/env token takes precedence.
+
+## E. Logout (clears both OAuth and PAT for the URL)
+
+`logout` clears only the *stored* credentials. A `--token` flag or `REQUEL_TOKEN`/`REQUEL_PAT` env var
+still takes precedence (that's the designed order: flag/env > stored OAuth > stored PAT), so unset any
+env token first or the request will still authenticate.
+
+```bash
+unset REQUEL_TOKEN REQUEL_PAT          # e.g. direnv may export these
+requel --url http://localhost:8080 logout
+#   expect: Cleared credentials for http://localhost:8080.
+requel --url http://localhost:8080 commands
+#   expect: with no stored credentials and no flag/env token, the server rejects the request
+#   (401 → exit code 3 AUTH), confirming both the OAuth tokens and PAT were removed.
+echo $?
+```
+
+**Pass:** logout removes stored credentials; a subsequent call is unauthenticated.
+
+## Notes on auto-refresh (not directly scriptable)
+
+Access tokens live 1h; `CliTokenSource` refreshes automatically via the 30-day rotating refresh token
+when the access token is within 60s of expiry, persisting the rotation. Verifying this manually means
+waiting out an access token (or temporarily shortening `ACCESS_TOKEN_TTL`); it is covered by
+`CliTokenSourceTest` (refresh-on-expiry + rotation persistence + refresh-failure fallback), so it is
+not part of the timed manual run.
+
+## Findings
+
+| Part | Check | Result | Notes |
+|------|-------|--------|-------|
+| A | `login --oauth` browser + consent, tokens saved | ☐ | confirm NO invalid_redirect_uri (loopback port relaxation) |
+| B | `commands` + `run EditGoal` with stored OAuth token | ☐ | write attributed to the logged-in user |
+| C | writes-off empty catalog; denied command → NOT_ALLOWED | ☐ | restart without write flag |
+| D | PAT login + flag/env precedence | ☐ | |
+| E | logout clears OAuth + PAT | ☐ | subsequent call → 401 / exit 3 |

--- a/doc/issue_cli_and_remote_connector.md
+++ b/doc/issue_cli_and_remote_connector.md
@@ -3,6 +3,27 @@
 Part of the v2.0 MCP command-gateway series (ticket 2 of 5). Design doc:
 `doc/local_mcp_bridge.md`. Depends on the Command Gateway ticket (series ticket 1).
 
+> **Status update (post-#83).** This ticket predates the OAuth work; the landscape has since shifted:
+> - Series ticket 1 (**#69** — Command Gateway + write tools + stdio bridge + command descriptors)
+>   is **merged**.
+> - **#83** delivered OAuth 2.1 on `/api/mcp/**`: an embedded authorization server backed by the
+>   Requel user store (authorization-code + PKCE, resource server, RFC 9728 discovery, gated DCR).
+> - **#73** delivered user-mintable, revocable PATs.
+>
+> Consequences: the OAuth-boundary and token-"refresh" open items below are **resolved**, and the
+> remote-connector auth design is largely **de-scoped** — the embedded AS *is* the Requel user
+> store, so there is no external-identity→Requel-user mapping to invent (that only arises if an
+> external IdP is added later, a separate ticket). Remaining work splits into two phases:
+>
+> - **Phase A — `requel-cli` (near-term, unblocked).** Builds on merged pieces (#69 in-process
+>   gateway + catalog, #83/#73 for auth); no external infrastructure. Note: #69 shipped only the
+>   *in-process* gateway — the **REST gateway client is built in Phase A** (own module
+>   `gateway-rest-client`). **Implementation plan: `doc/70-requel-cli-plan.md`.**
+> - **Phase B — remote MCP connector (deferred, ops-gated).** Operationalize the now
+>   OAuth-protected `/api/mcp` as a Cowork/Anthropic custom connector: reachable TLS host, IP
+>   allowlist, Owner-side registration. Deployment work with external dependencies, not code that
+>   merges in one PR — kept separate so it can't block Phase A. May be split into its own issue.
+
 ## Goal
 
 Add the remaining front-ends over the `gateway-api` core delivered in ticket 1: a command-line
@@ -30,36 +51,40 @@ In scope:
 - **`requel-cli`** — a new command-line module over the REST-backed gateway. Supports the generic
   `runCommand` (any allowlisted command type with a JSON/flag input) and convenience subcommands
   mirroring the typed tools (goal/story/actor/use-case/scenario/glossary-term/non-user-stakeholder
-  edits, container associations, notes). Auth is login→JWT, with **re-login on expiry** (or PAT
-  support once ticket 5 lands) — not JWT "refresh", which the current API does not support.
+  edits, container associations, notes). **Auth (updated for #73/#83):** prefer a **PAT** (#73) for
+  headless/scripting use; offer **OAuth login** (authorization-code + PKCE, 30-day rotating refresh
+  from #83) for interactive use. The original "login→JWT + re-login on expiry" is superseded — no
+  fixed-expiry-JWT re-login needed.
 - **Generated command surface** — CLI subcommands are generated from ticket 1's command
   **descriptors/schemas**, not from an allow/deny predicate alone. This ticket depends on ticket 1
   exporting those descriptors.
-- **Remote connector exposure** — operationalize the existing in-process `/api/mcp` (now with
-  write tools) as a custom remote connector:
+- **Remote connector exposure (Phase B)** — operationalize `/api/mcp` (now OAuth-protected via #83)
+  as a custom remote connector:
   - terminate TLS on a reachable host (deployed instance or tunnel; `localhost` is not reachable
     by Anthropic),
-  - **OAuth user mapping** (explicit subtask): how an external OAuth identity maps to a Requel
-    username/user id, how account linking is approved, and how the resulting request becomes a
-    Spring Security authentication compatible with `CurrentUserResolver`,
+  - ~~OAuth user mapping~~ — **resolved by #83**: the embedded AS authenticates against the Requel
+    user store, so the OAuth user *is* a Requel user; the resource server maps the token subject to
+    the user via `CurrentUserResolver` already. No external-identity linking unless an external IdP
+    is added later.
   - specify how JSON-RPC clients send auth, how failed auth is reported, and whether write tools
     are hidden from `tools/list` or listed-and-rejected when `requel.gateway.write.enabled=false`,
   - allowlist Anthropic inbound IP ranges,
   - document the Owner-side registration (Organization settings → Connectors) for a
     Team/Enterprise account.
+  - **Signing-key caveat:** the AS signing key is ephemeral today (#83 follow-up); a remotely
+    registered connector needs a persistent keystore so tokens survive restarts.
 
 Out of scope:
 
 - The issue-tracker→goals workflow and reconciliation (later tickets).
-- User-mintable API tokens (ticket 5) — until then the connector uses OAuth and the CLI uses
-  login→JWT.
+- External identity provider support (OAuth account-linking to a third-party IdP) — a separate
+  future ticket; the embedded AS from #83 covers the connector's auth needs.
 
 ## Design
 
 - `requel-cli` depends on `gateway-api` + the REST gateway client; no Spring MVC server. The
   command surface is generated from ticket 1's command descriptors so CLI and MCP stay in
-  lockstep; command discovery can be static (generated) and/or runtime (`tools/list`) — decide in
-  this ticket.
+  lockstep; command discovery is static-generated + runtime-reconciled (see Decisions).
 - The remote connector is the same `mcp-server` endpoint from ticket 1; this ticket is the
   deployment/auth/ops envelope around it, plus docs. Provider-specific (Cowork/Anthropic)
   reachability and registration are explicitly new work.
@@ -79,10 +104,12 @@ Out of scope:
 
 1. Create the `requel-cli` module over the REST gateway client; generate `run` (generic) and
    convenience subcommands from ticket 1's command descriptors.
-2. Add login→JWT auth, re-login-on-expiry (PAT later), and per-OS config/secret handling.
-3. Define CLI exit codes and JSON/stdout output formats for scripting; define command discovery
-   (static generated, runtime `tools/list`, or both).
-4. Package/distribute the CLI (fat jar or native launcher).
+2. Add auth: PAT (#73) for headless + OAuth login (#83) for interactive, and per-OS config/secret
+   handling.
+3. Define CLI exit codes and JSON/stdout output formats for scripting; implement command discovery
+   (static generated from #69 descriptors, reconciled at runtime against `tools/list` — see
+   Decisions).
+4. Package/distribute the CLI as a **fat jar** (+ a thin `requel` wrapper over `java -jar`).
 5. Stand up a reachable TLS host or tunnel for `/api/mcp`; implement OAuth at the connector
    boundary with the Requel-user mapping and Spring Security integration.
 6. Specify connector auth transport, failed-auth reporting, and write-tool visibility when the
@@ -102,7 +129,8 @@ Out of scope:
 ## Acceptance Criteria
 
 - `requel-cli` can perform the full allowlisted authoring surface against a running Requel via the
-  gateway, with login→JWT auth and re-login on expiry, with documented exit codes/output formats.
+  gateway, authenticating with a PAT (headless) or OAuth login (interactive), with documented exit
+  codes/output formats.
 - The `/api/mcp` endpoint is reachable as a remote connector over TLS with OAuth mapped to a
   Requel user, IP allowlisting, defined auth-failure behavior, and documented Owner registration.
 - Write-tool visibility under the write flag (hidden vs rejected) is defined and tested.
@@ -110,11 +138,23 @@ Out of scope:
 
 ## Dependencies
 
-- Series ticket 1 (Command Gateway + write tools + stdio bridge; command descriptors;
-  pseudo-user + rate-limit mechanism).
+- **#69** (Command Gateway + write tools + stdio bridge; command descriptors; pseudo-user +
+  rate-limit mechanism) — **merged**.
+- **#83** (OAuth 2.1 on `/api/mcp`) and **#73** (PATs) — **merged**; provide the CLI/connector auth.
 
-## Open Questions
+## Decisions (were open questions)
 
-- CLI distribution format (fat jar vs native image)?
-- One connector client registration per environment, or per user?
-- Command discovery: static generated, runtime `tools/list`, or both?
+- **CLI distribution → fat jar.** Trivial with the existing Maven build, runs anywhere with a JVM,
+  and a scripting CLI tolerates JVM startup. Native (GraalVM) image is deferred — the Spring/Jackson
+  reflection config and per-OS builds aren't worth it for a single-maintainer tool yet; revisit only
+  if it becomes a widely distributed end-user binary. Ship a thin `requel` wrapper over `java -jar`.
+- **Connector registration → one per environment.** One registered OAuth client per deployed Requel;
+  each user authenticates individually (per-user consent + tokens, single client) — the standard
+  "one client, many users" model, and how an Org custom connector works. Not per-user client
+  registration.
+- **Command discovery → both, static-primary.** Generate static subcommands from #69's command
+  descriptors (help, tab-completion, offline use, scripting ergonomics), and reconcile at runtime
+  against the server's `tools/list`/descriptors so the CLI reflects what the connected server
+  actually permits — notably the `requel.gateway.write.enabled` flag (write commands surface as
+  clearly unavailable, not a raw 500). Generic `runCommand` is always the escape hatch. An MVP may
+  start static-only and add the runtime check when drift / write-flag handling requires it.

--- a/modules/gateway-rest-client/pom.xml
+++ b/modules/gateway-rest-client/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.rreganjr.requel</groupId>
+        <artifactId>Requel-parent</artifactId>
+        <version>2.0.0-dev</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>gateway-rest-client</artifactId>
+    <name>Requel Gateway REST Client</name>
+    <description>REST-backed CommandGateway/QueryGateway implementations that call a running Requel
+        over HTTP with a bearer token (PAT or OAuth access token). Used by out-of-process front-ends
+        such as requel-cli. Depends on gateway-api + spring-web; no Spring MVC server.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.rreganjr.requel</groupId>
+            <artifactId>gateway-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- RestClient lives in spring-web; version managed by the Spring Boot BOM via the parent. -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <!-- test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/modules/gateway-rest-client/src/main/java/com/rreganjr/requel/gateway/rest/AsMetadata.java
+++ b/modules/gateway-rest-client/src/main/java/com/rreganjr/requel/gateway/rest/AsMetadata.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.rest;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * The subset of RFC 8414 authorization-server metadata the CLI needs, from
+ * {@code GET /.well-known/oauth-authorization-server}: where to send the user to authorize and where
+ * to exchange/refresh tokens. Unknown fields are ignored.
+ *
+ * @param issuer                the AS issuer identifier
+ * @param authorizationEndpoint the authorization endpoint URL (browser)
+ * @param tokenEndpoint         the token endpoint URL (code exchange + refresh)
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record AsMetadata(
+        @JsonProperty("issuer") String issuer,
+        @JsonProperty("authorization_endpoint") String authorizationEndpoint,
+        @JsonProperty("token_endpoint") String tokenEndpoint) {
+}

--- a/modules/gateway-rest-client/src/main/java/com/rreganjr/requel/gateway/rest/BearerTokenSource.java
+++ b/modules/gateway-rest-client/src/main/java/com/rreganjr/requel/gateway/rest/BearerTokenSource.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.rest;
+
+/**
+ * Supplies the bearer token the REST gateway attaches to each request — a personal access token
+ * (PAT, #73) for headless use, or an OAuth access token (#83) for interactive use. Resolved per
+ * request so an OAuth caller can transparently refresh an expired access token behind this source.
+ *
+ * @see RestCommandGateway
+ */
+@FunctionalInterface
+public interface BearerTokenSource {
+
+    /**
+     * @return the current bearer token to send as {@code Authorization: Bearer <token>}, or
+     *         {@code null} to send no Authorization header (the server will then answer 401 for
+     *         protected endpoints).
+     */
+    String currentToken();
+}

--- a/modules/gateway-rest-client/src/main/java/com/rreganjr/requel/gateway/rest/CommandInfo.java
+++ b/modules/gateway-rest-client/src/main/java/com/rreganjr/requel/gateway/rest/CommandInfo.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.rest;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Client-side view of a gateway command descriptor, as returned by
+ * {@code GET /api/gateway/commands/descriptors}. Mirrors the server's {@code DescriptorView}: the
+ * input type is a simple class name (a {@link String}), not a {@code Class}, since the client has no
+ * access to the server's DTO classes. Decoupled from {@link com.rreganjr.requel.gateway.CommandDescriptor}
+ * (which carries a {@code Class<?>} that can't be JSON-deserialized here) so it can be a plain
+ * transport record.
+ *
+ * @param commandType       the registered command type string (e.g. {@code "EditGoal"})
+ * @param inputType         the input DTO's simple class name, or {@code null} if none
+ * @param title             a short human-readable label
+ * @param description       a longer description, or {@code null}
+ * @param write             {@code true} for state-mutating commands
+ * @param authorizationHint a human-readable permission hint, or {@code null}
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CommandInfo(
+        String commandType,
+        String inputType,
+        String title,
+        String description,
+        boolean write,
+        String authorizationHint
+) {
+}

--- a/modules/gateway-rest-client/src/main/java/com/rreganjr/requel/gateway/rest/OAuthClient.java
+++ b/modules/gateway-rest-client/src/main/java/com/rreganjr/requel/gateway/rest/OAuthClient.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.rest;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+/**
+ * The OAuth 2.1 authorization-code + PKCE client the {@code requel} CLI drives for interactive
+ * {@code requel login} (#83 AS, #70 CLI): discover the AS via RFC 8414 metadata, exchange the
+ * authorization code for tokens, and refresh them. Public client — no client secret; PKCE
+ * ({@code code_verifier}) is the proof. The browser redirect + loopback capture live in the CLI; this
+ * class is just the HTTP calls, so it unit-tests cleanly against a stubbed server.
+ */
+public class OAuthClient {
+
+    private static final String WELL_KNOWN = "/.well-known/oauth-authorization-server";
+
+    private final RestClient http;
+
+    /** @param baseUrl the Requel server base URL (e.g. {@code http://localhost:8080}). */
+    public OAuthClient(String baseUrl) {
+        this(RestClient.builder().baseUrl(baseUrl).build());
+    }
+
+    /** For tests: inject a preconfigured (e.g. MockRestServiceServer-bound) client. */
+    OAuthClient(RestClient http) {
+        this.http = http;
+    }
+
+    /** Fetch the authorization-server metadata (authorization + token endpoints). */
+    public AsMetadata discover() {
+        return http.get().uri(WELL_KNOWN).retrieve().body(AsMetadata.class);
+    }
+
+    /** Exchange an authorization {@code code} (with its PKCE {@code codeVerifier}) for tokens. */
+    public OAuthTokens exchangeAuthorizationCode(String tokenEndpoint, String clientId,
+            String redirectUri, String code, String codeVerifier) {
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add("grant_type", "authorization_code");
+        form.add("client_id", clientId);
+        form.add("redirect_uri", redirectUri);
+        form.add("code", code);
+        form.add("code_verifier", codeVerifier);
+        return post(tokenEndpoint, form);
+    }
+
+    /** Redeem a refresh token for a fresh access (and rotated refresh) token. */
+    public OAuthTokens refresh(String tokenEndpoint, String clientId, String refreshToken) {
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add("grant_type", "refresh_token");
+        form.add("client_id", clientId);
+        form.add("refresh_token", refreshToken);
+        return post(tokenEndpoint, form);
+    }
+
+    private OAuthTokens post(String tokenEndpoint, MultiValueMap<String, String> form) {
+        Map<String, Object> body = http.post().uri(tokenEndpoint)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(form)
+                .retrieve()
+                .body(new ParameterizedTypeReference<>() { });
+        return toTokens(body);
+    }
+
+    private static OAuthTokens toTokens(Map<String, Object> body) {
+        if (body == null || body.get("access_token") == null) {
+            throw new IllegalStateException("Token response missing access_token");
+        }
+        String accessToken = String.valueOf(body.get("access_token"));
+        Object refresh = body.get("refresh_token");
+        Object scope = body.get("scope");
+        long expiresIn = body.get("expires_in") instanceof Number n ? n.longValue() : 0L;
+        Instant expiresAt = Instant.now().plus(Duration.ofSeconds(expiresIn));
+        return new OAuthTokens(accessToken,
+                refresh == null ? null : String.valueOf(refresh),
+                scope == null ? null : String.valueOf(scope),
+                expiresAt);
+    }
+}

--- a/modules/gateway-rest-client/src/main/java/com/rreganjr/requel/gateway/rest/OAuthTokens.java
+++ b/modules/gateway-rest-client/src/main/java/com/rreganjr/requel/gateway/rest/OAuthTokens.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.rest;
+
+import java.time.Instant;
+
+/**
+ * The tokens from an OAuth token response, as the {@code requel} CLI stores and uses them. The
+ * refresh token may be {@code null} (e.g. a response that didn't rotate one, though Requel's AS
+ * always issues one). {@code expiresAt} is computed from {@code expires_in} at fetch time.
+ *
+ * @param accessToken  the bearer access token
+ * @param refreshToken the rotating refresh token, or {@code null}
+ * @param scope        the granted scope (space-delimited), or {@code null}
+ * @param expiresAt    the access token's expiry instant
+ */
+public record OAuthTokens(String accessToken, String refreshToken, String scope, Instant expiresAt) {
+
+    /**
+     * @return {@code true} if the access token is expired (or within {@code skew} of expiry) at
+     *         {@code now}, so the caller should refresh before using it. A {@code null}
+     *         {@code expiresAt} is treated as expired.
+     */
+    public boolean isExpired(Instant now, java.time.Duration skew) {
+        return expiresAt == null || !now.plus(skew).isBefore(expiresAt);
+    }
+}

--- a/modules/gateway-rest-client/src/main/java/com/rreganjr/requel/gateway/rest/RestClients.java
+++ b/modules/gateway-rest-client/src/main/java/com/rreganjr/requel/gateway/rest/RestClients.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.rest;
+
+import org.springframework.web.client.RestClient;
+
+/** Shared construction of the bearer-authenticated {@link RestClient} used by the REST gateways. */
+final class RestClients {
+
+    private RestClients() {
+    }
+
+    /**
+     * A {@link RestClient} against {@code baseUrl} that attaches {@code Authorization: Bearer <token>}
+     * from {@code tokenSource} on every request (resolved per request, so an OAuth caller can refresh
+     * behind the source). No header is sent when the source yields {@code null}/blank.
+     */
+    static RestClient bearer(String baseUrl, BearerTokenSource tokenSource) {
+        return RestClient.builder()
+                .baseUrl(baseUrl)
+                .requestInterceptor((request, body, execution) -> {
+                    String token = tokenSource.currentToken();
+                    if (token != null && !token.isBlank()) {
+                        request.getHeaders().setBearerAuth(token);
+                    }
+                    return execution.execute(request, body);
+                })
+                .build();
+    }
+}

--- a/modules/gateway-rest-client/src/main/java/com/rreganjr/requel/gateway/rest/RestCommandGateway.java
+++ b/modules/gateway-rest-client/src/main/java/com/rreganjr/requel/gateway/rest/RestCommandGateway.java
@@ -1,0 +1,127 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.rest;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.rreganjr.requel.gateway.CommandGateway;
+import com.rreganjr.requel.gateway.GatewayException;
+import com.rreganjr.requel.gateway.GatewayRequest;
+import com.rreganjr.requel.gateway.GatewayResult;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+
+import java.util.Map;
+
+/**
+ * REST-backed {@link CommandGateway}: dispatches write commands to a running Requel via
+ * {@code POST /api/gateway/commands/{commandType}} — the server-side gateway facade
+ * ({@code GatewayCommandController}), so the allow/deny policy and per-stakeholder authorization are
+ * enforced <em>server-side</em> (the client never has to be trusted with the boundary). Out-of-process
+ * front-ends such as {@code requel-cli} use this to reuse the same command/authorization/audit path
+ * as the UI.
+ *
+ * <p>The request input is serialized as the JSON body; the server binds it to the command's
+ * registered input DTO. On failure the server returns a JSON body carrying the exact
+ * {@link GatewayException.Kind}, which is reconstructed here (falling back to an HTTP-status mapping
+ * if the body is absent). An {@code X-Requel-Client} header carries the client id for audit
+ * attribution (defaults to {@code requel-cli}); authentication is whatever {@link BearerTokenSource}
+ * yields — a PAT (#73) or an OAuth access token (#83).
+ */
+public class RestCommandGateway implements CommandGateway {
+
+    /** Default client id sent for audit attribution when the request carries none. */
+    static final String DEFAULT_CLIENT_ID = "requel-cli";
+
+    private final RestClient http;
+
+    public RestCommandGateway(String baseUrl, BearerTokenSource tokenSource) {
+        this(RestClients.bearer(baseUrl, tokenSource));
+    }
+
+    /** For tests: inject a preconfigured (e.g. MockRestServiceServer-bound) client. */
+    RestCommandGateway(RestClient http) {
+        this.http = http;
+    }
+
+    @Override
+    public GatewayResult execute(GatewayRequest request) throws GatewayException {
+        String clientId = request.clientId() != null ? request.clientId() : DEFAULT_CLIENT_ID;
+        Object input = request.input() != null ? request.input() : Map.of();
+
+        try {
+            Object result = http.post()
+                    .uri("/api/gateway/commands/{commandType}", request.commandType())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("X-Requel-Client", clientId)
+                    .body(input)
+                    .retrieve()
+                    .body(Object.class);
+            return new GatewayResult(request.commandType(), result);
+
+        } catch (RestClientResponseException e) {
+            throw toGatewayException(e);
+        } catch (RestClientException e) {
+            // Connection refused, timeout, malformed response, etc.
+            throw new GatewayException(GatewayException.Kind.EXECUTION_ERROR,
+                    "Failed to reach Requel: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Reconstruct the gateway failure from the server's error body (authoritative {@code kind}),
+     * falling back to a status-code mapping if the body isn't the expected shape (e.g. a 401 with an
+     * empty body from the security layer, before the request reaches the gateway controller).
+     */
+    private static GatewayException toGatewayException(RestClientResponseException e) {
+        try {
+            GatewayErrorBody body = e.getResponseBodyAs(GatewayErrorBody.class);
+            if (body != null && body.kind() != null) {
+                return new GatewayException(GatewayException.Kind.valueOf(body.kind()),
+                        body.message() != null ? body.message() : e.getStatusText(), e);
+            }
+        } catch (RuntimeException ignored) {
+            // Body wasn't a GatewayErrorBody (or kind was not a known enum name) — fall back.
+        }
+        return new GatewayException(kindFor(e.getStatusCode()), fallbackMessage(e), e);
+    }
+
+    private static GatewayException.Kind kindFor(HttpStatusCode status) {
+        return switch (status.value()) {
+            case 400 -> GatewayException.Kind.INVALID_INPUT;
+            case 401, 403 -> GatewayException.Kind.UNAUTHORIZED;
+            case 404 -> GatewayException.Kind.NOT_FOUND;
+            default -> GatewayException.Kind.EXECUTION_ERROR;
+        };
+    }
+
+    private static String fallbackMessage(RestClientResponseException e) {
+        String body = e.getResponseBodyAsString();
+        return (body != null && !body.isBlank()) ? body : e.getStatusText();
+    }
+
+    /** Mirror of {@code GatewayCommandController.GatewayErrorBody}; decoupled to avoid a dependency. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record GatewayErrorBody(String kind, String message) {
+    }
+}

--- a/modules/gateway-rest-client/src/main/java/com/rreganjr/requel/gateway/rest/RestGatewayCatalog.java
+++ b/modules/gateway-rest-client/src/main/java/com/rreganjr/requel/gateway/rest/RestGatewayCatalog.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.rest;
+
+import java.util.List;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Fetches the server's write-command catalog from
+ * {@code GET /api/gateway/commands/descriptors}. This is how out-of-process front-ends (e.g.
+ * {@code requel commands}) discover the invocable command surface at runtime, so the CLI reflects
+ * exactly what the running server exposes — including that the list is <em>empty</em> when the
+ * server has writes disabled ({@code requel.gateway.write.enabled=false}), mirroring how the MCP
+ * server hides its write tools.
+ *
+ * <p>On an HTTP error the underlying {@link RestClient} throws
+ * {@link org.springframework.web.client.RestClientResponseException} (unchecked), which a front-end
+ * maps to an exit code / message.
+ */
+public class RestGatewayCatalog {
+
+    private final RestClient http;
+
+    public RestGatewayCatalog(String baseUrl, BearerTokenSource tokenSource) {
+        this(RestClients.bearer(baseUrl, tokenSource));
+    }
+
+    /** For tests: inject a preconfigured (e.g. MockRestServiceServer-bound) client. */
+    RestGatewayCatalog(RestClient http) {
+        this.http = http;
+    }
+
+    /** @return the write commands the server currently exposes; empty when writes are disabled. */
+    public List<CommandInfo> descriptors() {
+        return http.get().uri("/api/gateway/commands/descriptors")
+                .retrieve().body(new ParameterizedTypeReference<>() { });
+    }
+}

--- a/modules/gateway-rest-client/src/main/java/com/rreganjr/requel/gateway/rest/RestQueryGateway.java
+++ b/modules/gateway-rest-client/src/main/java/com/rreganjr/requel/gateway/rest/RestQueryGateway.java
@@ -1,0 +1,127 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.rest;
+
+import com.rreganjr.requel.gateway.QueryGateway;
+import com.rreganjr.requel.service.api.dto.AnnotationsDto;
+import com.rreganjr.requel.service.api.dto.EntityReferenceDto;
+import com.rreganjr.requel.service.api.dto.GlossaryTermDto;
+import com.rreganjr.requel.service.api.dto.OpenIssueDto;
+import com.rreganjr.requel.service.api.dto.ProjectDto;
+import com.rreganjr.requel.service.api.dto.ProjectTreeNodeDto;
+import java.util.List;
+import java.util.Map;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.web.client.RestClient;
+
+/**
+ * REST-backed {@link QueryGateway}: the read side of {@code gateway-rest-client}, calling the
+ * {@code /api/gateway/query/**} facade (which delegates to the in-process query gateway, so read
+ * authorization is enforced server-side exactly as in the UI). Front-ends such as {@code requel-cli}
+ * consume the same {@link QueryGateway} contract regardless of in-process vs. REST.
+ *
+ * <p>The interface declares no checked exceptions; on an HTTP error the underlying
+ * {@link RestClient} throws {@link org.springframework.web.client.RestClientResponseException}
+ * (unchecked), which a front-end can map to an exit code / message.
+ */
+public class RestQueryGateway implements QueryGateway {
+
+    private static final String BASE = "/api/gateway/query";
+
+    private final RestClient http;
+
+    public RestQueryGateway(String baseUrl, BearerTokenSource tokenSource) {
+        this(RestClients.bearer(baseUrl, tokenSource));
+    }
+
+    /** For tests: inject a preconfigured (e.g. MockRestServiceServer-bound) client. */
+    RestQueryGateway(RestClient http) {
+        this.http = http;
+    }
+
+    @Override
+    public List<ProjectDto> listProjects() {
+        return http.get().uri(BASE + "/projects")
+                .retrieve().body(new ParameterizedTypeReference<>() { });
+    }
+
+    @Override
+    public ProjectDto getProject(String projectName) {
+        return http.get().uri(BASE + "/projects/{name}", projectName)
+                .retrieve().body(ProjectDto.class);
+    }
+
+    @Override
+    public List<ProjectTreeNodeDto> getProjectTree(String projectName) {
+        return http.get().uri(BASE + "/projects/{name}/tree", projectName)
+                .retrieve().body(new ParameterizedTypeReference<>() { });
+    }
+
+    @Override
+    public List<GlossaryTermDto> getGlossaryTerms(String projectName) {
+        return http.get().uri(BASE + "/projects/{name}/glossary", projectName)
+                .retrieve().body(new ParameterizedTypeReference<>() { });
+    }
+
+    @Override
+    public List<OpenIssueDto> getOpenIssues(String projectName) {
+        return http.get().uri(BASE + "/projects/{name}/open-issues", projectName)
+                .retrieve().body(new ParameterizedTypeReference<>() { });
+    }
+
+    @Override
+    public AnnotationsDto getAnnotations(String projectName, String entityType, long entityId) {
+        return http.get()
+                .uri(BASE + "/projects/{name}/annotations?entityType={type}&entityId={id}",
+                        projectName, entityType, entityId)
+                .retrieve().body(AnnotationsDto.class);
+    }
+
+    @Override
+    public Object getEntity(String projectName, String entityType, long entityId) {
+        return http.get()
+                .uri(BASE + "/projects/{name}/entity?entityType={type}&entityId={id}",
+                        projectName, entityType, entityId)
+                .retrieve().body(Object.class);
+    }
+
+    @Override
+    public Map<String, List<EntityReferenceDto>> getEntityNeighbors(String projectName,
+            String entityType, long entityId) {
+        return http.get()
+                .uri(BASE + "/projects/{name}/entity/neighbors?entityType={type}&entityId={id}",
+                        projectName, entityType, entityId)
+                .retrieve().body(new ParameterizedTypeReference<>() { });
+    }
+
+    @Override
+    public List<EntityReferenceDto> searchProjectEntities(String projectName, String query) {
+        return http.get()
+                .uri(BASE + "/projects/{name}/search?q={q}", projectName, query)
+                .retrieve().body(new ParameterizedTypeReference<>() { });
+    }
+
+    @Override
+    public Map<String, Object> getProjectContext(String projectName) {
+        return http.get().uri(BASE + "/projects/{name}/context", projectName)
+                .retrieve().body(new ParameterizedTypeReference<>() { });
+    }
+}

--- a/modules/gateway-rest-client/src/test/java/com/rreganjr/requel/gateway/rest/OAuthClientTest.java
+++ b/modules/gateway-rest-client/src/test/java/com/rreganjr/requel/gateway/rest/OAuthClientTest.java
@@ -1,0 +1,110 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class OAuthClientTest {
+
+    private record Fixture(OAuthClient client, MockRestServiceServer server) {
+    }
+
+    private static Fixture newFixture() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        return new Fixture(new OAuthClient(builder.build()), server);
+    }
+
+    @Test
+    void discoverParsesEndpoints() {
+        Fixture f = newFixture();
+        f.server().expect(requestTo("/.well-known/oauth-authorization-server"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("""
+                        {"issuer":"http://localhost:8080",
+                         "authorization_endpoint":"http://localhost:8080/oauth2/authorize",
+                         "token_endpoint":"http://localhost:8080/oauth2/token"}
+                        """, MediaType.APPLICATION_JSON));
+
+        AsMetadata meta = f.client().discover();
+
+        assertThat(meta.authorizationEndpoint()).isEqualTo("http://localhost:8080/oauth2/authorize");
+        assertThat(meta.tokenEndpoint()).isEqualTo("http://localhost:8080/oauth2/token");
+        f.server().verify();
+    }
+
+    @Test
+    void exchangeAuthorizationCodePostsFormAndComputesExpiry() {
+        Fixture f = newFixture();
+        f.server().expect(requestTo("http://localhost:8080/oauth2/token"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "grant_type=authorization_code")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("code_verifier=verifier")))
+                .andRespond(withSuccess("""
+                        {"access_token":"AT","refresh_token":"RT","scope":"mcp",
+                         "token_type":"Bearer","expires_in":3600}
+                        """, MediaType.APPLICATION_JSON));
+
+        Instant before = Instant.now();
+        OAuthTokens tokens = f.client().exchangeAuthorizationCode(
+                "http://localhost:8080/oauth2/token", "requel-cli",
+                "http://127.0.0.1:5555/callback", "the-code", "verifier");
+
+        assertThat(tokens.accessToken()).isEqualTo("AT");
+        assertThat(tokens.refreshToken()).isEqualTo("RT");
+        assertThat(tokens.scope()).isEqualTo("mcp");
+        assertThat(tokens.expiresAt()).isAfter(before.plus(Duration.ofSeconds(3000)));
+        assertThat(tokens.isExpired(Instant.now(), Duration.ofSeconds(60))).isFalse();
+        f.server().verify();
+    }
+
+    @Test
+    void refreshPostsRefreshGrant() {
+        Fixture f = newFixture();
+        f.server().expect(requestTo("http://localhost:8080/oauth2/token"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("grant_type=refresh_token")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("refresh_token=OLD")))
+                .andRespond(withSuccess("""
+                        {"access_token":"AT2","refresh_token":"NEW","scope":"mcp","expires_in":3600}
+                        """, MediaType.APPLICATION_JSON));
+
+        OAuthTokens tokens = f.client().refresh(
+                "http://localhost:8080/oauth2/token", "requel-cli", "OLD");
+
+        assertThat(tokens.accessToken()).isEqualTo("AT2");
+        assertThat(tokens.refreshToken()).isEqualTo("NEW");
+        f.server().verify();
+    }
+}

--- a/modules/gateway-rest-client/src/test/java/com/rreganjr/requel/gateway/rest/RestCommandGatewayTest.java
+++ b/modules/gateway-rest-client/src/test/java/com/rreganjr/requel/gateway/rest/RestCommandGatewayTest.java
@@ -1,0 +1,128 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.rreganjr.requel.gateway.GatewayException;
+import com.rreganjr.requel.gateway.GatewayRequest;
+import com.rreganjr.requel.gateway.GatewayResult;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class RestCommandGatewayTest {
+
+    private record Fixture(RestCommandGateway gateway, MockRestServiceServer server) {
+    }
+
+    private static Fixture newFixture() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        return new Fixture(new RestCommandGateway(builder.build()), server);
+    }
+
+    @Test
+    void dispatchesToGatewayEndpointAndReturnsResult() throws Exception {
+        Fixture f = newFixture();
+        f.server().expect(requestTo("/api/gateway/commands/EditGoal"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header("X-Requel-Client", "requel-cli"))
+                .andExpect(jsonPath("$.name").value("My Goal"))
+                .andRespond(withSuccess("{\"id\":7,\"name\":\"My Goal\"}", MediaType.APPLICATION_JSON));
+
+        GatewayResult result = f.gateway().execute(new GatewayRequest("EditGoal", Map.of("name", "My Goal")));
+
+        assertThat(result.commandType()).isEqualTo("EditGoal");
+        assertThat(result.result()).isInstanceOf(Map.class);
+        assertThat(((Map<?, ?>) result.result()).get("id")).isEqualTo(7);
+        f.server().verify();
+    }
+
+    @Test
+    void notAllowedKindComesFromErrorBody() {
+        Fixture f = newFixture();
+        f.server().expect(requestTo("/api/gateway/commands/DeleteUser"))
+                .andRespond(withStatus(HttpStatus.FORBIDDEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"kind\":\"NOT_ALLOWED\",\"message\":\"command 'DeleteUser' is denylisted\"}"));
+
+        assertThatThrownBy(() -> f.gateway().execute(new GatewayRequest("DeleteUser", Map.of())))
+                .isInstanceOf(GatewayException.class)
+                .satisfies(e -> {
+                    assertThat(((GatewayException) e).getKind()).isEqualTo(GatewayException.Kind.NOT_ALLOWED);
+                    assertThat(e.getMessage()).contains("denylisted");
+                });
+    }
+
+    @Test
+    void unauthorizedAndNotAllowedShareStatusButAreDistinguishedByBodyKind() {
+        Fixture f = newFixture();
+        f.server().expect(requestTo("/api/gateway/commands/EditGoal"))
+                .andRespond(withStatus(HttpStatus.FORBIDDEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"kind\":\"UNAUTHORIZED\",\"message\":\"no permission\"}"));
+
+        assertThatThrownBy(() -> f.gateway().execute(new GatewayRequest("EditGoal", Map.of())))
+                .isInstanceOf(GatewayException.class)
+                .satisfies(e -> assertThat(((GatewayException) e).getKind())
+                        .isEqualTo(GatewayException.Kind.UNAUTHORIZED));
+    }
+
+    @Test
+    void notFoundKindComesFromErrorBody() {
+        Fixture f = newFixture();
+        f.server().expect(requestTo("/api/gateway/commands/NoSuchCommand"))
+                .andRespond(withStatus(HttpStatus.NOT_FOUND)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"kind\":\"NOT_FOUND\",\"message\":\"Unknown command type: NoSuchCommand\"}"));
+
+        assertThatThrownBy(() -> f.gateway().execute(new GatewayRequest("NoSuchCommand", Map.of())))
+                .isInstanceOf(GatewayException.class)
+                .satisfies(e -> assertThat(((GatewayException) e).getKind())
+                        .isEqualTo(GatewayException.Kind.NOT_FOUND));
+    }
+
+    @Test
+    void emptyBodyFallsBackToStatusMapping() {
+        // Simulates a 401 from the security layer (before the request reaches the gateway controller),
+        // which has no GatewayErrorBody — the client falls back to mapping the status.
+        Fixture f = newFixture();
+        f.server().expect(requestTo("/api/gateway/commands/EditGoal"))
+                .andRespond(withStatus(HttpStatus.UNAUTHORIZED));
+
+        assertThatThrownBy(() -> f.gateway().execute(new GatewayRequest("EditGoal", Map.of())))
+                .isInstanceOf(GatewayException.class)
+                .satisfies(e -> assertThat(((GatewayException) e).getKind())
+                        .isEqualTo(GatewayException.Kind.UNAUTHORIZED));
+    }
+}

--- a/modules/gateway-rest-client/src/test/java/com/rreganjr/requel/gateway/rest/RestGatewayCatalogTest.java
+++ b/modules/gateway-rest-client/src/test/java/com/rreganjr/requel/gateway/rest/RestGatewayCatalogTest.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class RestGatewayCatalogTest {
+
+    private record Fixture(RestGatewayCatalog catalog, MockRestServiceServer server) {
+    }
+
+    private static Fixture newFixture() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        return new Fixture(new RestGatewayCatalog(builder.build()), server);
+    }
+
+    @Test
+    void descriptorsCallsTheCatalogEndpointAndParsesTheView() {
+        Fixture f = newFixture();
+        f.server().expect(requestTo("/api/gateway/commands/descriptors"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("""
+                        [{"commandType":"EditGoal","inputType":"EditGoalInput","title":"Edit Goal",
+                          "description":null,"write":true,"authorizationHint":null}]
+                        """, MediaType.APPLICATION_JSON));
+
+        List<CommandInfo> commands = f.catalog().descriptors();
+
+        assertThat(commands).singleElement().satisfies(c -> {
+            assertThat(c.commandType()).isEqualTo("EditGoal");
+            assertThat(c.inputType()).isEqualTo("EditGoalInput");
+            assertThat(c.title()).isEqualTo("Edit Goal");
+            assertThat(c.write()).isTrue();
+        });
+        f.server().verify();
+    }
+
+    @Test
+    void emptyListWhenServerExposesNoWriteCommands() {
+        Fixture f = newFixture();
+        f.server().expect(requestTo("/api/gateway/commands/descriptors"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("[]", MediaType.APPLICATION_JSON));
+
+        assertThat(f.catalog().descriptors()).isEmpty();
+        f.server().verify();
+    }
+}

--- a/modules/gateway-rest-client/src/test/java/com/rreganjr/requel/gateway/rest/RestQueryGatewayTest.java
+++ b/modules/gateway-rest-client/src/test/java/com/rreganjr/requel/gateway/rest/RestQueryGatewayTest.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class RestQueryGatewayTest {
+
+    private record Fixture(RestQueryGateway gateway, MockRestServiceServer server) {
+    }
+
+    private static Fixture newFixture() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        return new Fixture(new RestQueryGateway(builder.build()), server);
+    }
+
+    @Test
+    void listProjectsCallsGatewayEndpoint() {
+        Fixture f = newFixture();
+        f.server().expect(requestTo("/api/gateway/query/projects"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("[]", MediaType.APPLICATION_JSON));
+
+        List<?> projects = f.gateway().listProjects();
+
+        assertThat(projects).isEmpty();
+        f.server().verify();
+    }
+
+    @Test
+    void getEntityPassesTypeAndIdAsQueryParams() {
+        Fixture f = newFixture();
+        f.server().expect(requestTo("/api/gateway/query/projects/Demo/entity?entityType=Goal&entityId=7"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("{\"id\":7,\"name\":\"My Goal\"}", MediaType.APPLICATION_JSON));
+
+        Object entity = f.gateway().getEntity("Demo", "Goal", 7L);
+
+        assertThat(entity).isInstanceOf(Map.class);
+        assertThat(((Map<?, ?>) entity).get("name")).isEqualTo("My Goal");
+        f.server().verify();
+    }
+
+    @Test
+    void getProjectContextReturnsKeyedBundle() {
+        Fixture f = newFixture();
+        f.server().expect(requestTo("/api/gateway/query/projects/Demo/context"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("{\"project\":{\"name\":\"Demo\"},\"openIssues\":[]}",
+                        MediaType.APPLICATION_JSON));
+
+        Map<String, Object> context = f.gateway().getProjectContext("Demo");
+
+        assertThat(context).containsKeys("project", "openIssues");
+        f.server().verify();
+    }
+}

--- a/modules/requel-app/src/main/resources/application.properties
+++ b/modules/requel-app/src/main/resources/application.properties
@@ -140,6 +140,12 @@ spring.ai.mcp.server.sse-message-endpoint=/api/mcp/message
 # flow is testable before Dynamic Client Registration (Slice 4) lands. Off by default; dev only.
 requel.oauth.seed-dev-client=false
 #
+# Seed the first-party "requel-cli" OAuth client (public/PKCE/loopback, scope=mcp, consent required)
+# so `requel login --oauth` works without minting a DCR initial token (issue #70, Milestone 5). The
+# registered redirect is the port-less loopback http://127.0.0.1/callback; Spring AS relaxes the port
+# for loopback redirect URIs (RFC 8252), so the CLI's ephemeral callback port matches. Off by default.
+requel.oauth.seed-cli-client=false
+#
 # Dynamic Client Registration (Slice 4). The OIDC client-registration endpoint (/connect/register)
 # is always enabled but is UNUSABLE until a registrar client exists: Spring AS requires an initial
 # access token (client_credentials + scope client.create), single-use, ~5 min TTL. Set

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/service/config/RequelCliOAuthClientTest.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/service/config/RequelCliOAuthClientTest.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+
+/**
+ * Unit test for the seeded {@code requel-cli} OAuth client (#70, Milestone 5): asserts the security
+ * shape the CLI's {@code requel login} depends on — public/PKCE, loopback redirect, consent, the
+ * {@code mcp} scope, and authorization-code + refresh with the standard 1h/30d token settings.
+ */
+class RequelCliOAuthClientTest {
+
+    private final RegisteredClient client = AuthorizationServerConfig.requelCliRegisteredClient();
+
+    @Test
+    void isPublicPkceLoopbackClientScopedToMcp() {
+        assertThat(client.getClientId()).isEqualTo(AuthorizationServerConfig.CLI_CLIENT_ID);
+        assertThat(client.getClientAuthenticationMethods())
+                .containsExactly(ClientAuthenticationMethod.NONE);
+        assertThat(client.getAuthorizationGrantTypes())
+                .containsExactlyInAnyOrder(AuthorizationGrantType.AUTHORIZATION_CODE,
+                        AuthorizationGrantType.REFRESH_TOKEN);
+        assertThat(client.getScopes()).containsExactly("mcp");
+        assertThat(client.getRedirectUris()).containsExactly(AuthorizationServerConfig.CLI_REDIRECT_URI);
+        assertThat(AuthorizationServerConfig.CLI_REDIRECT_URI).startsWith("http://127.0.0.1");
+    }
+
+    @Test
+    void requiresPkceAndConsent() {
+        assertThat(client.getClientSettings().isRequireProofKey()).isTrue();
+        assertThat(client.getClientSettings().isRequireAuthorizationConsent()).isTrue();
+    }
+
+    @Test
+    void usesTheStandardRotatingTokenSettings() {
+        assertThat(client.getTokenSettings().getAccessTokenTimeToLive()).isEqualTo(Duration.ofHours(1));
+        assertThat(client.getTokenSettings().getRefreshTokenTimeToLive()).isEqualTo(Duration.ofDays(30));
+        assertThat(client.getTokenSettings().isReuseRefreshTokens()).isFalse();
+    }
+}

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/service/gateway/GatewayCommandCatalogImplTest.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/service/gateway/GatewayCommandCatalogImplTest.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.rreganjr.requel.gateway.CommandDescriptor;
+import com.rreganjr.requel.service.api.CommandRegistry;
+import com.rreganjr.requel.service.command.ApiCommandFactory;
+import org.junit.jupiter.api.Test;
+
+class GatewayCommandCatalogImplTest {
+
+    @Test
+    void catalogCoversEveryRegisteredAllowedCommandAsAWrite() {
+        CommandRegistry registry = mock(CommandRegistry.class);
+        when(registry.isRegistered(anyString())).thenReturn(true);
+        ApiCommandFactory factory = mock(ApiCommandFactory.class);
+        // doReturn(...) avoids the Class<?> generic-capture mismatch that when(...).thenReturn hits.
+        doReturn(Object.class).when(factory).getInputType(anyString());
+
+        GatewayCommandCatalogImpl catalog = new GatewayCommandCatalogImpl(registry, factory);
+
+        assertThat(catalog.descriptors())
+                .extracting(CommandDescriptor::commandType)
+                .containsExactlyInAnyOrderElementsOf(GatewayPolicyConfig.ALLOWED);
+        assertThat(catalog.descriptors()).allMatch(CommandDescriptor::write);
+        // Allowed commands are present; denied ones (e.g. user management) are not.
+        assertThat(catalog.find("EditGoal")).isPresent();
+        assertThat(catalog.find("EditUser")).isEmpty();
+    }
+
+    @Test
+    void skipsCommandsNotRegisteredInThisDeployment() {
+        CommandRegistry registry = mock(CommandRegistry.class);
+        when(registry.isRegistered(anyString())).thenReturn(false);
+        ApiCommandFactory factory = mock(ApiCommandFactory.class);
+
+        GatewayCommandCatalogImpl catalog = new GatewayCommandCatalogImpl(registry, factory);
+
+        assertThat(catalog.descriptors()).isEmpty();
+    }
+
+    @Test
+    void humanizeSplitsPascalCase() {
+        assertThat(GatewayCommandCatalogImpl.humanize("EditGoal")).isEqualTo("Edit Goal");
+        assertThat(GatewayCommandCatalogImpl.humanize("AddScenarioToUseCase"))
+                .isEqualTo("Add Scenario To Use Case");
+    }
+}

--- a/modules/requel-cli/pom.xml
+++ b/modules/requel-cli/pom.xml
@@ -88,6 +88,18 @@
                                         <exclude>META-INF/*.RSA</exclude>
                                     </excludes>
                                 </filter>
+                                <!-- A transitive dep drags in the legacy commons-logging, which owns the
+                                     same org.apache.commons.logging.* package as Spring's spring-jcl. Both
+                                     in one jar makes commons-logging print "Standard Commons Logging
+                                     discovery in action with spring-jcl…" to stdout, corrupting piped
+                                     output (e.g. JSON output through jq). Drop the legacy artifact;
+                                     spring-jcl supplies those classes. -->
+                                <filter>
+                                    <artifact>commons-logging:commons-logging</artifact>
+                                    <excludes>
+                                        <exclude>**</exclude>
+                                    </excludes>
+                                </filter>
                             </filters>
                         </configuration>
                     </execution>

--- a/modules/requel-cli/pom.xml
+++ b/modules/requel-cli/pom.xml
@@ -45,4 +45,54 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <!--
+              Package requel-cli as a single self-contained executable jar (fat/uber jar):
+              `java -jar target/requel-cli-<version>.jar <args>`. requel-cli is NOT a Spring Boot
+              application, so we use maven-shade (a plain executable jar with a Main-Class), not the
+              Spring Boot repackager. ServicesResourceTransformer merges META-INF/services so Jackson
+              module auto-registration and any ServiceLoader wiring survive the merge. Version is
+              managed by spring-boot-starter-parent's pluginManagement.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration combine.self="override">
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <!-- combine.self="override" replaces spring-boot-starter-parent's managed
+                                 shade configuration wholesale; its transformer entries carry <resource>
+                                 elements that otherwise merge element-wise onto ours and fail to parse. -->
+                            <transformers>
+                                <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.rreganjr.requel.cli.RequelCli</mainClass>
+                                </transformer>
+                                <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                                <!-- Drop signature files from signed dependencies; they break a merged jar. -->
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/modules/requel-cli/pom.xml
+++ b/modules/requel-cli/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.rreganjr.requel</groupId>
+        <artifactId>Requel-parent</artifactId>
+        <version>2.0.0-dev</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>requel-cli</artifactId>
+    <name>Requel CLI</name>
+    <description>Command-line front-end over the Requel gateway (issue #70, Phase A). A picocli app
+        that dispatches commands through the REST-backed gateway client with a PAT or OAuth token.
+        Not a Spring Boot server.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.rreganjr.requel</groupId>
+            <artifactId>gateway-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.rreganjr.requel</groupId>
+            <artifactId>gateway-rest-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+            <version>4.7.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <!-- test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/CliTokenSource.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/CliTokenSource.java
@@ -1,0 +1,98 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import com.rreganjr.requel.gateway.rest.AsMetadata;
+import com.rreganjr.requel.gateway.rest.BearerTokenSource;
+import com.rreganjr.requel.gateway.rest.OAuthClient;
+import com.rreganjr.requel.gateway.rest.OAuthTokens;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.function.Function;
+
+/**
+ * Resolves the bearer token for each REST call, in precedence order:
+ * <ol>
+ *   <li>an explicit token ({@code --token} flag / {@code REQUEL_TOKEN} env);</li>
+ *   <li>OAuth tokens stored by {@code requel login} — the access token, transparently refreshed via
+ *       the rotating refresh token when it is at/near expiry (the store is updated with the rotated
+ *       tokens);</li>
+ *   <li>a stored PAT (#73) for the URL.</li>
+ * </ol>
+ * Returns {@code null} when nothing is configured (no Authorization header is sent). If a refresh
+ * fails, the (stale) access token is returned so the server — not the client — decides; the user then
+ * re-runs {@code requel login}.
+ */
+public class CliTokenSource implements BearerTokenSource {
+
+    /** The first-party client id; must match the seeded {@code requel-cli} AS client. */
+    public static final String CLI_CLIENT_ID = "requel-cli";
+
+    /** Refresh when the access token is within this window of expiry. */
+    private static final Duration EXPIRY_SKEW = Duration.ofSeconds(60);
+
+    private final String explicitToken;
+    private final String url;
+    private final CredentialStore store;
+    private final Function<String, OAuthClient> oauthClientFactory;
+
+    public CliTokenSource(String explicitToken, String url, CredentialStore store) {
+        this(explicitToken, url, store, OAuthClient::new);
+    }
+
+    /** For tests: inject an {@link OAuthClient} factory (keyed by base URL). */
+    CliTokenSource(String explicitToken, String url, CredentialStore store,
+            Function<String, OAuthClient> oauthClientFactory) {
+        this.explicitToken = explicitToken;
+        this.url = url;
+        this.store = store;
+        this.oauthClientFactory = oauthClientFactory;
+    }
+
+    @Override
+    public String currentToken() {
+        if (explicitToken != null && !explicitToken.isBlank()) {
+            return explicitToken;
+        }
+        OAuthTokens tokens = store.findOAuth(url);
+        if (tokens != null) {
+            return tokens.isExpired(Instant.now(), EXPIRY_SKEW) ? refreshed(tokens) : tokens.accessToken();
+        }
+        return store.find(url);
+    }
+
+    private String refreshed(OAuthTokens stale) {
+        if (stale.refreshToken() == null || stale.refreshToken().isBlank()) {
+            return stale.accessToken();
+        }
+        try {
+            OAuthClient client = oauthClientFactory.apply(url);
+            AsMetadata meta = client.discover();
+            OAuthTokens fresh = client.refresh(meta.tokenEndpoint(), CLI_CLIENT_ID, stale.refreshToken());
+            store.saveOAuth(url, fresh);
+            return fresh.accessToken();
+        } catch (RuntimeException e) {
+            // Refresh failed (expired/revoked/offline): return the stale token and let the server
+            // reject it, prompting the user to re-run `requel login`.
+            return stale.accessToken();
+        }
+    }
+}

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/CommandsCommand.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/CommandsCommand.java
@@ -1,0 +1,98 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rreganjr.requel.gateway.rest.CommandInfo;
+import com.rreganjr.requel.gateway.rest.RestGatewayCatalog;
+import java.util.List;
+import java.util.concurrent.Callable;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.ParentCommand;
+
+/**
+ * {@code requel commands} — lists the write commands the server currently exposes, fetched at
+ * runtime from {@code /api/gateway/commands/descriptors}. The list reflects the live server, so it
+ * is empty when the server has writes disabled ({@code requel.gateway.write.enabled=false}). This is
+ * the runtime-primary discovery from the #70 plan: the CLI's command surface is derived from the
+ * server's catalog rather than hard-coded, keeping CLI and MCP in lockstep with the gateway policy.
+ */
+@Command(name = "commands",
+        description = "List the gateway write commands the server exposes (input: requel run <type>).")
+public class CommandsCommand implements Callable<Integer> {
+
+    @ParentCommand
+    RequelCli parent;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    /** Test seam: when set, used instead of building a {@link RestGatewayCatalog} from the parent. */
+    RestGatewayCatalog catalogOverride;
+
+    @Override
+    public Integer call() {
+        RestGatewayCatalog catalog = (catalogOverride != null) ? catalogOverride
+                : new RestGatewayCatalog(parent.url, parent.tokenSource());
+        List<CommandInfo> commands;
+        try {
+            commands = catalog.descriptors();
+        } catch (RestClientResponseException e) {
+            System.err.println("Error: " + e.getStatusCode() + " " + e.getStatusText());
+            int status = e.getStatusCode().value();
+            return (status == 401 || status == 403) ? ExitCode.AUTH : ExitCode.REQUEST_ERROR;
+        } catch (RestClientException e) {
+            System.err.println("Failed to reach Requel: " + e.getMessage());
+            return ExitCode.REQUEST_ERROR;
+        }
+
+        if (parent.output == OutputFormat.JSON) {
+            printJson(commands);
+        } else {
+            printText(commands);
+        }
+        return ExitCode.SUCCESS;
+    }
+
+    private void printJson(List<CommandInfo> commands) {
+        try {
+            System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(commands));
+        } catch (JsonProcessingException e) {
+            System.out.println(String.valueOf(commands));
+        }
+    }
+
+    private static void printText(List<CommandInfo> commands) {
+        if (commands.isEmpty()) {
+            System.out.println("No commands exposed (server writes may be disabled: "
+                    + "requel.gateway.write.enabled=false).");
+            return;
+        }
+        int width = commands.stream().mapToInt(c -> c.commandType().length()).max().orElse(0);
+        for (CommandInfo c : commands) {
+            String input = c.inputType() != null ? "  (" + c.inputType() + ")" : "";
+            System.out.printf("%-" + width + "s  %s%s%n",
+                    c.commandType(), c.title() != null ? c.title() : "", input);
+        }
+    }
+}

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/CredentialStore.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/CredentialStore.java
@@ -1,0 +1,125 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Properties;
+
+/**
+ * Persists {@code requel} bearer tokens (PATs, #73) per server URL, so a token survives across
+ * invocations without living in {@code --token}/{@code REQUEL_TOKEN}. Stored as a simple properties
+ * file (URL → token) under {@code ~/.config/requel/credentials} (override the directory with
+ * {@code REQUEL_CONFIG_DIR}), created with owner-only permissions on POSIX filesystems. Never a
+ * checked-in location.
+ */
+public class CredentialStore {
+
+    private final Path dir;
+    private final Path file;
+
+    public CredentialStore() {
+        this(defaultDir());
+    }
+
+    /** For tests / custom locations. */
+    public CredentialStore(Path dir) {
+        this.dir = dir;
+        this.file = dir.resolve("credentials");
+    }
+
+    private static Path defaultDir() {
+        String override = System.getenv("REQUEL_CONFIG_DIR");
+        if (override != null && !override.isBlank()) {
+            return Path.of(override);
+        }
+        return Path.of(System.getProperty("user.home"), ".config", "requel");
+    }
+
+    /** @return the stored token for {@code baseUrl}, or {@code null} if none. */
+    public synchronized String find(String baseUrl) {
+        String value = load().getProperty(key(baseUrl));
+        return (value == null || value.isBlank()) ? null : value;
+    }
+
+    /** Store (or replace) the token for {@code baseUrl}. */
+    public synchronized void save(String baseUrl, String token) {
+        Properties props = load();
+        props.setProperty(key(baseUrl), token);
+        write(props);
+    }
+
+    /** Remove any stored token for {@code baseUrl}. */
+    public synchronized void delete(String baseUrl) {
+        Properties props = load();
+        if (props.remove(key(baseUrl)) != null) {
+            write(props);
+        }
+    }
+
+    /** The credentials file location (for messages/tests). */
+    public Path file() {
+        return file;
+    }
+
+    private static String key(String baseUrl) {
+        return baseUrl == null ? "" : baseUrl.trim();
+    }
+
+    private Properties load() {
+        Properties props = new Properties();
+        if (Files.isRegularFile(file)) {
+            try (InputStream in = Files.newInputStream(file)) {
+                props.load(in);
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed to read " + file, e);
+            }
+        }
+        return props;
+    }
+
+    private void write(Properties props) {
+        try {
+            Files.createDirectories(dir);
+            restrict(dir, "rwx------");
+            try (OutputStream out = Files.newOutputStream(file)) {
+                props.store(out, "Requel CLI credentials — do not commit");
+            }
+            restrict(file, "rw-------");
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to write " + file, e);
+        }
+    }
+
+    /** Best-effort owner-only permissions; silently skipped on non-POSIX filesystems (e.g. Windows). */
+    private static void restrict(Path path, String perms) {
+        try {
+            Files.setPosixFilePermissions(path, PosixFilePermissions.fromString(perms));
+        } catch (UnsupportedOperationException | IOException ignored) {
+            // Non-POSIX filesystem — rely on the platform's default ACLs.
+        }
+    }
+}

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/CredentialStore.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/CredentialStore.java
@@ -20,6 +20,7 @@
  */
 package com.rreganjr.requel.cli;
 
+import com.rreganjr.requel.gateway.rest.OAuthTokens;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -27,6 +28,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.time.Instant;
 import java.util.Properties;
 
 /**
@@ -72,12 +74,41 @@ public class CredentialStore {
         write(props);
     }
 
-    /** Remove any stored token for {@code baseUrl}. */
+    /** Remove any stored credentials for {@code baseUrl} — both a PAT and OAuth tokens. */
     public synchronized void delete(String baseUrl) {
         Properties props = load();
-        if (props.remove(key(baseUrl)) != null) {
+        boolean changed = props.remove(key(baseUrl)) != null;
+        for (String suffix : OAUTH_SUFFIXES) {
+            changed |= props.remove(oauthKey(baseUrl, suffix)) != null;
+        }
+        if (changed) {
             write(props);
         }
+    }
+
+    /** Store (or replace) the OAuth tokens for {@code baseUrl}. */
+    public synchronized void saveOAuth(String baseUrl, OAuthTokens tokens) {
+        Properties props = load();
+        props.setProperty(oauthKey(baseUrl, "access"), tokens.accessToken());
+        setOrRemove(props, oauthKey(baseUrl, "refresh"), tokens.refreshToken());
+        setOrRemove(props, oauthKey(baseUrl, "scope"), tokens.scope());
+        setOrRemove(props, oauthKey(baseUrl, "expiresAt"),
+                tokens.expiresAt() == null ? null : Long.toString(tokens.expiresAt().getEpochSecond()));
+        write(props);
+    }
+
+    /** @return the stored OAuth tokens for {@code baseUrl}, or {@code null} if none. */
+    public synchronized OAuthTokens findOAuth(String baseUrl) {
+        Properties props = load();
+        String access = props.getProperty(oauthKey(baseUrl, "access"));
+        if (access == null || access.isBlank()) {
+            return null;
+        }
+        String expiresAt = props.getProperty(oauthKey(baseUrl, "expiresAt"));
+        return new OAuthTokens(access,
+                props.getProperty(oauthKey(baseUrl, "refresh")),
+                props.getProperty(oauthKey(baseUrl, "scope")),
+                expiresAt == null ? null : Instant.ofEpochSecond(Long.parseLong(expiresAt)));
     }
 
     /** The credentials file location (for messages/tests). */
@@ -85,8 +116,23 @@ public class CredentialStore {
         return file;
     }
 
+    private static final String[] OAUTH_SUFFIXES = {"access", "refresh", "scope", "expiresAt"};
+
     private static String key(String baseUrl) {
         return baseUrl == null ? "" : baseUrl.trim();
+    }
+
+    /** OAuth keys are namespaced ({@code oauth.<url>.<field>}) so they never collide with a PAT key. */
+    private static String oauthKey(String baseUrl, String suffix) {
+        return "oauth." + key(baseUrl) + "." + suffix;
+    }
+
+    private static void setOrRemove(Properties props, String key, String value) {
+        if (value == null || value.isBlank()) {
+            props.remove(key);
+        } else {
+            props.setProperty(key, value);
+        }
     }
 
     private Properties load() {

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/ExitCode.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/ExitCode.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import com.rreganjr.requel.gateway.GatewayException;
+
+/**
+ * Process exit codes for {@code requel}, chosen so scripts can branch on outcome. Aligns with
+ * picocli's conventions ({@code 0} ok, {@code 2} usage) and maps {@link GatewayException.Kind} onto
+ * stable codes.
+ */
+public final class ExitCode {
+
+    /** Command succeeded. */
+    public static final int SUCCESS = 0;
+    /** Unexpected/internal error. */
+    public static final int UNEXPECTED = 1;
+    /** Usage error — bad arguments/options (picocli's default). */
+    public static final int USAGE = 2;
+    /** Authentication/authorization failure (401/403 → {@code UNAUTHORIZED}). */
+    public static final int AUTH = 3;
+    /** Command not permitted through the gateway ({@code NOT_ALLOWED}). */
+    public static final int NOT_ALLOWED = 4;
+    /** Request could not be completed: bad input, unknown command, or execution error. */
+    public static final int REQUEST_ERROR = 5;
+
+    private ExitCode() {
+    }
+
+    /** Map a gateway failure category to an exit code. */
+    public static int forKind(GatewayException.Kind kind) {
+        return switch (kind) {
+            case UNAUTHORIZED -> AUTH;
+            case NOT_ALLOWED -> NOT_ALLOWED;
+            case NOT_FOUND, INVALID_INPUT, EXECUTION_ERROR -> REQUEST_ERROR;
+        };
+    }
+}

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/LoginCommand.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/LoginCommand.java
@@ -20,31 +20,143 @@
  */
 package com.rreganjr.requel.cli;
 
+import com.rreganjr.requel.gateway.rest.AsMetadata;
+import com.rreganjr.requel.gateway.rest.OAuthClient;
+import com.rreganjr.requel.gateway.rest.OAuthTokens;
+import java.awt.Desktop;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ParentCommand;
 
 /**
- * Stores a personal access token (PAT, #73) for the current {@code --url}, so later commands
- * authenticate without re-passing {@code --token}. Interactive OAuth login is a later milestone;
- * this milestone covers the headless PAT path.
+ * Stores credentials for the current {@code --url}. Two mutually-exclusive modes:
+ * <ul>
+ *   <li>{@code requel login --token reqpat_…} — headless: save a personal access token (#73).</li>
+ *   <li>{@code requel login --oauth} — interactive: run the OAuth 2.1 authorization-code + PKCE flow
+ *       (#83 AS, seeded {@code requel-cli} client) via a loopback browser redirect, and save the
+ *       resulting access + rotating refresh tokens. Later commands auto-refresh (see
+ *       {@link CliTokenSource}).</li>
+ * </ul>
  */
-@Command(name = "login", description = "Store a bearer token (PAT) for the server URL.")
+@Command(name = "login", description = "Store credentials for the server URL (PAT or OAuth login).")
 public class LoginCommand implements Callable<Integer> {
+
+    /** How long to wait for the user to complete the browser login before giving up. */
+    private static final long LOGIN_TIMEOUT_MINUTES = 5;
 
     @ParentCommand
     RequelCli parent;
 
-    @Option(names = "--token", paramLabel = "TOKEN", required = true,
-            description = "A Requel personal access token (reqpat_...).")
-    String token;
+    @ArgGroup(multiplicity = "1")
+    Mode mode = new Mode();
+
+    /** Exactly one of a PAT or interactive OAuth. */
+    static class Mode {
+        @Option(names = "--token", paramLabel = "TOKEN",
+                description = "A Requel personal access token (reqpat_...).")
+        String token;
+
+        @Option(names = "--oauth",
+                description = "Log in interactively via OAuth (browser); stores refreshable tokens.")
+        boolean oauth;
+    }
+
+    // ---- Test seams -----------------------------------------------------------------------------
+
+    /** When set, used instead of {@code new OAuthClient(parent.url)}. */
+    OAuthClient oauthClientOverride;
+    /** How the authorize URL is opened; defaults to the desktop browser (falls back to printing). */
+    Consumer<String> browserOpener = LoginCommand::openInBrowser;
+
+    private final SecureRandom random = new SecureRandom();
 
     @Override
     public Integer call() {
-        parent.credentialStore.save(parent.url, token);
-        System.out.println("Saved credentials for " + parent.url + " ("
-                + parent.credentialStore.file() + ").");
-        return ExitCode.SUCCESS;
+        if (mode.token != null) {
+            parent.credentialStore.save(parent.url, mode.token);
+            System.out.println("Saved credentials for " + parent.url + " ("
+                    + parent.credentialStore.file() + ").");
+            return ExitCode.SUCCESS;
+        }
+        return oauthLogin();
+    }
+
+    private Integer oauthLogin() {
+        OAuthClient client = (oauthClientOverride != null) ? oauthClientOverride
+                : new OAuthClient(parent.url);
+        try (LoopbackCallbackServer server = LoopbackCallbackServer.start()) {
+            AsMetadata meta = client.discover();
+            Pkce pkce = Pkce.generate();
+            String state = randomState();
+            String authorizeUrl = buildAuthorizeUrl(meta.authorizationEndpoint(),
+                    server.redirectUri(), pkce.challenge(), state);
+
+            System.out.println("Opening your browser to log in. If it doesn't open, visit:\n  "
+                    + authorizeUrl);
+            browserOpener.accept(authorizeUrl);
+
+            String code = server.awaitCode(state, LOGIN_TIMEOUT_MINUTES, TimeUnit.MINUTES);
+            OAuthTokens tokens = client.exchangeAuthorizationCode(meta.tokenEndpoint(),
+                    CliTokenSource.CLI_CLIENT_ID, server.redirectUri(), code, pkce.verifier());
+            parent.credentialStore.saveOAuth(parent.url, tokens);
+            System.out.println("Logged in. Tokens saved for " + parent.url + " ("
+                    + parent.credentialStore.file() + ").");
+            return ExitCode.SUCCESS;
+        } catch (java.util.concurrent.TimeoutException e) {
+            System.err.println("Login timed out waiting for the browser redirect.");
+            return ExitCode.AUTH;
+        } catch (IllegalStateException e) {
+            System.err.println("Login failed: " + e.getMessage());
+            return ExitCode.AUTH;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            System.err.println("Login interrupted.");
+            return ExitCode.UNEXPECTED;
+        } catch (RuntimeException | java.io.IOException e) {
+            System.err.println("Login failed: " + e.getMessage());
+            return ExitCode.UNEXPECTED;
+        }
+    }
+
+    private String randomState() {
+        byte[] raw = new byte[16];
+        random.nextBytes(raw);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(raw);
+    }
+
+    private static String buildAuthorizeUrl(String authorizationEndpoint, String redirectUri,
+            String codeChallenge, String state) {
+        return authorizationEndpoint
+                + "?response_type=code"
+                + "&client_id=" + enc(CliTokenSource.CLI_CLIENT_ID)
+                + "&scope=" + enc("mcp")
+                + "&redirect_uri=" + enc(redirectUri)
+                + "&code_challenge=" + enc(codeChallenge)
+                + "&code_challenge_method=" + enc(Pkce.METHOD)
+                + "&state=" + enc(state);
+    }
+
+    private static String enc(String s) {
+        return URLEncoder.encode(s, StandardCharsets.UTF_8);
+    }
+
+    /** Best-effort desktop browser open; a headless/unsupported environment just relies on the URL. */
+    private static void openInBrowser(String url) {
+        try {
+            if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+                Desktop.getDesktop().browse(URI.create(url));
+            }
+        } catch (Exception ignored) {
+            // Fall back to the printed URL the caller already emitted.
+        }
     }
 }

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/LoginCommand.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/LoginCommand.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+
+/**
+ * Stores a personal access token (PAT, #73) for the current {@code --url}, so later commands
+ * authenticate without re-passing {@code --token}. Interactive OAuth login is a later milestone;
+ * this milestone covers the headless PAT path.
+ */
+@Command(name = "login", description = "Store a bearer token (PAT) for the server URL.")
+public class LoginCommand implements Callable<Integer> {
+
+    @ParentCommand
+    RequelCli parent;
+
+    @Option(names = "--token", paramLabel = "TOKEN", required = true,
+            description = "A Requel personal access token (reqpat_...).")
+    String token;
+
+    @Override
+    public Integer call() {
+        parent.credentialStore.save(parent.url, token);
+        System.out.println("Saved credentials for " + parent.url + " ("
+                + parent.credentialStore.file() + ").");
+        return ExitCode.SUCCESS;
+    }
+}

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/LogoutCommand.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/LogoutCommand.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.ParentCommand;
+
+/** Removes any stored token for the current {@code --url}. */
+@Command(name = "logout", description = "Remove stored credentials for the server URL.")
+public class LogoutCommand implements Callable<Integer> {
+
+    @ParentCommand
+    RequelCli parent;
+
+    @Override
+    public Integer call() {
+        parent.credentialStore.delete(parent.url);
+        System.out.println("Cleared credentials for " + parent.url + ".");
+        return ExitCode.SUCCESS;
+    }
+}

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/LoopbackCallbackServer.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/LoopbackCallbackServer.java
@@ -1,0 +1,136 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * A tiny loopback HTTP server that catches the OAuth authorization-code redirect. Binds an ephemeral
+ * port on {@code 127.0.0.1} (per RFC 8252 native-app guidance; Requel's AS relaxes the port for
+ * loopback redirect URIs), serves the fixed {@code /callback} path, captures the {@code code}/
+ * {@code state} query params, shows the user a "you can close this tab" page, and completes a future.
+ * The IP literal (not {@code localhost}) is used so the AS's loopback matching applies.
+ */
+public final class LoopbackCallbackServer implements AutoCloseable {
+
+    /** The callback path; must match the seeded client's registered redirect URI path. */
+    public static final String CALLBACK_PATH = "/callback";
+
+    private final HttpServer server;
+    private final int port;
+    private final CompletableFuture<Map<String, String>> received = new CompletableFuture<>();
+
+    private LoopbackCallbackServer(HttpServer server, int port) {
+        this.server = server;
+        this.port = port;
+    }
+
+    /** Bind and start on an ephemeral loopback port. */
+    public static LoopbackCallbackServer start() throws IOException {
+        HttpServer server = HttpServer.create(
+                new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0), 0);
+        LoopbackCallbackServer callback = new LoopbackCallbackServer(server, server.getAddress().getPort());
+        server.createContext(CALLBACK_PATH, exchange -> {
+            Map<String, String> params = parseQuery(exchange.getRequestURI());
+            byte[] body = ("<html><body><h3>Requel CLI</h3><p>Login complete — you can close this "
+                    + "tab and return to the terminal.</p></body></html>").getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "text/html; charset=utf-8");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(body);
+            }
+            callback.received.complete(params);
+        });
+        server.start();
+        return callback;
+    }
+
+    /** The redirect URI to hand the AS, e.g. {@code http://127.0.0.1:49xxx/callback}. */
+    public String redirectUri() {
+        return "http://127.0.0.1:" + port + CALLBACK_PATH;
+    }
+
+    /**
+     * Block until the redirect arrives (or {@code timeout} elapses), validate {@code state}, and return
+     * the authorization {@code code}.
+     *
+     * @throws IllegalStateException if the AS returned an {@code error}, {@code state} mismatched, or no
+     *                               {@code code} was present
+     */
+    public String awaitCode(String expectedState, long timeout, TimeUnit unit)
+            throws InterruptedException, TimeoutException {
+        Map<String, String> params;
+        try {
+            params = received.get(timeout, unit);
+        } catch (java.util.concurrent.ExecutionException e) {
+            throw new IllegalStateException("Callback server failed", e.getCause());
+        }
+        if (params.containsKey("error")) {
+            throw new IllegalStateException("Authorization failed: " + params.get("error")
+                    + (params.containsKey("error_description") ? " — " + params.get("error_description") : ""));
+        }
+        if (expectedState != null && !expectedState.equals(params.get("state"))) {
+            throw new IllegalStateException("State mismatch — possible CSRF; aborting login.");
+        }
+        String code = params.get("code");
+        if (code == null || code.isBlank()) {
+            throw new IllegalStateException("No authorization code in callback.");
+        }
+        return code;
+    }
+
+    @Override
+    public void close() {
+        server.stop(0);
+    }
+
+    private static Map<String, String> parseQuery(URI uri) {
+        Map<String, String> params = new HashMap<>();
+        String query = uri.getRawQuery();
+        if (query == null || query.isBlank()) {
+            return params;
+        }
+        for (String pair : query.split("&")) {
+            int eq = pair.indexOf('=');
+            if (eq < 0) {
+                params.put(decode(pair), "");
+            } else {
+                params.put(decode(pair.substring(0, eq)), decode(pair.substring(eq + 1)));
+            }
+        }
+        return params;
+    }
+
+    private static String decode(String s) {
+        return java.net.URLDecoder.decode(s, StandardCharsets.UTF_8);
+    }
+}

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/OutputFormat.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/OutputFormat.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+/** How {@code requel} renders results: human-readable text or machine-readable JSON. */
+public enum OutputFormat {
+    TEXT,
+    JSON
+}

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/Pkce.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/Pkce.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+/**
+ * A PKCE (RFC 7636) verifier/challenge pair for the {@code S256} method: {@code challenge =
+ * base64url(sha256(verifier))}, no padding. The verifier is a high-entropy URL-safe random string.
+ *
+ * @param verifier  the {@code code_verifier} kept secret in-process and sent on token exchange
+ * @param challenge the {@code code_challenge} sent on the authorization request
+ */
+public record Pkce(String verifier, String challenge) {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final Base64.Encoder B64URL = Base64.getUrlEncoder().withoutPadding();
+
+    /** The {@code code_challenge_method} this class implements. */
+    public static final String METHOD = "S256";
+
+    /** Generate a fresh pair with a 32-byte (256-bit) random verifier. */
+    public static Pkce generate() {
+        byte[] raw = new byte[32];
+        RANDOM.nextBytes(raw);
+        String verifier = B64URL.encodeToString(raw);
+        return new Pkce(verifier, challengeFor(verifier));
+    }
+
+    /** {@code base64url(sha256(verifier))} — the S256 challenge for a given verifier. */
+    static String challengeFor(String verifier) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(verifier.getBytes(StandardCharsets.US_ASCII));
+            return B64URL.encodeToString(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+}

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/RequelCli.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/RequelCli.java
@@ -37,7 +37,7 @@ import picocli.CommandLine.Option;
  */
 @Command(name = "requel", mixinStandardHelpOptions = true, version = "requel-cli 2.0.0-dev",
         description = "Command-line access to a Requel server via the gateway.",
-        subcommands = {RunCommand.class})
+        subcommands = {RunCommand.class, LoginCommand.class, LogoutCommand.class})
 public class RequelCli implements Runnable {
 
     @Option(names = "--url", paramLabel = "URL",
@@ -56,9 +56,22 @@ public class RequelCli implements Runnable {
 
     private final ObjectMapper mapper = new ObjectMapper();
 
-    /** The per-request bearer supplier passed to the REST gateway (blank/unset token → no header). */
+    /** Persisted PATs, keyed by server URL. Package-visible so subcommands and tests can use it. */
+    CredentialStore credentialStore = new CredentialStore();
+
+    /**
+     * The per-request bearer supplier passed to the REST gateway. Token precedence:
+     * {@code --token} flag &gt; {@code REQUEL_TOKEN} env (both already merged into {@link #token} by
+     * picocli) &gt; a token stored for this {@link #url} via {@code requel login}. Blank/absent → no
+     * Authorization header.
+     */
     BearerTokenSource tokenSource() {
-        return () -> (token == null || token.isBlank()) ? null : token;
+        return () -> {
+            if (token != null && !token.isBlank()) {
+                return token;
+            }
+            return credentialStore.find(url);
+        };
     }
 
     void printResult(GatewayResult result) {

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/RequelCli.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/RequelCli.java
@@ -60,18 +60,13 @@ public class RequelCli implements Runnable {
     CredentialStore credentialStore = new CredentialStore();
 
     /**
-     * The per-request bearer supplier passed to the REST gateway. Token precedence:
-     * {@code --token} flag &gt; {@code REQUEL_TOKEN} env (both already merged into {@link #token} by
-     * picocli) &gt; a token stored for this {@link #url} via {@code requel login}. Blank/absent → no
-     * Authorization header.
+     * The per-request bearer supplier passed to the REST gateway. Precedence: {@code --token} flag /
+     * {@code REQUEL_TOKEN} env (both already merged into {@link #token} by picocli) &gt; OAuth tokens
+     * from {@code requel login} (auto-refreshed) &gt; a PAT stored for this {@link #url}. Blank/absent
+     * → no Authorization header. See {@link CliTokenSource}.
      */
     BearerTokenSource tokenSource() {
-        return () -> {
-            if (token != null && !token.isBlank()) {
-                return token;
-            }
-            return credentialStore.find(url);
-        };
+        return new CliTokenSource(token, url, credentialStore);
     }
 
     void printResult(GatewayResult result) {

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/RequelCli.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/RequelCli.java
@@ -1,0 +1,110 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rreganjr.requel.gateway.GatewayException;
+import com.rreganjr.requel.gateway.GatewayResult;
+import com.rreganjr.requel.gateway.rest.BearerTokenSource;
+import java.util.Map;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * {@code requel} — command-line front-end over the Requel gateway (issue #70, Phase A). A picocli
+ * app that dispatches through the REST-backed gateway client; authentication is a PAT (#73) or an
+ * OAuth access token (#83) supplied via {@code --token}/{@code REQUEL_TOKEN}.
+ */
+@Command(name = "requel", mixinStandardHelpOptions = true, version = "requel-cli 2.0.0-dev",
+        description = "Command-line access to a Requel server via the gateway.",
+        subcommands = {RunCommand.class})
+public class RequelCli implements Runnable {
+
+    @Option(names = "--url", paramLabel = "URL",
+            defaultValue = "${env:REQUEL_URL:-http://localhost:8080}",
+            description = "Requel base URL (env REQUEL_URL; default ${DEFAULT-VALUE}).")
+    String url;
+
+    @Option(names = "--token", paramLabel = "TOKEN",
+            defaultValue = "${env:REQUEL_TOKEN}",
+            description = "Bearer token: a PAT (reqpat_...) or OAuth access token (env REQUEL_TOKEN).")
+    String token;
+
+    @Option(names = "--output", paramLabel = "FORMAT", defaultValue = "TEXT",
+            description = "Output format: ${COMPLETION-CANDIDATES} (default ${DEFAULT-VALUE}).")
+    OutputFormat output;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    /** The per-request bearer supplier passed to the REST gateway (blank/unset token → no header). */
+    BearerTokenSource tokenSource() {
+        return () -> (token == null || token.isBlank()) ? null : token;
+    }
+
+    void printResult(GatewayResult result) {
+        Object payload = result.result();
+        if (output == OutputFormat.JSON) {
+            try {
+                System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(payload));
+            } catch (JsonProcessingException e) {
+                System.out.println(String.valueOf(payload));
+            }
+        } else {
+            System.out.println(summarize(result.commandType(), payload));
+        }
+    }
+
+    void printError(GatewayException e) {
+        System.err.println("Error [" + e.getKind() + "]: " + e.getMessage());
+    }
+
+    private static String summarize(String commandType, Object payload) {
+        if (payload instanceof Map<?, ?> map) {
+            Object id = map.get("id");
+            Object name = map.get("name");
+            StringBuilder sb = new StringBuilder("OK ").append(commandType);
+            if (name != null) {
+                sb.append(": ").append(name);
+            }
+            if (id != null) {
+                sb.append(" (id=").append(id).append(")");
+            }
+            return sb.toString();
+        }
+        return payload == null ? "OK " + commandType : "OK " + commandType + ": " + payload;
+    }
+
+    /** No subcommand given: show usage. */
+    @Override
+    public void run() {
+        CommandLine.usage(this, System.out);
+    }
+
+    public static void main(String[] args) {
+        int code = new CommandLine(new RequelCli())
+                // Don't treat a leading '@' (e.g. --input-file @path) as a picocli argument file.
+                .setExpandAtFiles(false)
+                .execute(args);
+        System.exit(code);
+    }
+}

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/RequelCli.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/RequelCli.java
@@ -112,6 +112,8 @@ public class RequelCli implements Runnable {
         int code = new CommandLine(new RequelCli())
                 // Don't treat a leading '@' (e.g. --input-file @path) as a picocli argument file.
                 .setExpandAtFiles(false)
+                // Accept --output json/text as well as JSON/TEXT.
+                .setCaseInsensitiveEnumValuesAllowed(true)
                 .execute(args);
         System.exit(code);
     }

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/RequelCli.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/RequelCli.java
@@ -37,7 +37,7 @@ import picocli.CommandLine.Option;
  */
 @Command(name = "requel", mixinStandardHelpOptions = true, version = "requel-cli 2.0.0-dev",
         description = "Command-line access to a Requel server via the gateway.",
-        subcommands = {RunCommand.class, LoginCommand.class, LogoutCommand.class})
+        subcommands = {RunCommand.class, CommandsCommand.class, LoginCommand.class, LogoutCommand.class})
 public class RequelCli implements Runnable {
 
     @Option(names = "--url", paramLabel = "URL",

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/RunCommand.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/RunCommand.java
@@ -1,0 +1,108 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rreganjr.requel.gateway.CommandGateway;
+import com.rreganjr.requel.gateway.GatewayException;
+import com.rreganjr.requel.gateway.GatewayRequest;
+import com.rreganjr.requel.gateway.GatewayResult;
+import com.rreganjr.requel.gateway.rest.RestCommandGateway;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.ParentCommand;
+
+/**
+ * The generic gateway dispatch: {@code requel run <CommandType> --input '{...}'}. Sends the input
+ * through the REST {@link CommandGateway} to {@code /api/gateway/commands/<CommandType>} and prints
+ * the result. Returns a {@link ExitCode} keyed on the outcome. This is the always-available core;
+ * typed convenience subcommands (runtime-discovered) are a later milestone.
+ */
+@Command(name = "run",
+        description = "Run a gateway command, e.g. requel run EditGoal --input '{\"projectName\":\"Demo\",\"name\":\"G\"}'")
+public class RunCommand implements Callable<Integer> {
+
+    @ParentCommand
+    RequelCli parent;
+
+    @Parameters(index = "0", paramLabel = "COMMAND_TYPE",
+            description = "Registered command type, e.g. EditGoal.")
+    String commandType;
+
+    @Option(names = "--input", paramLabel = "JSON",
+            description = "Command input as a JSON object string.")
+    String inputJson;
+
+    @Option(names = "--input-file", paramLabel = "PATH",
+            description = "Path to a file containing the JSON input object.")
+    Path inputFile;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    /** Test seam: when set, used instead of building a {@link RestCommandGateway} from the parent. */
+    CommandGateway gatewayOverride;
+
+    @Override
+    public Integer call() {
+        Map<String, Object> input;
+        try {
+            input = parseInput();
+        } catch (IllegalArgumentException | IOException e) {
+            System.err.println("Invalid input: " + e.getMessage());
+            return ExitCode.USAGE;
+        }
+
+        CommandGateway gateway = (gatewayOverride != null) ? gatewayOverride
+                : new RestCommandGateway(parent.url, parent.tokenSource());
+        try {
+            GatewayResult result = gateway.execute(new GatewayRequest(commandType, input));
+            parent.printResult(result);
+            return ExitCode.SUCCESS;
+        } catch (GatewayException e) {
+            parent.printError(e);
+            return ExitCode.forKind(e.getKind());
+        }
+    }
+
+    /** @return the parsed JSON input as a map, or {@code null} when no input was supplied. */
+    private Map<String, Object> parseInput() throws IOException {
+        if (inputJson != null && inputFile != null) {
+            throw new IllegalArgumentException("use only one of --input or --input-file");
+        }
+        String json = null;
+        if (inputJson != null) {
+            json = inputJson;
+        } else if (inputFile != null) {
+            json = Files.readString(inputFile);
+        }
+        if (json == null || json.isBlank()) {
+            return null;
+        }
+        return mapper.readValue(json, new TypeReference<Map<String, Object>>() { });
+    }
+}

--- a/modules/requel-cli/src/main/scripts/requel
+++ b/modules/requel-cli/src/main/scripts/requel
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Thin launcher for the Requel CLI: `requel <args>` == `java -jar requel-cli-<version>.jar <args>`.
+#
+# Resolution order for the fat jar:
+#   1. $REQUEL_CLI_JAR, if set (explicit override).
+#   2. the newest requel-cli-*.jar next to this script (an unpacked release layout).
+#   3. the newest requel-cli-*.jar under ../target relative to this script (a local build:
+#      modules/requel-cli/target after `mvn -pl modules/requel-cli -am package`).
+#
+# Requires Java 17+ on the PATH (or set $JAVA_HOME).
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+java_bin="java"
+if [[ -n "${JAVA_HOME:-}" ]]; then
+  java_bin="$JAVA_HOME/bin/java"
+fi
+
+find_jar() {
+  # newest matching jar in the given dir, or nothing
+  ls -t "$1"/requel-cli-*.jar 2>/dev/null | grep -v -- '-sources\|-javadoc' | head -n1 || true
+}
+
+jar="${REQUEL_CLI_JAR:-}"
+if [[ -z "$jar" ]]; then
+  jar="$(find_jar "$script_dir")"
+fi
+if [[ -z "$jar" ]]; then
+  jar="$(find_jar "$script_dir/../target")"
+fi
+
+if [[ -z "$jar" || ! -f "$jar" ]]; then
+  echo "requel: could not find requel-cli-*.jar." >&2
+  echo "  Build it with:  mvn -pl modules/requel-cli -am package" >&2
+  echo "  or set REQUEL_CLI_JAR=/path/to/requel-cli-<version>.jar" >&2
+  exit 1
+fi
+
+exec "$java_bin" -jar "$jar" "$@"

--- a/modules/requel-cli/src/main/scripts/requel
+++ b/modules/requel-cli/src/main/scripts/requel
@@ -5,8 +5,10 @@
 # Resolution order for the fat jar:
 #   1. $REQUEL_CLI_JAR, if set (explicit override).
 #   2. the newest requel-cli-*.jar next to this script (an unpacked release layout).
-#   3. the newest requel-cli-*.jar under ../target relative to this script (a local build:
-#      modules/requel-cli/target after `mvn -pl modules/requel-cli -am package`).
+#   3. the newest requel-cli-*.jar in the module's target dir (a local build:
+#      modules/requel-cli/target after `mvn -pl modules/requel-cli -am package`). From this script
+#      at src/main/scripts/, that is three levels up.
+# The shade plugin also leaves an `original-requel-cli-*.jar` (the pre-shade jar); it is excluded.
 #
 # Requires Java 17+ on the PATH (or set $JAVA_HOME).
 set -euo pipefail
@@ -19,8 +21,9 @@ if [[ -n "${JAVA_HOME:-}" ]]; then
 fi
 
 find_jar() {
-  # newest matching jar in the given dir, or nothing
-  ls -t "$1"/requel-cli-*.jar 2>/dev/null | grep -v -- '-sources\|-javadoc' | head -n1 || true
+  # newest matching jar in the given dir (excluding original-/sources/javadoc), or nothing
+  ls -t "$1"/requel-cli-*.jar 2>/dev/null \
+    | grep -v -- '-sources\|-javadoc\|/original-' | head -n1 || true
 }
 
 jar="${REQUEL_CLI_JAR:-}"
@@ -28,7 +31,7 @@ if [[ -z "$jar" ]]; then
   jar="$(find_jar "$script_dir")"
 fi
 if [[ -z "$jar" ]]; then
-  jar="$(find_jar "$script_dir/../target")"
+  jar="$(find_jar "$script_dir/../../../target")"
 fi
 
 if [[ -z "$jar" || ! -f "$jar" ]]; then

--- a/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/CliTokenSourceTest.java
+++ b/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/CliTokenSourceTest.java
@@ -1,0 +1,118 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.rreganjr.requel.gateway.rest.AsMetadata;
+import com.rreganjr.requel.gateway.rest.OAuthClient;
+import com.rreganjr.requel.gateway.rest.OAuthTokens;
+import java.time.Instant;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import java.nio.file.Path;
+
+class CliTokenSourceTest {
+
+    private static final String URL = "http://localhost:8080";
+
+    private static Function<String, OAuthClient> noRefresh() {
+        return url -> {
+            throw new AssertionError("refresh must not be attempted");
+        };
+    }
+
+    @Test
+    void explicitTokenWinsOverEverything(@TempDir Path dir) {
+        CredentialStore store = new CredentialStore(dir);
+        store.save(URL, "reqpat_STORED");
+        store.saveOAuth(URL, new OAuthTokens("AT", "RT", "mcp", Instant.now().plusSeconds(3600)));
+
+        CliTokenSource src = new CliTokenSource("reqpat_FLAG", URL, store, noRefresh());
+        assertThat(src.currentToken()).isEqualTo("reqpat_FLAG");
+    }
+
+    @Test
+    void returnsValidOAuthAccessTokenWithoutRefreshing(@TempDir Path dir) {
+        CredentialStore store = new CredentialStore(dir);
+        store.saveOAuth(URL, new OAuthTokens("AT", "RT", "mcp", Instant.now().plusSeconds(3600)));
+
+        CliTokenSource src = new CliTokenSource(null, URL, store, noRefresh());
+        assertThat(src.currentToken()).isEqualTo("AT");
+    }
+
+    @Test
+    void refreshesExpiredOAuthTokenAndPersistsTheRotation(@TempDir Path dir) {
+        CredentialStore store = new CredentialStore(dir);
+        store.saveOAuth(URL, new OAuthTokens("OLD_AT", "OLD_RT", "mcp", Instant.now().minusSeconds(10)));
+
+        OAuthClient fake = new OAuthClient(URL) {
+            @Override
+            public AsMetadata discover() {
+                return new AsMetadata("iss", "auth", URL + "/oauth2/token");
+            }
+
+            @Override
+            public OAuthTokens refresh(String tokenEndpoint, String clientId, String refreshToken) {
+                assertThat(refreshToken).isEqualTo("OLD_RT");
+                assertThat(clientId).isEqualTo(CliTokenSource.CLI_CLIENT_ID);
+                return new OAuthTokens("NEW_AT", "NEW_RT", "mcp", Instant.now().plusSeconds(3600));
+            }
+        };
+
+        CliTokenSource src = new CliTokenSource(null, URL, store, url -> fake);
+        assertThat(src.currentToken()).isEqualTo("NEW_AT");
+        assertThat(store.findOAuth(URL).accessToken()).isEqualTo("NEW_AT");
+        assertThat(store.findOAuth(URL).refreshToken()).isEqualTo("NEW_RT");
+    }
+
+    @Test
+    void returnsStaleAccessTokenWhenRefreshFails(@TempDir Path dir) {
+        CredentialStore store = new CredentialStore(dir);
+        store.saveOAuth(URL, new OAuthTokens("STALE_AT", "RT", "mcp", Instant.now().minusSeconds(10)));
+
+        OAuthClient failing = new OAuthClient(URL) {
+            @Override
+            public AsMetadata discover() {
+                throw new RuntimeException("offline");
+            }
+        };
+
+        CliTokenSource src = new CliTokenSource(null, URL, store, url -> failing);
+        assertThat(src.currentToken()).isEqualTo("STALE_AT");
+    }
+
+    @Test
+    void fallsBackToPatWhenNoOAuth(@TempDir Path dir) {
+        CredentialStore store = new CredentialStore(dir);
+        store.save(URL, "reqpat_STORED");
+
+        CliTokenSource src = new CliTokenSource(null, URL, store, noRefresh());
+        assertThat(src.currentToken()).isEqualTo("reqpat_STORED");
+    }
+
+    @Test
+    void returnsNullWhenNothingConfigured(@TempDir Path dir) {
+        CliTokenSource src = new CliTokenSource(null, URL, new CredentialStore(dir), noRefresh());
+        assertThat(src.currentToken()).isNull();
+    }
+}

--- a/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/CommandsCommandTest.java
+++ b/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/CommandsCommandTest.java
@@ -1,0 +1,115 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.rreganjr.requel.gateway.rest.CommandInfo;
+import com.rreganjr.requel.gateway.rest.RestGatewayCatalog;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+
+class CommandsCommandTest {
+
+    /** A catalog stub — overrides descriptors() so no network call is made. */
+    private static RestGatewayCatalog catalogReturning(List<CommandInfo> commands) {
+        return new RestGatewayCatalog("http://unused", () -> null) {
+            @Override
+            public List<CommandInfo> descriptors() {
+                return commands;
+            }
+        };
+    }
+
+    private static RestGatewayCatalog catalogThrowing(HttpStatus status) {
+        return new RestGatewayCatalog("http://unused", () -> null) {
+            @Override
+            public List<CommandInfo> descriptors() {
+                throw new HttpClientErrorException(status);
+            }
+        };
+    }
+
+    private static CommandsCommand command(OutputFormat output, RestGatewayCatalog catalog) {
+        RequelCli parent = new RequelCli();
+        parent.url = "http://localhost:8080";
+        parent.output = output;
+        CommandsCommand cmd = new CommandsCommand();
+        cmd.parent = parent;
+        cmd.catalogOverride = catalog;
+        return cmd;
+    }
+
+    @Test
+    void listsCommandsAndReturnsSuccess() {
+        RestGatewayCatalog catalog = catalogReturning(List.of(
+                new CommandInfo("EditGoal", "EditGoalInput", "Edit Goal", null, true, null)));
+        String out = captureStdout(() ->
+                assertThat(command(OutputFormat.TEXT, catalog).call()).isEqualTo(ExitCode.SUCCESS));
+        assertThat(out).contains("EditGoal").contains("Edit Goal");
+    }
+
+    @Test
+    void emptyCatalogExplainsWritesMayBeDisabled() {
+        String out = captureStdout(() ->
+                assertThat(command(OutputFormat.TEXT, catalogReturning(List.of())).call())
+                        .isEqualTo(ExitCode.SUCCESS));
+        assertThat(out).contains("requel.gateway.write.enabled=false");
+    }
+
+    @Test
+    void jsonOutputEmitsArray() {
+        RestGatewayCatalog catalog = catalogReturning(List.of(
+                new CommandInfo("EditGoal", "EditGoalInput", "Edit Goal", null, true, null)));
+        String out = captureStdout(() ->
+                assertThat(command(OutputFormat.JSON, catalog).call()).isEqualTo(ExitCode.SUCCESS));
+        assertThat(out.trim()).startsWith("[").contains("\"commandType\" : \"EditGoal\"");
+    }
+
+    @Test
+    void unauthorizedReturnsAuthCode() {
+        assertThat(command(OutputFormat.TEXT, catalogThrowing(HttpStatus.UNAUTHORIZED)).call())
+                .isEqualTo(ExitCode.AUTH);
+    }
+
+    @Test
+    void otherHttpErrorReturnsRequestErrorCode() {
+        assertThat(command(OutputFormat.TEXT, catalogThrowing(HttpStatus.INTERNAL_SERVER_ERROR)).call())
+                .isEqualTo(ExitCode.REQUEST_ERROR);
+    }
+
+    private static String captureStdout(Runnable body) {
+        PrintStream original = System.out;
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(buf, true, StandardCharsets.UTF_8));
+        try {
+            body.run();
+        } finally {
+            System.setOut(original);
+        }
+        return buf.toString(StandardCharsets.UTF_8);
+    }
+}

--- a/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/CredentialStoreTest.java
+++ b/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/CredentialStoreTest.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CredentialStoreTest {
+
+    @Test
+    void savesAndFindsTokenPerUrl(@TempDir Path dir) {
+        CredentialStore store = new CredentialStore(dir);
+        store.save("http://a:8080", "reqpat_A");
+        store.save("http://b:9090", "reqpat_B");
+
+        assertThat(store.find("http://a:8080")).isEqualTo("reqpat_A");
+        assertThat(store.find("http://b:9090")).isEqualTo("reqpat_B");
+        assertThat(store.find("http://unknown")).isNull();
+    }
+
+    @Test
+    void deleteRemovesOnlyThatUrl(@TempDir Path dir) {
+        CredentialStore store = new CredentialStore(dir);
+        store.save("http://a:8080", "reqpat_A");
+        store.save("http://b:9090", "reqpat_B");
+
+        store.delete("http://a:8080");
+
+        assertThat(store.find("http://a:8080")).isNull();
+        assertThat(store.find("http://b:9090")).isEqualTo("reqpat_B");
+    }
+
+    @Test
+    void persistsAcrossInstances(@TempDir Path dir) {
+        new CredentialStore(dir).save("http://a:8080", "reqpat_A");
+        assertThat(new CredentialStore(dir).find("http://a:8080")).isEqualTo("reqpat_A");
+    }
+
+    @Test
+    void credentialsFileIsOwnerOnlyOnPosix(@TempDir Path dir) throws Exception {
+        assumeTrue(FileSystems.getDefault().supportedFileAttributeViews().contains("posix"));
+        CredentialStore store = new CredentialStore(dir);
+        store.save("http://a:8080", "reqpat_A");
+
+        String perms = PosixFilePermissions.toString(Files.getPosixFilePermissions(store.file()));
+        assertThat(perms).isEqualTo("rw-------");
+    }
+}

--- a/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/CredentialStoreTest.java
+++ b/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/CredentialStoreTest.java
@@ -23,10 +23,12 @@ package com.rreganjr.requel.cli;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import com.rreganjr.requel.gateway.rest.OAuthTokens;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.time.Instant;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -59,6 +61,38 @@ class CredentialStoreTest {
     void persistsAcrossInstances(@TempDir Path dir) {
         new CredentialStore(dir).save("http://a:8080", "reqpat_A");
         assertThat(new CredentialStore(dir).find("http://a:8080")).isEqualTo("reqpat_A");
+    }
+
+    @Test
+    void savesAndFindsOAuthTokensPerUrl(@TempDir Path dir) {
+        CredentialStore store = new CredentialStore(dir);
+        Instant expiry = Instant.now().plusSeconds(3600);
+        store.saveOAuth("http://a:8080", new OAuthTokens("AT", "RT", "mcp", expiry));
+
+        OAuthTokens found = new CredentialStore(dir).findOAuth("http://a:8080");
+        assertThat(found).isNotNull();
+        assertThat(found.accessToken()).isEqualTo("AT");
+        assertThat(found.refreshToken()).isEqualTo("RT");
+        assertThat(found.scope()).isEqualTo("mcp");
+        assertThat(found.expiresAt().getEpochSecond()).isEqualTo(expiry.getEpochSecond());
+        assertThat(store.findOAuth("http://unknown")).isNull();
+    }
+
+    @Test
+    void oauthAndPatCoexistAndDeleteClearsBoth(@TempDir Path dir) {
+        CredentialStore store = new CredentialStore(dir);
+        store.save("http://a:8080", "reqpat_A");
+        store.saveOAuth("http://a:8080", new OAuthTokens("AT", "RT", "mcp",
+                Instant.now().plusSeconds(3600)));
+
+        // Both are stored independently.
+        assertThat(store.find("http://a:8080")).isEqualTo("reqpat_A");
+        assertThat(store.findOAuth("http://a:8080")).isNotNull();
+
+        store.delete("http://a:8080");
+
+        assertThat(store.find("http://a:8080")).isNull();
+        assertThat(store.findOAuth("http://a:8080")).isNull();
     }
 
     @Test

--- a/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/ExitCodeTest.java
+++ b/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/ExitCodeTest.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.rreganjr.requel.gateway.GatewayException;
+import org.junit.jupiter.api.Test;
+
+class ExitCodeTest {
+
+    @Test
+    void mapsEveryGatewayKind() {
+        assertThat(ExitCode.forKind(GatewayException.Kind.UNAUTHORIZED)).isEqualTo(ExitCode.AUTH);
+        assertThat(ExitCode.forKind(GatewayException.Kind.NOT_ALLOWED)).isEqualTo(ExitCode.NOT_ALLOWED);
+        assertThat(ExitCode.forKind(GatewayException.Kind.NOT_FOUND)).isEqualTo(ExitCode.REQUEST_ERROR);
+        assertThat(ExitCode.forKind(GatewayException.Kind.INVALID_INPUT)).isEqualTo(ExitCode.REQUEST_ERROR);
+        assertThat(ExitCode.forKind(GatewayException.Kind.EXECUTION_ERROR)).isEqualTo(ExitCode.REQUEST_ERROR);
+    }
+}

--- a/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/LoginLogoutTest.java
+++ b/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/LoginLogoutTest.java
@@ -40,7 +40,7 @@ class LoginLogoutTest {
         RequelCli parent = cli(dir);
         LoginCommand login = new LoginCommand();
         login.parent = parent;
-        login.token = "reqpat_ABC";
+        login.mode.token = "reqpat_ABC";
 
         assertThat(login.call()).isEqualTo(ExitCode.SUCCESS);
         assertThat(parent.credentialStore.find("http://localhost:8080")).isEqualTo("reqpat_ABC");

--- a/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/LoginLogoutTest.java
+++ b/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/LoginLogoutTest.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LoginLogoutTest {
+
+    private static RequelCli cli(Path dir) {
+        RequelCli parent = new RequelCli();
+        parent.url = "http://localhost:8080";
+        parent.credentialStore = new CredentialStore(dir);
+        return parent;
+    }
+
+    @Test
+    void loginStoresTokenForUrl(@TempDir Path dir) {
+        RequelCli parent = cli(dir);
+        LoginCommand login = new LoginCommand();
+        login.parent = parent;
+        login.token = "reqpat_ABC";
+
+        assertThat(login.call()).isEqualTo(ExitCode.SUCCESS);
+        assertThat(parent.credentialStore.find("http://localhost:8080")).isEqualTo("reqpat_ABC");
+    }
+
+    @Test
+    void logoutClearsStoredToken(@TempDir Path dir) {
+        RequelCli parent = cli(dir);
+        parent.credentialStore.save("http://localhost:8080", "reqpat_ABC");
+
+        LogoutCommand logout = new LogoutCommand();
+        logout.parent = parent;
+
+        assertThat(logout.call()).isEqualTo(ExitCode.SUCCESS);
+        assertThat(parent.credentialStore.find("http://localhost:8080")).isNull();
+    }
+
+    @Test
+    void tokenSourcePrefersFlagOverStored(@TempDir Path dir) {
+        RequelCli parent = cli(dir);
+        parent.credentialStore.save("http://localhost:8080", "reqpat_STORED");
+        parent.token = "reqpat_FLAG";
+
+        assertThat(parent.tokenSource().currentToken()).isEqualTo("reqpat_FLAG");
+    }
+
+    @Test
+    void tokenSourceFallsBackToStoredWhenNoFlagOrEnv(@TempDir Path dir) {
+        RequelCli parent = cli(dir);
+        parent.credentialStore.save("http://localhost:8080", "reqpat_STORED");
+        parent.token = null; // no --token and no REQUEL_TOKEN
+
+        assertThat(parent.tokenSource().currentToken()).isEqualTo("reqpat_STORED");
+    }
+
+    @Test
+    void tokenSourceReturnsNullWhenNothingConfigured(@TempDir Path dir) {
+        RequelCli parent = cli(dir);
+        parent.token = null;
+
+        assertThat(parent.tokenSource().currentToken()).isNull();
+    }
+}

--- a/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/LoginOAuthTest.java
+++ b/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/LoginOAuthTest.java
@@ -1,0 +1,108 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.rreganjr.requel.gateway.rest.AsMetadata;
+import com.rreganjr.requel.gateway.rest.OAuthClient;
+import com.rreganjr.requel.gateway.rest.OAuthTokens;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LoginOAuthTest {
+
+    private static final String URL = "http://localhost:8080";
+
+    /** A fake AS: discovery returns endpoints; the code exchange returns fixed tokens. */
+    private static OAuthClient fakeAs() {
+        return new OAuthClient(URL) {
+            @Override
+            public AsMetadata discover() {
+                return new AsMetadata("iss", URL + "/oauth2/authorize", URL + "/oauth2/token");
+            }
+
+            @Override
+            public OAuthTokens exchangeAuthorizationCode(String tokenEndpoint, String clientId,
+                    String redirectUri, String code, String codeVerifier) {
+                assertThat(clientId).isEqualTo(CliTokenSource.CLI_CLIENT_ID);
+                assertThat(code).isEqualTo("test-code");
+                assertThat(codeVerifier).isNotBlank();
+                return new OAuthTokens("AT", "RT", "mcp", Instant.now().plusSeconds(3600));
+            }
+        };
+    }
+
+    /** Simulates the user's browser: parse the authorize URL and hit the loopback callback. */
+    private static void simulateBrowser(String authorizeUrl) {
+        Map<String, String> q = query(authorizeUrl);
+        String callback = q.get("redirect_uri") + "?code=test-code&state="
+                + URLDecoder.decode(q.get("state"), StandardCharsets.UTF_8);
+        try {
+            HttpClient.newHttpClient().send(
+                    HttpRequest.newBuilder(URI.create(callback)).GET().build(),
+                    HttpResponse.BodyHandlers.discarding());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void oauthLoginExchangesCodeAndStoresTokens(@TempDir Path dir) {
+        RequelCli parent = new RequelCli();
+        parent.url = URL;
+        parent.credentialStore = new CredentialStore(dir);
+
+        LoginCommand login = new LoginCommand();
+        login.parent = parent;
+        login.mode.oauth = true;
+        login.oauthClientOverride = fakeAs();
+        login.browserOpener = LoginOAuthTest::simulateBrowser;
+
+        assertThat(login.call()).isEqualTo(ExitCode.SUCCESS);
+
+        OAuthTokens stored = parent.credentialStore.findOAuth(URL);
+        assertThat(stored).isNotNull();
+        assertThat(stored.accessToken()).isEqualTo("AT");
+        assertThat(stored.refreshToken()).isEqualTo("RT");
+    }
+
+    private static Map<String, String> query(String url) {
+        Map<String, String> params = new HashMap<>();
+        String q = URI.create(url).getRawQuery();
+        for (String pair : q.split("&")) {
+            int eq = pair.indexOf('=');
+            params.put(pair.substring(0, eq),
+                    URLDecoder.decode(pair.substring(eq + 1), StandardCharsets.UTF_8));
+        }
+        return params;
+    }
+}

--- a/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/LoopbackCallbackServerTest.java
+++ b/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/LoopbackCallbackServerTest.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class LoopbackCallbackServerTest {
+
+    private static void hit(String url) throws Exception {
+        HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder(URI.create(url)).GET().build(),
+                HttpResponse.BodyHandlers.discarding());
+    }
+
+    @Test
+    void capturesCodeAndValidatesState() throws Exception {
+        try (LoopbackCallbackServer server = LoopbackCallbackServer.start()) {
+            assertThat(server.redirectUri()).startsWith("http://127.0.0.1:").endsWith("/callback");
+            hit(server.redirectUri() + "?code=the-code&state=xyz");
+
+            assertThat(server.awaitCode("xyz", 5, TimeUnit.SECONDS)).isEqualTo("the-code");
+        }
+    }
+
+    @Test
+    void rejectsStateMismatch() throws Exception {
+        try (LoopbackCallbackServer server = LoopbackCallbackServer.start()) {
+            hit(server.redirectUri() + "?code=the-code&state=wrong");
+
+            assertThatThrownBy(() -> server.awaitCode("expected", 5, TimeUnit.SECONDS))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("State mismatch");
+        }
+    }
+
+    @Test
+    void surfacesAuthorizationServerError() throws Exception {
+        try (LoopbackCallbackServer server = LoopbackCallbackServer.start()) {
+            hit(server.redirectUri() + "?error=access_denied&error_description=nope");
+
+            assertThatThrownBy(() -> server.awaitCode("xyz", 5, TimeUnit.SECONDS))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("access_denied");
+        }
+    }
+}

--- a/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/OutputFormatParsingTest.java
+++ b/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/OutputFormatParsingTest.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+class OutputFormatParsingTest {
+
+    private static RequelCli parse(String... args) {
+        RequelCli cli = new RequelCli();
+        new CommandLine(cli)
+                .setExpandAtFiles(false)
+                .setCaseInsensitiveEnumValuesAllowed(true)
+                .parseArgs(args);
+        return cli;
+    }
+
+    @Test
+    void acceptsLowercaseOutputValue() {
+        assertThat(parse("--output", "json", "commands").output).isEqualTo(OutputFormat.JSON);
+        assertThat(parse("--output", "text", "commands").output).isEqualTo(OutputFormat.TEXT);
+    }
+
+    @Test
+    void acceptsUppercaseOutputValue() {
+        assertThat(parse("--output", "JSON", "commands").output).isEqualTo(OutputFormat.JSON);
+    }
+}

--- a/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/PkceTest.java
+++ b/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/PkceTest.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class PkceTest {
+
+    @Test
+    void s256MatchesRfc7636AppendixBVector() {
+        // RFC 7636 Appendix B worked example.
+        String verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+        assertThat(Pkce.challengeFor(verifier))
+                .isEqualTo("E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM");
+    }
+
+    @Test
+    void generateProducesConsistentUrlSafePair() {
+        Pkce pkce = Pkce.generate();
+        assertThat(pkce.verifier()).hasSizeGreaterThanOrEqualTo(43)  // >= 256 bits base64url
+                .doesNotContain("+", "/", "=");
+        assertThat(pkce.challenge()).isEqualTo(Pkce.challengeFor(pkce.verifier()))
+                .doesNotContain("+", "/", "=");
+    }
+}

--- a/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/RunCommandTest.java
+++ b/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/RunCommandTest.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.rreganjr.requel.gateway.CommandGateway;
+import com.rreganjr.requel.gateway.GatewayException;
+import com.rreganjr.requel.gateway.GatewayResult;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class RunCommandTest {
+
+    /** Build a RunCommand wired to a parent (TEXT output) and a stub gateway. */
+    private static RunCommand runCommand(String inputJson, CommandGateway gateway) {
+        RequelCli parent = new RequelCli();
+        parent.url = "http://localhost:8080";
+        parent.output = OutputFormat.TEXT;
+        RunCommand run = new RunCommand();
+        run.parent = parent;
+        run.commandType = "EditGoal";
+        run.inputJson = inputJson;
+        run.gatewayOverride = gateway;
+        return run;
+    }
+
+    private static CommandGateway throwing(GatewayException.Kind kind) {
+        return request -> {
+            throw new GatewayException(kind, "boom");
+        };
+    }
+
+    @Test
+    void successReturnsZero() {
+        CommandGateway ok = request -> new GatewayResult(request.commandType(), Map.of("id", 1, "name", "G"));
+        assertThat(runCommand("{\"name\":\"G\"}", ok).call()).isEqualTo(ExitCode.SUCCESS);
+    }
+
+    @Test
+    void unauthorizedReturnsAuthCode() {
+        assertThat(runCommand("{}", throwing(GatewayException.Kind.UNAUTHORIZED)).call())
+                .isEqualTo(ExitCode.AUTH);
+    }
+
+    @Test
+    void notAllowedReturnsNotAllowedCode() {
+        assertThat(runCommand("{}", throwing(GatewayException.Kind.NOT_ALLOWED)).call())
+                .isEqualTo(ExitCode.NOT_ALLOWED);
+    }
+
+    @Test
+    void executionErrorReturnsRequestErrorCode() {
+        assertThat(runCommand("{}", throwing(GatewayException.Kind.EXECUTION_ERROR)).call())
+                .isEqualTo(ExitCode.REQUEST_ERROR);
+    }
+
+    @Test
+    void malformedInputJsonReturnsUsageCodeWithoutCallingGateway() {
+        CommandGateway neverCalled = request -> {
+            throw new AssertionError("gateway must not be called when input is invalid");
+        };
+        assertThat(runCommand("{not json", neverCalled).call()).isEqualTo(ExitCode.USAGE);
+    }
+
+    @Test
+    void bothInputAndInputFileIsUsageError() {
+        RunCommand run = runCommand("{}", request -> new GatewayResult("EditGoal", null));
+        run.inputFile = java.nio.file.Path.of("ignored.json");
+        assertThat(run.call()).isEqualTo(ExitCode.USAGE);
+    }
+}

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/config/AuthorizationServerConfig.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/config/AuthorizationServerConfig.java
@@ -129,6 +129,11 @@ public class AuthorizationServerConfig {
         return environment.getProperty("requel.oauth.seed-dev-client", Boolean.class, false);
     }
 
+    /** Seed the first-party {@code requel-cli} OAuth client for {@code requel login} (#70, M5). */
+    private boolean seedCliClient() {
+        return environment.getProperty("requel.oauth.seed-cli-client", Boolean.class, false);
+    }
+
     /** Seed the DCR registrar client. The registration endpoint is unusable until a registrar exists. */
     private boolean dcrEnabled() {
         return environment.getProperty("requel.oauth.dcr.enabled", Boolean.class, false);
@@ -147,9 +152,9 @@ public class AuthorizationServerConfig {
     @jakarta.annotation.PostConstruct
     void logResolvedOAuthConfig() {
         String secret = registrarClientSecret();
-        log.info("OAuth AS config resolved: seed-dev-client={}, dcr.enabled={}, "
+        log.info("OAuth AS config resolved: seed-dev-client={}, seed-cli-client={}, dcr.enabled={}, "
                 + "dcr.registrar-client-id={}, registrar-secret-set={}, issuer='{}'",
-                seedDevClient(), dcrEnabled(), registrarClientId(),
+                seedDevClient(), seedCliClient(), dcrEnabled(), registrarClientId(),
                 (secret != null && !secret.isBlank()), issuer());
     }
 
@@ -336,6 +341,65 @@ public class AuthorizationServerConfig {
             registeredClientRepository.save(devClient);
             log.info("Seeded OAuth dev client '{}' (loopback PKCE, scope=mcp, consent required).",
                     clientId);
+        };
+    }
+
+    // ---- First-party requel-cli OAuth client (#70, Milestone 5) ---------------------------------
+
+    /** The client id the {@code requel} CLI uses for its interactive {@code requel login} flow. */
+    public static final String CLI_CLIENT_ID = "requel-cli";
+
+    /**
+     * The loopback redirect URI registered for {@link #CLI_CLIENT_ID}. Port-less on purpose: the CLI
+     * binds an ephemeral loopback port at login time, and Spring Authorization Server relaxes the port
+     * when matching loopback ({@code 127.0.0.1}) redirect URIs per RFC 8252, so any actual port on
+     * {@code http://127.0.0.1/callback} matches. The IP literal (not {@code localhost}) is required for
+     * that relaxation.
+     */
+    public static final String CLI_REDIRECT_URI = "http://127.0.0.1/callback";
+
+    /**
+     * The {@code requel-cli} registered client: a public (PKCE-only) loopback native app, consent
+     * required, scope {@code mcp}, authorization-code + refresh, sharing the standard 1h/30d rotating
+     * token settings. Factored out (and package-visible) so it can be asserted in a unit test without
+     * booting the AS.
+     */
+    static RegisteredClient requelCliRegisteredClient() {
+        return RegisteredClient.withId(UUID.randomUUID().toString())
+                .clientId(CLI_CLIENT_ID)
+                .clientName("Requel CLI")
+                // Public client (no secret): PKCE-only, like other native/desktop agent clients.
+                .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
+                .redirectUri(CLI_REDIRECT_URI)
+                .scope("mcp")
+                .clientSettings(ClientSettings.builder()
+                        .requireAuthorizationConsent(true)
+                        .requireProofKey(true)
+                        .build())
+                .tokenSettings(defaultTokenSettings())
+                .build();
+    }
+
+    /**
+     * Registers the first-party {@link #CLI_CLIENT_ID} client on startup when
+     * {@code requel.oauth.seed-cli-client=true}, so {@code requel login} works out of the box without
+     * the operator minting a DCR initial access token. Gated DCR stays the default for third-party
+     * clients; this is one known first-party client. Idempotent.
+     */
+    @Bean
+    public ApplicationRunner seedOAuthCliClient(RegisteredClientRepository registeredClientRepository) {
+        return args -> {
+            if (!seedCliClient()) {
+                return;
+            }
+            if (registeredClientRepository.findByClientId(CLI_CLIENT_ID) != null) {
+                return;
+            }
+            registeredClientRepository.save(requelCliRegisteredClient());
+            log.info("Seeded OAuth client '{}' (loopback PKCE, scope=mcp, consent required) for "
+                    + "`requel login`.", CLI_CLIENT_ID);
         };
     }
 

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/gateway/GatewayCommandCatalogImpl.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/gateway/GatewayCommandCatalogImpl.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.gateway;
+
+import com.rreganjr.requel.gateway.CommandDescriptor;
+import com.rreganjr.requel.gateway.GatewayCommandCatalog;
+import com.rreganjr.requel.service.api.CommandRegistry;
+import com.rreganjr.requel.service.command.ApiCommandFactory;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.TreeSet;
+import org.springframework.stereotype.Component;
+
+/**
+ * The single source of truth for the gateway's exposed write commands (issue #70). Builds a
+ * {@link CommandDescriptor} for every command on the gateway allowlist
+ * ({@link GatewayPolicyConfig#ALLOWED}) that is actually registered, deriving the input DTO type
+ * from the {@link CommandRegistry}. Because it is built from the same {@code ALLOWED} set the
+ * {@link com.rreganjr.requel.gateway.CommandPolicy} bean uses, the catalog cannot drift from what
+ * the gateway actually permits.
+ *
+ * <p>Consumed by the REST descriptors endpoint (so {@code requel-cli} generates its surface from it)
+ * and available to any front-end that wants to enumerate the write surface. Read/query operations
+ * are the {@link com.rreganjr.requel.gateway.QueryGateway} surface, not part of this command catalog.
+ */
+@Component
+public class GatewayCommandCatalogImpl implements GatewayCommandCatalog {
+
+    private final List<CommandDescriptor> descriptors;
+    private final LinkedHashMap<String, CommandDescriptor> byType = new LinkedHashMap<>();
+
+    public GatewayCommandCatalogImpl(CommandRegistry registry, ApiCommandFactory apiCommandFactory) {
+        List<CommandDescriptor> built = new ArrayList<>();
+        for (String commandType : new TreeSet<>(GatewayPolicyConfig.ALLOWED)) {
+            if (!registry.isRegistered(commandType)) {
+                continue; // allowlisted but not registered in this deployment — skip.
+            }
+            Class<?> inputType;
+            try {
+                inputType = apiCommandFactory.getInputType(commandType);
+            } catch (RuntimeException e) {
+                inputType = Void.class;
+            }
+            CommandDescriptor descriptor = new CommandDescriptor(
+                    commandType, inputType, humanize(commandType), null, true, null);
+            built.add(descriptor);
+            byType.put(commandType, descriptor);
+        }
+        this.descriptors = List.copyOf(built);
+    }
+
+    @Override
+    public List<CommandDescriptor> descriptors() {
+        return descriptors;
+    }
+
+    @Override
+    public Optional<CommandDescriptor> find(String commandType) {
+        return Optional.ofNullable(byType.get(commandType));
+    }
+
+    /** Turn a PascalCase command type into a spaced title, e.g. {@code EditGoal} → {@code Edit Goal}. */
+    static String humanize(String commandType) {
+        return commandType == null ? "" : commandType.replaceAll("(?<=[a-z0-9])(?=[A-Z])", " ");
+    }
+}

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/gateway/GatewayCommandController.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/gateway/GatewayCommandController.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.gateway;
+
+import com.rreganjr.requel.gateway.CommandGateway;
+import com.rreganjr.requel.gateway.GatewayException;
+import com.rreganjr.requel.gateway.GatewayRequest;
+import com.rreganjr.requel.gateway.GatewayResult;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST facade over the {@link CommandGateway} write contract, for out-of-process front-ends (the
+ * REST-backed gateway client used by {@code requel-cli}). Unlike the raw {@code /api/commands/*}
+ * CQRS endpoint, this dispatches through the in-process {@link CommandGateway} bean, so the gateway
+ * <strong>allow/deny policy is enforced server-side</strong> (the denylist boundary — never expose
+ * user/identity commands — holds independently of authorization, per doc/local_mcp_bridge.md), not
+ * merely trusted to the client.
+ *
+ * <p>Success returns {@code 200} with the command's result DTO (or empty body when the command has
+ * no result). Failure returns a JSON {@link GatewayErrorBody} carrying the exact
+ * {@link GatewayException.Kind}, so the client reconstructs a stable error regardless of the HTTP
+ * status. Sits under {@code /api/**}, so the standard JWT/PAT/OAuth chain authenticates it and
+ * {@code CurrentUserResolver} establishes the acting user.
+ */
+@RestController
+@RequestMapping("/api/gateway/commands")
+public class GatewayCommandController {
+
+    private final CommandGateway commandGateway;
+
+    public GatewayCommandController(CommandGateway commandGateway) {
+        this.commandGateway = commandGateway;
+    }
+
+    @PostMapping(value = "/{commandType}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> dispatch(
+            @PathVariable String commandType,
+            @RequestBody(required = false) Map<String, Object> input,
+            @RequestHeader(value = "X-Requel-Client", required = false) String clientId) {
+        try {
+            GatewayResult result = commandGateway.execute(new GatewayRequest(commandType, input, clientId));
+            return ResponseEntity.ok(result.result());
+        } catch (GatewayException e) {
+            return ResponseEntity.status(statusFor(e.getKind()))
+                    .body(new GatewayErrorBody(e.getKind().name(), e.getMessage()));
+        }
+    }
+
+    private static HttpStatus statusFor(GatewayException.Kind kind) {
+        return switch (kind) {
+            case NOT_ALLOWED, UNAUTHORIZED -> HttpStatus.FORBIDDEN;
+            case NOT_FOUND -> HttpStatus.NOT_FOUND;
+            case INVALID_INPUT -> HttpStatus.BAD_REQUEST;
+            case EXECUTION_ERROR -> HttpStatus.UNPROCESSABLE_ENTITY;
+        };
+    }
+
+    /** Error envelope carrying the gateway failure category so clients get a stable {@code kind}. */
+    public record GatewayErrorBody(String kind, String message) {
+    }
+}

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/gateway/GatewayCommandController.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/gateway/GatewayCommandController.java
@@ -20,14 +20,19 @@
  */
 package com.rreganjr.requel.service.gateway;
 
+import com.rreganjr.requel.gateway.CommandDescriptor;
 import com.rreganjr.requel.gateway.CommandGateway;
+import com.rreganjr.requel.gateway.GatewayCommandCatalog;
 import com.rreganjr.requel.gateway.GatewayException;
 import com.rreganjr.requel.gateway.GatewayRequest;
 import com.rreganjr.requel.gateway.GatewayResult;
+import java.util.List;
 import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -54,9 +59,27 @@ import org.springframework.web.bind.annotation.RestController;
 public class GatewayCommandController {
 
     private final CommandGateway commandGateway;
+    private final GatewayCommandCatalog catalog;
+    private final boolean writeEnabled;
 
-    public GatewayCommandController(CommandGateway commandGateway) {
+    public GatewayCommandController(CommandGateway commandGateway, GatewayCommandCatalog catalog,
+            @Value("${requel.gateway.write.enabled:false}") boolean writeEnabled) {
         this.commandGateway = commandGateway;
+        this.catalog = catalog;
+        this.writeEnabled = writeEnabled;
+    }
+
+    /**
+     * The write-command catalog for client discovery (e.g. {@code requel commands}). Empty when
+     * writes are disabled ({@code requel.gateway.write.enabled=false}), mirroring how the MCP server
+     * hides write tools, so a client reflects exactly what is invocable here.
+     */
+    @GetMapping("/descriptors")
+    public List<DescriptorView> descriptors() {
+        if (!writeEnabled) {
+            return List.of();
+        }
+        return catalog.descriptors().stream().map(DescriptorView::from).toList();
     }
 
     @PostMapping(value = "/{commandType}", consumes = MediaType.APPLICATION_JSON_VALUE)
@@ -84,5 +107,16 @@ public class GatewayCommandController {
 
     /** Error envelope carrying the gateway failure category so clients get a stable {@code kind}. */
     public record GatewayErrorBody(String kind, String message) {
+    }
+
+    /** JSON view of a {@link CommandDescriptor} — the input type as a simple name, not a Class. */
+    public record DescriptorView(String commandType, String inputType, String title,
+            String description, boolean write, String authorizationHint) {
+
+        static DescriptorView from(CommandDescriptor d) {
+            return new DescriptorView(d.commandType(),
+                    d.inputType() == null ? null : d.inputType().getSimpleName(),
+                    d.title(), d.description(), d.write(), d.authorizationHint());
+        }
     }
 }

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/gateway/GatewayQueryController.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/gateway/GatewayQueryController.java
@@ -1,0 +1,112 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.gateway;
+
+import com.rreganjr.requel.gateway.QueryGateway;
+import com.rreganjr.requel.service.api.dto.AnnotationsDto;
+import com.rreganjr.requel.service.api.dto.EntityReferenceDto;
+import com.rreganjr.requel.service.api.dto.GlossaryTermDto;
+import com.rreganjr.requel.service.api.dto.OpenIssueDto;
+import com.rreganjr.requel.service.api.dto.ProjectDto;
+import com.rreganjr.requel.service.api.dto.ProjectTreeNodeDto;
+import java.util.List;
+import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST facade over the {@link QueryGateway} read contract, for out-of-process front-ends (the
+ * REST-backed gateway client used by {@code requel-cli}). Exposes the whole {@link QueryGateway}
+ * surface 1:1 under {@code /api/gateway/query/**} so the client maps straight onto it and stays
+ * decoupled from the UI's query controllers.
+ *
+ * <p>It delegates to the injected in-process {@link QueryGateway} bean, which itself forwards to the
+ * same query controllers the UI uses — so read authorization (project membership, per-entity gating)
+ * is enforced exactly as elsewhere. Sits under {@code /api/**}, so the standard JWT/PAT/OAuth
+ * security chain authenticates it.
+ */
+@RestController
+@RequestMapping("/api/gateway/query")
+public class GatewayQueryController {
+
+    private final QueryGateway queryGateway;
+
+    public GatewayQueryController(QueryGateway queryGateway) {
+        this.queryGateway = queryGateway;
+    }
+
+    @GetMapping("/projects")
+    public List<ProjectDto> listProjects() {
+        return queryGateway.listProjects();
+    }
+
+    @GetMapping("/projects/{name}")
+    public ProjectDto getProject(@PathVariable String name) {
+        return queryGateway.getProject(name);
+    }
+
+    @GetMapping("/projects/{name}/tree")
+    public List<ProjectTreeNodeDto> getProjectTree(@PathVariable String name) {
+        return queryGateway.getProjectTree(name);
+    }
+
+    @GetMapping("/projects/{name}/glossary")
+    public List<GlossaryTermDto> getGlossaryTerms(@PathVariable String name) {
+        return queryGateway.getGlossaryTerms(name);
+    }
+
+    @GetMapping("/projects/{name}/open-issues")
+    public List<OpenIssueDto> getOpenIssues(@PathVariable String name) {
+        return queryGateway.getOpenIssues(name);
+    }
+
+    @GetMapping("/projects/{name}/annotations")
+    public AnnotationsDto getAnnotations(@PathVariable String name,
+            @RequestParam String entityType, @RequestParam long entityId) {
+        return queryGateway.getAnnotations(name, entityType, entityId);
+    }
+
+    @GetMapping("/projects/{name}/entity")
+    public Object getEntity(@PathVariable String name,
+            @RequestParam String entityType, @RequestParam long entityId) {
+        return queryGateway.getEntity(name, entityType, entityId);
+    }
+
+    @GetMapping("/projects/{name}/entity/neighbors")
+    public Map<String, List<EntityReferenceDto>> getEntityNeighbors(@PathVariable String name,
+            @RequestParam String entityType, @RequestParam long entityId) {
+        return queryGateway.getEntityNeighbors(name, entityType, entityId);
+    }
+
+    @GetMapping("/projects/{name}/search")
+    public List<EntityReferenceDto> searchProjectEntities(@PathVariable String name,
+            @RequestParam("q") String query) {
+        return queryGateway.searchProjectEntities(name, query);
+    }
+
+    @GetMapping("/projects/{name}/context")
+    public Map<String, Object> getProjectContext(@PathVariable String name) {
+        return queryGateway.getProjectContext(name);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,7 @@
         <module>modules/service-api</module>
         <module>modules/gateway-api</module>
         <module>modules/gateway-rest-client</module>
+        <module>modules/requel-cli</module>
         <module>modules/assistant-api</module>
         <module>modules/assistant-core</module>
         <module>modules/assistant-ai</module>

--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,7 @@
         <module>modules/nlp-jpa</module>
         <module>modules/service-api</module>
         <module>modules/gateway-api</module>
+        <module>modules/gateway-rest-client</module>
         <module>modules/assistant-api</module>
         <module>modules/assistant-core</module>
         <module>modules/assistant-ai</module>


### PR DESCRIPTION
Phase A of #70: a picocli command-line front-end over the Requel gateway. Thin layer over the
existing gateway + auth (#69/#73/#83) — no new domain or command behavior. Phase B (remote MCP
connector ops) is deferred to a follow-up issue.

Delivered milestone-by-milestone:
- **M1 `gateway-rest-client`** — REST-backed CommandGateway/QueryGateway + server-side gateway
  facades (`/api/gateway/commands`, `/api/gateway/query/**`), so the allow/deny policy and
  per-stakeholder authorization are enforced server-side.
- **M2 CLI skeleton** — picocli app, `--url`/`--token`/`--output`, generic `requel run <Type>
  --input`, exit codes mapping `GatewayException.Kind`.
- **M3 PAT login** — `requel login --token` + per-URL credential store (`~/.config/requel`,
  owner-only perms), token precedence flag/env > stored.
- **M4 shared catalog** — `GatewayCommandCatalog` implemented as the authoritative source (derived
  from the same allowlist the policy enforces), exposed at `/api/gateway/commands/descriptors`, and
  a `requel commands` discovery subcommand. (Migrating MCP tool generation onto the catalog is a
  separate follow-up.)
- **M5 interactive OAuth** — `requel login --oauth` (authorization-code + PKCE, ephemeral loopback
  callback) against the #83 AS, a seeded first-party `requel-cli` client
  (`requel.oauth.seed-cli-client`), and auto-refresh of the access token via the rotating refresh
  token.
- **M6 packaging** — single executable fat jar via maven-shade + a thin `requel` wrapper.

Testing: unit/integration tests across all modules (REST gateways, catalog, PKCE, loopback callback,
OAuth client, token precedence + refresh, login orchestration, seeded-client shape). The interactive
OAuth browser flow is verified via doc/70-requel-cli-verification.md (can't run in CI).

Implementation plan: doc/70-requel-cli-plan.md.