### PR TITLE
requel-cli: read/query subcommands over the QueryGateway (#100)

### DIFF
--- a/doc/70-requel-cli-verification.md
+++ b/doc/70-requel-cli-verification.md
@@ -76,14 +76,20 @@ requel --url http://localhost:8080 commands
 requel --url http://localhost:8080 --output json commands | jq '.[0]'
 #   expect: {commandType, inputType, title, write:true, …}
 
-# Perform a real write as the logged-in user (use a project the user can edit)
-requel --url http://localhost:8080 run EditGoal --input '{"projectName":"Demo","name":"CLI smoke goal"}'
+# Read subcommands over the QueryGateway (#100) — find a project to write to
+requel --url http://localhost:8080 projects
+#   expect: one line per project you can see, with counts. Use a name from here below.
+requel --url http://localhost:8080 project "<name>" --tree     # content tree
+requel --url http://localhost:8080 search "<name>" goal        # find entities by name
+
+# Perform a real write as the logged-in user (use a project name from `requel projects`)
+requel --url http://localhost:8080 run EditGoal --input '{"projectName":"<name>","name":"CLI smoke goal"}'
 #   expect: OK EditGoal: … (id=…). The goal is created/edited as your user, through the gateway
 #   (allow/deny policy + per-stakeholder authorization enforced server-side).
 ```
 
-**Pass:** `commands` lists the catalog using the stored token; the write succeeds and is attributed to
-the logged-in user.
+**Pass:** `commands` lists the catalog and `projects` lists your projects using the stored token; the
+write succeeds and is attributed to the logged-in user.
 
 ## C. Writes-disabled and denylist behavior (optional, restart-gated)
 

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/AbstractQueryCommand.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/AbstractQueryCommand.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rreganjr.requel.gateway.QueryGateway;
+import com.rreganjr.requel.gateway.rest.RestQueryGateway;
+import java.util.concurrent.Callable;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+import picocli.CommandLine.ParentCommand;
+
+/**
+ * Base for {@code requel} read subcommands over the {@link QueryGateway} (#100). Handles building the
+ * REST-backed gateway from the parent's URL + token, mapping transport failures to exit codes, and
+ * rendering the result as text or {@code --output json}. Subclasses supply the query call and the
+ * text rendering. Reads go through {@code /api/gateway/query/**}, so read authorization is enforced
+ * server-side exactly as in the UI.
+ */
+abstract class AbstractQueryCommand implements Callable<Integer> {
+
+    @ParentCommand
+    RequelCli parent;
+
+    /** Test seam: when set, used instead of building a {@link RestQueryGateway} from the parent. */
+    QueryGateway queryOverride;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    /** Run the query against the gateway. */
+    protected abstract Object query(QueryGateway gateway);
+
+    /** Render the (non-null) result for text output. */
+    protected abstract String renderText(Object result);
+
+    @Override
+    public Integer call() {
+        QueryGateway gateway = (queryOverride != null) ? queryOverride
+                : new RestQueryGateway(parent.url, parent.tokenSource());
+        Object result;
+        try {
+            result = query(gateway);
+        } catch (RestClientResponseException e) {
+            System.err.println("Error: " + e.getStatusCode().value() + " " + e.getStatusText());
+            int status = e.getStatusCode().value();
+            return (status == 401 || status == 403) ? ExitCode.AUTH : ExitCode.REQUEST_ERROR;
+        } catch (RestClientException e) {
+            System.err.println("Failed to reach Requel: " + e.getMessage());
+            return ExitCode.REQUEST_ERROR;
+        }
+        if (parent.output == OutputFormat.JSON) {
+            System.out.println(json(result));
+        } else {
+            System.out.println(renderText(result));
+        }
+        return ExitCode.SUCCESS;
+    }
+
+    /** Pretty JSON for the result, falling back to {@code toString()} if serialization fails. */
+    protected String json(Object result) {
+        try {
+            return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(result);
+        } catch (JsonProcessingException e) {
+            return String.valueOf(result);
+        }
+    }
+}

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/ContextCommand.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/ContextCommand.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import com.rreganjr.requel.gateway.QueryGateway;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+/**
+ * {@code requel context <project>} — the composite project-context bundle (summary, tree, glossary,
+ * open issues), the same bundle an agent would prime on. Text output shows it as formatted JSON since
+ * it is a composite; use {@code --output json} for the raw bundle.
+ */
+@Command(name = "context", description = "Show a project's composite context bundle.")
+public class ContextCommand extends AbstractQueryCommand {
+
+    @Parameters(index = "0", paramLabel = "PROJECT", description = "Project name.")
+    String projectName;
+
+    @Override
+    protected Object query(QueryGateway gateway) {
+        return gateway.getProjectContext(projectName);
+    }
+
+    @Override
+    protected String renderText(Object result) {
+        return json(result);
+    }
+}

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/EntityCommand.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/EntityCommand.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import com.rreganjr.requel.gateway.QueryGateway;
+import com.rreganjr.requel.service.api.dto.EntityReferenceDto;
+import java.util.List;
+import java.util.Map;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+/**
+ * {@code requel entity <project> <type> <id> [--neighbors]} — read one entity by its domain-interface
+ * simple name (e.g. Goal, Story, Actor, UseCase, Scenario, GlossaryTerm) and id, or its related
+ * entities grouped by relationship with {@code --neighbors}.
+ */
+@Command(name = "entity", description = "Read one project entity by type + id (or its --neighbors).")
+public class EntityCommand extends AbstractQueryCommand {
+
+    @Parameters(index = "0", paramLabel = "PROJECT", description = "Project name.")
+    String projectName;
+
+    @Parameters(index = "1", paramLabel = "TYPE", description = "Entity type, e.g. Goal, Story, Actor.")
+    String entityType;
+
+    @Parameters(index = "2", paramLabel = "ID", description = "Entity id.")
+    long entityId;
+
+    @Option(names = "--neighbors", description = "Show related entities grouped by relationship.")
+    boolean neighbors;
+
+    @Override
+    protected Object query(QueryGateway gateway) {
+        return neighbors
+                ? gateway.getEntityNeighbors(projectName, entityType, entityId)
+                : gateway.getEntity(projectName, entityType, entityId);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected String renderText(Object result) {
+        if (!neighbors) {
+            // A single entity detail DTO — no fixed shape here, so show it as JSON.
+            return json(result);
+        }
+        Map<String, List<EntityReferenceDto>> byRelation = (Map<String, List<EntityReferenceDto>>) result;
+        if (byRelation.isEmpty()) {
+            return "No related entities.";
+        }
+        StringBuilder sb = new StringBuilder();
+        byRelation.forEach((relation, refs) -> {
+            if (sb.length() > 0) {
+                sb.append('\n');
+            }
+            sb.append(relation).append(':');
+            for (EntityReferenceDto r : refs) {
+                sb.append("\n  ").append(r.entityType()).append(" #").append(r.id())
+                        .append("  ").append(r.name());
+            }
+        });
+        return sb.toString();
+    }
+}

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/GlossaryCommand.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/GlossaryCommand.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import com.rreganjr.requel.gateway.QueryGateway;
+import com.rreganjr.requel.service.api.dto.GlossaryTermDto;
+import java.util.List;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+/** {@code requel glossary <project>} — the project's glossary terms. */
+@Command(name = "glossary", description = "List a project's glossary terms.")
+public class GlossaryCommand extends AbstractQueryCommand {
+
+    @Parameters(index = "0", paramLabel = "PROJECT", description = "Project name.")
+    String projectName;
+
+    @Override
+    protected Object query(QueryGateway gateway) {
+        return gateway.getGlossaryTerms(projectName);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected String renderText(Object result) {
+        List<GlossaryTermDto> terms = (List<GlossaryTermDto>) result;
+        if (terms.isEmpty()) {
+            return "No glossary terms.";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (GlossaryTermDto t : terms) {
+            if (sb.length() > 0) {
+                sb.append('\n');
+            }
+            sb.append(t.name());
+            if (t.text() != null && !t.text().isBlank()) {
+                sb.append(" — ").append(t.text());
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/OpenIssuesCommand.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/OpenIssuesCommand.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import com.rreganjr.requel.gateway.QueryGateway;
+import com.rreganjr.requel.service.api.dto.OpenIssueDto;
+import java.util.List;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+/** {@code requel open-issues <project>} — unresolved issues across the project's entities. */
+@Command(name = "open-issues", description = "List a project's unresolved issues.")
+public class OpenIssuesCommand extends AbstractQueryCommand {
+
+    @Parameters(index = "0", paramLabel = "PROJECT", description = "Project name.")
+    String projectName;
+
+    @Override
+    protected Object query(QueryGateway gateway) {
+        return gateway.getOpenIssues(projectName);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected String renderText(Object result) {
+        List<OpenIssueDto> issues = (List<OpenIssueDto>) result;
+        if (issues.isEmpty()) {
+            return "No open issues.";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (OpenIssueDto i : issues) {
+            if (sb.length() > 0) {
+                sb.append('\n');
+            }
+            sb.append('[').append(i.entityType()).append(' ').append(i.entityName()).append("] ")
+                    .append(i.issueText());
+            if (i.mustBeResolved()) {
+                sb.append("  (must resolve)");
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/ProjectCommand.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/ProjectCommand.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import com.rreganjr.requel.gateway.QueryGateway;
+import com.rreganjr.requel.service.api.dto.ProjectDto;
+import com.rreganjr.requel.service.api.dto.ProjectTreeNodeDto;
+import java.util.List;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+/** {@code requel project <name> [--tree]} — a project's summary, or its content tree. */
+@Command(name = "project", description = "Show a project's summary, or its content tree with --tree.")
+public class ProjectCommand extends AbstractQueryCommand {
+
+    @Parameters(index = "0", paramLabel = "PROJECT", description = "Project name.")
+    String projectName;
+
+    @Option(names = "--tree", description = "Show the project's content tree instead of a summary.")
+    boolean tree;
+
+    @Override
+    protected Object query(QueryGateway gateway) {
+        return tree ? gateway.getProjectTree(projectName) : gateway.getProject(projectName);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected String renderText(Object result) {
+        if (result instanceof ProjectDto p) {
+            return String.format("%s%s%n  %s%n  goals=%d stories=%d actors=%d useCases=%d "
+                    + "scenarios=%d glossary=%d stakeholders=%d",
+                    p.name(), p.status() == null ? "" : "  (" + p.status() + ")",
+                    p.description() == null ? "(no description)" : p.description(),
+                    p.goalCount(), p.storyCount(), p.actorCount(), p.useCaseCount(),
+                    p.scenarioCount(), p.glossaryTermCount(), p.stakeholderCount());
+        }
+        List<ProjectTreeNodeDto> nodes = (List<ProjectTreeNodeDto>) result;
+        StringBuilder sb = new StringBuilder();
+        renderNodes(nodes, 0, sb);
+        return sb.length() == 0 ? "(empty)" : sb.toString();
+    }
+
+    private static void renderNodes(List<ProjectTreeNodeDto> nodes, int depth, StringBuilder sb) {
+        if (nodes == null) {
+            return;
+        }
+        for (ProjectTreeNodeDto node : nodes) {
+            if (sb.length() > 0) {
+                sb.append('\n');
+            }
+            sb.append("  ".repeat(depth)).append("- ").append(node.name());
+            if (node.type() != null) {
+                sb.append(" [").append(node.type()).append(node.id() != null ? " #" + node.id() : "").append("]");
+            }
+            renderNodes(node.children(), depth + 1, sb);
+        }
+    }
+}

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/ProjectsCommand.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/ProjectsCommand.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import com.rreganjr.requel.gateway.QueryGateway;
+import com.rreganjr.requel.service.api.dto.ProjectDto;
+import java.util.List;
+import picocli.CommandLine.Command;
+
+/** {@code requel projects} — list the projects the authenticated user can see. */
+@Command(name = "projects", description = "List projects visible to you.")
+public class ProjectsCommand extends AbstractQueryCommand {
+
+    @Override
+    protected Object query(QueryGateway gateway) {
+        return gateway.listProjects();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected String renderText(Object result) {
+        List<ProjectDto> projects = (List<ProjectDto>) result;
+        if (projects.isEmpty()) {
+            return "No projects.";
+        }
+        int width = projects.stream().mapToInt(p -> p.name().length()).max().orElse(0);
+        StringBuilder sb = new StringBuilder();
+        for (ProjectDto p : projects) {
+            if (sb.length() > 0) {
+                sb.append('\n');
+            }
+            sb.append(String.format("%-" + width + "s  %s  (goals=%d stories=%d actors=%d useCases=%d)",
+                    p.name(), p.status() == null ? "" : p.status(),
+                    p.goalCount(), p.storyCount(), p.actorCount(), p.useCaseCount()));
+        }
+        return sb.toString();
+    }
+}

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/RequelCli.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/RequelCli.java
@@ -37,7 +37,10 @@ import picocli.CommandLine.Option;
  */
 @Command(name = "requel", mixinStandardHelpOptions = true, version = "requel-cli 2.0.0-dev",
         description = "Command-line access to a Requel server via the gateway.",
-        subcommands = {RunCommand.class, CommandsCommand.class, LoginCommand.class, LogoutCommand.class})
+        subcommands = {RunCommand.class, CommandsCommand.class,
+                ProjectsCommand.class, ProjectCommand.class, GlossaryCommand.class,
+                OpenIssuesCommand.class, SearchCommand.class, EntityCommand.class, ContextCommand.class,
+                LoginCommand.class, LogoutCommand.class})
 public class RequelCli implements Runnable {
 
     @Option(names = "--url", paramLabel = "URL",

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/SearchCommand.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/SearchCommand.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import com.rreganjr.requel.gateway.QueryGateway;
+import com.rreganjr.requel.service.api.dto.EntityReferenceDto;
+import java.util.List;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+/** {@code requel search <project> <query>} — find project entities by name (case-insensitive). */
+@Command(name = "search", description = "Search a project's entities by name.")
+public class SearchCommand extends AbstractQueryCommand {
+
+    @Parameters(index = "0", paramLabel = "PROJECT", description = "Project name.")
+    String projectName;
+
+    @Parameters(index = "1", paramLabel = "QUERY", description = "Name substring to match.")
+    String queryText;
+
+    @Override
+    protected Object query(QueryGateway gateway) {
+        return gateway.searchProjectEntities(projectName, queryText);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected String renderText(Object result) {
+        List<EntityReferenceDto> refs = (List<EntityReferenceDto>) result;
+        if (refs.isEmpty()) {
+            return "No matches.";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (EntityReferenceDto r : refs) {
+            if (sb.length() > 0) {
+                sb.append('\n');
+            }
+            sb.append(r.entityType()).append(" #").append(r.id()).append("  ").append(r.name());
+        }
+        return sb.toString();
+    }
+}

--- a/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/QueryCommandsTest.java
+++ b/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/QueryCommandsTest.java
@@ -1,0 +1,244 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.rreganjr.requel.gateway.QueryGateway;
+import com.rreganjr.requel.service.api.dto.EntityReferenceDto;
+import com.rreganjr.requel.service.api.dto.GlossaryTermDto;
+import com.rreganjr.requel.service.api.dto.OpenIssueDto;
+import com.rreganjr.requel.service.api.dto.ProjectDto;
+import com.rreganjr.requel.service.api.dto.ProjectTreeNodeDto;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+
+class QueryCommandsTest {
+
+    private static RequelCli parent(OutputFormat output) {
+        RequelCli p = new RequelCli();
+        p.url = "http://localhost:8080";
+        p.output = output;
+        return p;
+    }
+
+    private static ProjectDto project(String name) {
+        return new ProjectDto(1L, 0, name, "A demo project", "Org", "ron", "ACTIVE",
+                2, 3, 4, 5, 6, 7, 8, 0);
+    }
+
+    @Test
+    void projectsListsNamesInText() {
+        QueryGateway gw = mock(QueryGateway.class);
+        when(gw.listProjects()).thenReturn(List.of(project("Demo"), project("Other")));
+        ProjectsCommand cmd = new ProjectsCommand();
+        cmd.parent = parent(OutputFormat.TEXT);
+        cmd.queryOverride = gw;
+
+        String out = capture(() -> assertThat(cmd.call()).isEqualTo(ExitCode.SUCCESS));
+        assertThat(out).contains("Demo").contains("Other").contains("goals=3");
+    }
+
+    @Test
+    void projectsEmptyMessage() {
+        QueryGateway gw = mock(QueryGateway.class);
+        when(gw.listProjects()).thenReturn(List.of());
+        ProjectsCommand cmd = new ProjectsCommand();
+        cmd.parent = parent(OutputFormat.TEXT);
+        cmd.queryOverride = gw;
+
+        String out = capture(() -> assertThat(cmd.call()).isEqualTo(ExitCode.SUCCESS));
+        assertThat(out).contains("No projects.");
+    }
+
+    @Test
+    void projectsJsonOutput() {
+        QueryGateway gw = mock(QueryGateway.class);
+        when(gw.listProjects()).thenReturn(List.of(project("Demo")));
+        ProjectsCommand cmd = new ProjectsCommand();
+        cmd.parent = parent(OutputFormat.JSON);
+        cmd.queryOverride = gw;
+
+        String out = capture(() -> assertThat(cmd.call()).isEqualTo(ExitCode.SUCCESS));
+        assertThat(out.trim()).startsWith("[").contains("\"name\" : \"Demo\"");
+    }
+
+    @Test
+    void projectSummary() {
+        QueryGateway gw = mock(QueryGateway.class);
+        when(gw.getProject("Demo")).thenReturn(project("Demo"));
+        ProjectCommand cmd = new ProjectCommand();
+        cmd.parent = parent(OutputFormat.TEXT);
+        cmd.queryOverride = gw;
+        cmd.projectName = "Demo";
+
+        String out = capture(() -> assertThat(cmd.call()).isEqualTo(ExitCode.SUCCESS));
+        assertThat(out).contains("Demo").contains("stakeholders=2").contains("A demo project");
+    }
+
+    @Test
+    void projectTreeIndented() {
+        QueryGateway gw = mock(QueryGateway.class);
+        ProjectTreeNodeDto child = new ProjectTreeNodeDto(9L, "Goal", "G1");
+        ProjectTreeNodeDto group = new ProjectTreeNodeDto("GoalGroup", "Goals", List.of(child));
+        when(gw.getProjectTree("Demo")).thenReturn(List.of(group));
+        ProjectCommand cmd = new ProjectCommand();
+        cmd.parent = parent(OutputFormat.TEXT);
+        cmd.queryOverride = gw;
+        cmd.projectName = "Demo";
+        cmd.tree = true;
+
+        String out = capture(() -> assertThat(cmd.call()).isEqualTo(ExitCode.SUCCESS));
+        assertThat(out).contains("- Goals").contains("  - G1 [Goal #9]");
+    }
+
+    @Test
+    void glossaryTerms() {
+        QueryGateway gw = mock(QueryGateway.class);
+        when(gw.getGlossaryTerms("Demo")).thenReturn(List.of(
+                new GlossaryTermDto(1L, 0, "SLA", "Service level agreement", "ron", null, null, null, null)));
+        GlossaryCommand cmd = new GlossaryCommand();
+        cmd.parent = parent(OutputFormat.TEXT);
+        cmd.queryOverride = gw;
+        cmd.projectName = "Demo";
+
+        String out = capture(() -> assertThat(cmd.call()).isEqualTo(ExitCode.SUCCESS));
+        assertThat(out).contains("SLA — Service level agreement");
+    }
+
+    @Test
+    void openIssues() {
+        QueryGateway gw = mock(QueryGateway.class);
+        when(gw.getOpenIssues("Demo")).thenReturn(List.of(
+                new OpenIssueDto(5L, "Ambiguous wording", true, "Goal", 3L, "Login goal")));
+        OpenIssuesCommand cmd = new OpenIssuesCommand();
+        cmd.parent = parent(OutputFormat.TEXT);
+        cmd.queryOverride = gw;
+        cmd.projectName = "Demo";
+
+        String out = capture(() -> assertThat(cmd.call()).isEqualTo(ExitCode.SUCCESS));
+        assertThat(out).contains("[Goal Login goal] Ambiguous wording").contains("(must resolve)");
+    }
+
+    @Test
+    void search() {
+        QueryGateway gw = mock(QueryGateway.class);
+        when(gw.searchProjectEntities("Demo", "log")).thenReturn(List.of(
+                new EntityReferenceDto("Goal", 3L, "Login goal")));
+        SearchCommand cmd = new SearchCommand();
+        cmd.parent = parent(OutputFormat.TEXT);
+        cmd.queryOverride = gw;
+        cmd.projectName = "Demo";
+        cmd.queryText = "log";
+
+        String out = capture(() -> assertThat(cmd.call()).isEqualTo(ExitCode.SUCCESS));
+        assertThat(out).contains("Goal #3").contains("Login goal");
+    }
+
+    @Test
+    void entityNeighborsGrouped() {
+        QueryGateway gw = mock(QueryGateway.class);
+        when(gw.getEntityNeighbors("Demo", "Goal", 3L)).thenReturn(Map.of(
+                "refinedBy", List.of(new EntityReferenceDto("Goal", 4L, "Sub goal"))));
+        EntityCommand cmd = new EntityCommand();
+        cmd.parent = parent(OutputFormat.TEXT);
+        cmd.queryOverride = gw;
+        cmd.projectName = "Demo";
+        cmd.entityType = "Goal";
+        cmd.entityId = 3L;
+        cmd.neighbors = true;
+
+        String out = capture(() -> assertThat(cmd.call()).isEqualTo(ExitCode.SUCCESS));
+        assertThat(out).contains("refinedBy:").contains("Goal #4").contains("Sub goal");
+    }
+
+    @Test
+    void entitySingleRendersAsJson() {
+        QueryGateway gw = mock(QueryGateway.class);
+        when(gw.getEntity("Demo", "Goal", 3L)).thenReturn(Map.of("id", 3, "name", "Login goal"));
+        EntityCommand cmd = new EntityCommand();
+        cmd.parent = parent(OutputFormat.TEXT);
+        cmd.queryOverride = gw;
+        cmd.projectName = "Demo";
+        cmd.entityType = "Goal";
+        cmd.entityId = 3L;
+
+        String out = capture(() -> assertThat(cmd.call()).isEqualTo(ExitCode.SUCCESS));
+        assertThat(out).contains("\"name\" : \"Login goal\"");
+    }
+
+    @Test
+    void contextRendersBundle() {
+        QueryGateway gw = mock(QueryGateway.class);
+        when(gw.getProjectContext("Demo")).thenReturn(Map.of("project", Map.of("name", "Demo"),
+                "openIssues", List.of()));
+        ContextCommand cmd = new ContextCommand();
+        cmd.parent = parent(OutputFormat.TEXT);
+        cmd.queryOverride = gw;
+        cmd.projectName = "Demo";
+
+        String out = capture(() -> assertThat(cmd.call()).isEqualTo(ExitCode.SUCCESS));
+        assertThat(out).contains("\"project\"").contains("Demo");
+    }
+
+    @Test
+    void unauthorizedReturnsAuthCode() {
+        QueryGateway gw = mock(QueryGateway.class);
+        when(gw.listProjects()).thenThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED));
+        ProjectsCommand cmd = new ProjectsCommand();
+        cmd.parent = parent(OutputFormat.TEXT);
+        cmd.queryOverride = gw;
+
+        assertThat(cmd.call()).isEqualTo(ExitCode.AUTH);
+    }
+
+    @Test
+    void otherHttpErrorReturnsRequestErrorCode() {
+        QueryGateway gw = mock(QueryGateway.class);
+        when(gw.getProject("Demo")).thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+        ProjectCommand cmd = new ProjectCommand();
+        cmd.parent = parent(OutputFormat.TEXT);
+        cmd.queryOverride = gw;
+        cmd.projectName = "Demo";
+
+        assertThat(cmd.call()).isEqualTo(ExitCode.REQUEST_ERROR);
+    }
+
+    private static String capture(Runnable body) {
+        PrintStream original = System.out;
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(buf, true, StandardCharsets.UTF_8));
+        try {
+            body.run();
+        } finally {
+            System.setOut(original);
+        }
+        return buf.toString(StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
Adds read subcommands to requel-cli so the tool is usable day-to-day without dropping to curl —
notably `requel projects` to find a project to act on. Thin layer over the existing QueryGateway /
RestQueryGateway (`/api/gateway/query/**`); read authorization is enforced server-side exactly as in
the UI, and auth reuses CliTokenSource (PAT or OAuth).

Subcommands (each 1:1 with a QueryGateway method, text or `--output json`):
- `projects` — visible projects with entity counts.
- `project <name> [--tree]` — summary, or the indented content tree.
- `glossary <project>` — glossary terms.
- `open-issues <project>` — unresolved issues (with entity + must-resolve marker).
- `search <project> <query>` — entities whose name matches.
- `entity <project> <type> <id> [--neighbors]` — one entity, or its related entities by relationship.
- `context <project>` — the composite context bundle.

All share `AbstractQueryCommand` (gateway build + error→exit-code mapping + text/JSON rendering) and
are covered by `QueryCommandsTest` (mocked QueryGateway: rendering, JSON, empty cases, tree
indentation, 401→AUTH / 404→REQUEST_ERROR). Runbook Part B updated to use `requel projects`.

Closes #100.