### PR TITLE
Generate MCP write tools from the shared GatewayCommandCatalog

### DIFF
--- a/doc/VS_CODE_MCP.md
+++ b/doc/VS_CODE_MCP.md
@@ -215,7 +215,7 @@ curl -N -H "Authorization: Bearer $REQUEL_TOKEN" http://localhost:8080/api/mcp/s
 ```
 
 In the client, list tools and call `listProjects` to confirm reads; if writes are enabled, try
-`createGoal` against a project you have `Goal[Edit]` on.
+`EditGoal` against a project you have `Goal[Edit]` on.
 
 ## Security notes
 

--- a/doc/local_mcp_bridge.md
+++ b/doc/local_mcp_bridge.md
@@ -165,11 +165,14 @@ Two complementary styles, both routed through `CommandGateway`:
 1. **Generic command tool** — `requel.runCommand(commandType, input)`. Dispatches any
    allowlisted command type; near-zero marginal cost to cover the full set; ideal for
    CLI/scripting. Guarded by the policy below.
-2. **Typed convenience tools** — curated schemas for common authoring: `requel.editGoal`,
-   `requel.editStory`, `requel.editActor`, `requel.editUseCase`, `requel.editScenario`,
-   `requel.editGlossaryTerm`, `requel.editNonUserStakeholder`,
-   `requel.addEntityToContainer` (wraps the polymorphic `Add*ToContainer` via
-   `childType`/`containerType`/`containerId`), `requel.editNote`.
+2. **Typed tools** — one per command in the shared `GatewayCommandCatalog` (issue #104). Each is
+   **named after its command type** (`EditGoal`, `EditStory`, `EditActor`, `EditUseCase`,
+   `EditScenario`, `EditGlossaryTerm`, `EditNonUserStakeholder`, `AddGoalToGoalContainer`,
+   `EditNote`, `EditIssue`, `Delete*`, …) and its JSON schema is derived from the command's
+   registered input DTO. Because the catalog is built from the same allowlist the policy enforces,
+   the typed tool set can't drift from what the gateway permits. (There is no separate
+   `create*`/`edit*` split — a single `Edit*` tool creates when no id is supplied and updates
+   otherwise.)
 
 Ship both: generic for coverage/scripting, typed for AI affordances. Typed tools are sugar over
 the same dispatch path, not a second write path.
@@ -204,7 +207,7 @@ Source-agnostic; Jira shown as the example.
    requirements from the body. (No Requel involvement.)
 2. **Resolve the target project** (`requel.getProject` / `requel.listProjects`).
 3. **Load existing goals** (`requel.getProjectContext`) to compare against the requirements.
-4. **For each requirement:** `requel.editGoal` (create/update), then `requel.editNote` on the
+4. **For each requirement:** `EditGoal` (create/update), then `EditNote` on the
    returned goal id with provenance: client, `sourceSystem`/`sourceRef`/`sourceUrl`, criterion
    reference.
 5. **Report** goals created vs. updated, with ids and the source ref, for review.

--- a/doc/mcp_remote_connection.md
+++ b/doc/mcp_remote_connection.md
@@ -161,7 +161,7 @@ In `claude_desktop_config.json` (Settings → Developer → Edit Config):
 }
 ```
 
-Restart Claude Desktop. The Requel tools (`listProjects`, `getProject`, `createGoal`, `runCommand`,
+Restart Claude Desktop. The Requel tools (`listProjects`, `getProject`, `EditGoal`, `runCommand`,
 …) appear in the tools list. Write tools only appear when the server has writes enabled.
 
 `--transport sse-only` is important: `mcp-remote` defaults to Streamable HTTP and probes it first;
@@ -229,7 +229,7 @@ curl -N -H "Authorization: Bearer $REQUEL_TOKEN" http://localhost:8080/api/mcp/s
 ```
 
 In the client, list tools and call `listProjects` to confirm reads, then (if writes are on)
-`createGoal` against a project you have `Goal[Edit]` on.
+`EditGoal` against a project you have `Goal[Edit]` on.
 
 ## Security notes
 

--- a/modules/gateway-api/src/main/java/com/rreganjr/requel/gateway/GatewayCommandCatalog.java
+++ b/modules/gateway-api/src/main/java/com/rreganjr/requel/gateway/GatewayCommandCatalog.java
@@ -35,4 +35,22 @@ public interface GatewayCommandCatalog {
 
     /** Look up one descriptor by command type. */
     Optional<CommandDescriptor> find(String commandType);
+
+    /**
+     * An empty catalog exposing no commands. Useful for read-only deployments and tests where a
+     * catalog is required but no write surface should be advertised.
+     */
+    static GatewayCommandCatalog empty() {
+        return new GatewayCommandCatalog() {
+            @Override
+            public List<CommandDescriptor> descriptors() {
+                return List.of();
+            }
+
+            @Override
+            public Optional<CommandDescriptor> find(String commandType) {
+                return Optional.empty();
+            }
+        };
+    }
 }

--- a/modules/mcp-server/src/main/java/com/rreganjr/requel/mcp/McpReadService.java
+++ b/modules/mcp-server/src/main/java/com/rreganjr/requel/mcp/McpReadService.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rreganjr.requel.assistant.api.AnnotationAction;
 import com.rreganjr.requel.assistant.api.EntityRef;
+import com.rreganjr.requel.gateway.GatewayCommandCatalog;
 import com.rreganjr.requel.gateway.QueryGateway;
 
 @Service
@@ -55,10 +56,12 @@ public class McpReadService {
 
 	/**
 	 * Convenience constructor for read-only deployments and tests: no write tools are exposed
-	 * (a disabled {@link McpWriteService} with no command gateway) and the no-op rate limiter.
+	 * (a disabled {@link McpWriteService} with no command gateway and an empty catalog) and the
+	 * no-op rate limiter.
 	 */
 	public McpReadService(QueryGateway projectQueryGateway, ObjectMapper objectMapper) {
-		this(projectQueryGateway, new McpWriteService(null, objectMapper, false),
+		this(projectQueryGateway,
+				new McpWriteService(null, GatewayCommandCatalog.empty(), objectMapper, false),
 				McpRateLimiter.NOOP, objectMapper);
 	}
 

--- a/modules/mcp-server/src/main/java/com/rreganjr/requel/mcp/McpWriteService.java
+++ b/modules/mcp-server/src/main/java/com/rreganjr/requel/mcp/McpWriteService.java
@@ -20,6 +20,9 @@
  */
 package com.rreganjr.requel.mcp;
 
+import java.lang.reflect.RecordComponent;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -28,16 +31,22 @@ import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rreganjr.requel.gateway.CommandDescriptor;
 import com.rreganjr.requel.gateway.CommandGateway;
+import com.rreganjr.requel.gateway.GatewayCommandCatalog;
 import com.rreganjr.requel.gateway.GatewayException;
 import com.rreganjr.requel.gateway.GatewayRequest;
 import com.rreganjr.requel.gateway.GatewayResult;
 
 /**
  * MCP write tools, backed by the {@link CommandGateway}. Exposes a generic
- * {@code runCommand} (any allowlisted command type + JSON input) plus a curated set of
- * ergonomic typed tools whose argument names already match the command input DTOs, so they are
- * thin wrappers that fix the command type and forward the arguments.
+ * {@code runCommand} (any allowlisted command type + JSON input) plus one typed tool per command
+ * in the shared {@link GatewayCommandCatalog}. The catalog is the single source of truth for the
+ * gateway's exposed write surface — the same set the allow/deny {@code CommandPolicy} enforces and
+ * the CLI discovers via {@code /api/gateway/commands/descriptors} — so MCP, the CLI, and the policy
+ * stay in lockstep (issue #104). Each typed tool is named after its command type (e.g.
+ * {@code EditGoal}) and its JSON schema is derived from the command's registered input DTO, so the
+ * tools can never drift from what the gateway actually permits.
  * <p>
  * Writes are <strong>opt-in</strong> via {@code requel.gateway.write.enabled} (default
  * {@code false}). When disabled, the write tools are omitted from {@code tools/list} and any direct
@@ -51,22 +60,16 @@ public class McpWriteService {
 	/** Generic escape hatch: run any allowlisted command by type + input. */
 	static final String RUN_COMMAND = "runCommand";
 
-	/** Typed convenience tools -> the gateway command type each forwards to. */
-	private static final Map<String, String> TYPED_TOOLS = Map.of(
-			"createProject", "EditProject",
-			"createGoal", "EditGoal",
-			"editGoal", "EditGoal",
-			"addGoalToContainer", "AddGoalToGoalContainer",
-			"createNote", "EditNote",
-			"createIssue", "EditIssue");
-
 	private final CommandGateway commandGateway;
+	private final GatewayCommandCatalog catalog;
 	private final ObjectMapper objectMapper;
 	private final boolean writeEnabled;
 
-	public McpWriteService(CommandGateway commandGateway, ObjectMapper objectMapper,
+	public McpWriteService(CommandGateway commandGateway, GatewayCommandCatalog catalog,
+			ObjectMapper objectMapper,
 			@Value("${requel.gateway.write.enabled:false}") boolean writeEnabled) {
 		this.commandGateway = commandGateway;
+		this.catalog = catalog;
 		this.objectMapper = objectMapper;
 		this.writeEnabled = writeEnabled;
 	}
@@ -77,7 +80,7 @@ public class McpWriteService {
 
 	/** @return true if {@code toolName} is a write tool (regardless of the opt-in flag). */
 	public boolean handles(String toolName) {
-		return RUN_COMMAND.equals(toolName) || TYPED_TOOLS.containsKey(toolName);
+		return RUN_COMMAND.equals(toolName) || catalog.find(toolName).isPresent();
 	}
 
 	/** Write tool descriptors for {@code tools/list}; empty when the write flag is disabled. */
@@ -85,45 +88,19 @@ public class McpWriteService {
 		if (!writeEnabled) {
 			return List.of();
 		}
-		return List.of(
-				new McpToolDescriptor(RUN_COMMAND,
-						"Execute any gateway-allowlisted Requel command by type with a JSON input"
-								+ " object. Subject to the gateway allow/deny policy and the caller's"
-								+ " stakeholder permissions.",
-						runCommandSchema()),
-				new McpToolDescriptor("createProject",
-						"Create a project. Arguments: name, organizationName, optional description.",
-						objectSchema(Map.of("name", stringType(), "organizationName", stringType(),
-								"description", stringType()), List.of("name", "organizationName"))),
-				new McpToolDescriptor("createGoal",
-						"Create a goal in a project. Arguments: projectName, name, optional text.",
-						objectSchema(Map.of("projectName", stringType(), "name", stringType(),
-								"text", stringType()), List.of("projectName", "name"))),
-				new McpToolDescriptor("editGoal",
-						"Edit an existing goal. Arguments: projectName, goalId, optional name/text.",
-						objectSchema(Map.of("projectName", stringType(), "goalId", integerType(),
-								"name", stringType(), "text", stringType()),
-								List.of("projectName", "goalId"))),
-				new McpToolDescriptor("addGoalToContainer",
-						"Associate a goal with a container (Project, Story, UseCase, Actor, or"
-								+ " Stakeholder). Arguments: projectName, goalId, goalContainerId,"
-								+ " containerType.",
-						objectSchema(Map.of("projectName", stringType(), "goalId", integerType(),
-								"goalContainerId", integerType(), "containerType", stringType()),
-								List.of("projectName", "goalId", "goalContainerId", "containerType"))),
-				new McpToolDescriptor("createNote",
-						"Attach a note to an entity. Arguments: projectName, entityType, entityId,"
-								+ " text.",
-						objectSchema(Map.of("projectName", stringType(), "entityType", stringType(),
-								"entityId", integerType(), "text", stringType()),
-								List.of("projectName", "entityType", "entityId", "text"))),
-				new McpToolDescriptor("createIssue",
-						"Raise an issue on an entity. Arguments: projectName, entityType, entityId,"
-								+ " text, optional mustBeResolved.",
-						objectSchema(Map.of("projectName", stringType(), "entityType", stringType(),
-								"entityId", integerType(), "text", stringType(),
-								"mustBeResolved", booleanType()),
-								List.of("projectName", "entityType", "entityId", "text"))));
+		List<McpToolDescriptor> tools = new ArrayList<>();
+		tools.add(new McpToolDescriptor(RUN_COMMAND,
+				"Execute any gateway-allowlisted Requel command by type with a JSON input"
+						+ " object. Subject to the gateway allow/deny policy and the caller's"
+						+ " stakeholder permissions.",
+				runCommandSchema()));
+		// One typed tool per catalog command, generated from the shared catalog so the MCP write
+		// surface is exactly the gateway's exposed write surface (issue #104).
+		for (CommandDescriptor descriptor : catalog.descriptors()) {
+			tools.add(new McpToolDescriptor(descriptor.commandType(), describe(descriptor),
+					schemaFor(descriptor.inputType())));
+		}
+		return tools;
 	}
 
 	/**
@@ -140,12 +117,12 @@ public class McpWriteService {
 			JsonNode input = arguments == null ? null : arguments.get("input");
 			return execute(commandType, input == null || input.isNull() ? Map.of() : toMap(input));
 		}
-		String commandType = TYPED_TOOLS.get(toolName);
-		if (commandType == null) {
+		// Typed tool: the tool name IS the catalog command type, and its argument names already
+		// match the command input DTO field names, so forward the arguments as-is.
+		if (catalog.find(toolName).isEmpty()) {
 			throw new McpInvalidParamsException("Unknown MCP write tool: " + toolName);
 		}
-		// Typed-tool arguments already match the command input DTO field names; forward as-is.
-		return execute(commandType, arguments == null ? Map.of() : toMap(arguments));
+		return execute(toolName, arguments == null ? Map.of() : toMap(arguments));
 	}
 
 	private Object execute(String commandType, Object input) {
@@ -165,13 +142,102 @@ public class McpWriteService {
 		}
 	}
 
-	// ---- schema + json helpers -----------------------------------------------------------------
+	// ---- schema + description helpers ----------------------------------------------------------
+
+	/** Human-readable tool description: the catalog title/description plus the input field names. */
+	private static String describe(CommandDescriptor descriptor) {
+		String base = descriptor.description() != null && !descriptor.description().isBlank()
+				? descriptor.description()
+				: descriptor.title();
+		List<String> fields = fieldNames(descriptor.inputType());
+		String fieldHint = fields.isEmpty() ? "" : " Input fields: " + String.join(", ", fields) + ".";
+		return base + "." + fieldHint;
+	}
 
 	private Map<String, Object> runCommandSchema() {
 		return objectSchema(Map.of(
 				"commandType", stringType(),
 				"input", Map.of("type", "object")),
 				List.of("commandType"));
+	}
+
+	/**
+	 * Derive a JSON schema for a command's input DTO. Input DTOs are Java records, so each record
+	 * component becomes a typed property. A component is marked <em>required</em> when it carries a
+	 * {@code jakarta.validation} {@code @NotNull}/{@code @NotBlank} annotation — those annotations
+	 * encode the fields the command's applicator dereferences unconditionally (issue #104). Unknown
+	 * fields are rejected so typos surface early. A {@code null}/{@link Void} input type yields an
+	 * empty object schema.
+	 */
+	private static Map<String, Object> schemaFor(Class<?> inputType) {
+		if (inputType == null || inputType == Void.class || !inputType.isRecord()) {
+			return objectSchema(Map.of(), List.of());
+		}
+		Map<String, Object> properties = new LinkedHashMap<>();
+		List<String> required = new ArrayList<>();
+		for (RecordComponent component : inputType.getRecordComponents()) {
+			properties.put(component.getName(), jsonType(component.getType()));
+			if (isRequired(component)) {
+				required.add(component.getName());
+			}
+		}
+		return objectSchema(properties, required);
+	}
+
+	/**
+	 * A record component is required when it (or its generated accessor) carries a
+	 * {@code jakarta.validation} {@code @NotNull} or {@code @NotBlank} annotation. Matched by fully
+	 * qualified name so this module needs no compile-time dependency on the validation API.
+	 */
+	private static boolean isRequired(RecordComponent component) {
+		return hasRequiredAnnotation(component.getAnnotations())
+				|| hasRequiredAnnotation(component.getAccessor().getAnnotations());
+	}
+
+	private static boolean hasRequiredAnnotation(java.lang.annotation.Annotation[] annotations) {
+		for (java.lang.annotation.Annotation a : annotations) {
+			String name = a.annotationType().getName();
+			if (name.equals("jakarta.validation.constraints.NotNull")
+					|| name.equals("jakarta.validation.constraints.NotBlank")) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static List<String> fieldNames(Class<?> inputType) {
+		if (inputType == null || inputType == Void.class || !inputType.isRecord()) {
+			return List.of();
+		}
+		List<String> names = new ArrayList<>();
+		for (RecordComponent component : inputType.getRecordComponents()) {
+			names.add(component.getName());
+		}
+		return names;
+	}
+
+	/** Map a Java type to a JSON-schema type node. */
+	private static Map<String, Object> jsonType(Class<?> type) {
+		if (type == String.class || type == Character.class || type == char.class) {
+			return stringType();
+		}
+		if (type == Boolean.class || type == boolean.class) {
+			return booleanType();
+		}
+		if (type == Integer.class || type == int.class || type == Long.class || type == long.class
+				|| type == Short.class || type == short.class || type == Byte.class
+				|| type == byte.class) {
+			return integerType();
+		}
+		if (type == Double.class || type == double.class || type == Float.class
+				|| type == float.class) {
+			return Map.of("type", "number");
+		}
+		if (Iterable.class.isAssignableFrom(type) || type.isArray()) {
+			return Map.of("type", "array");
+		}
+		// Enums serialize as their name; everything else is a nested object.
+		return type.isEnum() ? stringType() : Map.of("type", "object");
 	}
 
 	private static Map<String, Object> objectSchema(Map<String, Object> properties,

--- a/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/McpReadServiceTest.java
+++ b/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/McpReadServiceTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rreganjr.requel.gateway.GatewayCommandCatalog;
 
 class McpReadServiceTest {
 
@@ -43,7 +44,8 @@ class McpReadServiceTest {
 			throw new McpRateLimitExceededException("over limit for " + toolName);
 		};
 		McpReadService limited = new McpReadService(new StubProjectQueryGateway(),
-				new McpWriteService(null, objectMapper, false), blocking, objectMapper);
+				new McpWriteService(null, GatewayCommandCatalog.empty(), objectMapper, false),
+				blocking, objectMapper);
 		assertThatThrownBy(() -> limited.callTool(json("""
 				{ "name": "getProject", "arguments": { "projectName": "Sample" } }
 				""")))

--- a/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/McpTestCatalog.java
+++ b/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/McpTestCatalog.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.mcp;
+
+import com.rreganjr.requel.gateway.CommandDescriptor;
+import com.rreganjr.requel.gateway.GatewayCommandCatalog;
+import com.rreganjr.requel.service.api.dto.AddGoalToGoalContainerInput;
+import com.rreganjr.requel.service.api.dto.EditGoalInput;
+import com.rreganjr.requel.service.api.dto.EditIssueInput;
+import com.rreganjr.requel.service.api.dto.EditNoteInput;
+import com.rreganjr.requel.service.api.dto.EditProjectInput;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A small, representative {@link GatewayCommandCatalog} for MCP unit tests: a handful of the real
+ * allowlisted command types wired to their real input DTOs, so tool-name and schema generation is
+ * exercised against genuine records without booting a Spring context.
+ */
+final class McpTestCatalog {
+
+	private McpTestCatalog() {
+	}
+
+	/** A representative catalog covering create/edit, association, and annotation commands. */
+	static GatewayCommandCatalog sample() {
+		Map<String, CommandDescriptor> byType = new LinkedHashMap<>();
+		add(byType, "EditProject", EditProjectInput.class, "Edit Project");
+		add(byType, "EditGoal", EditGoalInput.class, "Edit Goal");
+		add(byType, "AddGoalToGoalContainer", AddGoalToGoalContainerInput.class,
+				"Add Goal To Goal Container");
+		add(byType, "EditNote", EditNoteInput.class, "Edit Note");
+		add(byType, "EditIssue", EditIssueInput.class, "Edit Issue");
+		return of(byType);
+	}
+
+	private static void add(Map<String, CommandDescriptor> byType, String commandType,
+			Class<?> inputType, String title) {
+		byType.put(commandType,
+				new CommandDescriptor(commandType, inputType, title, null, true, null));
+	}
+
+	private static GatewayCommandCatalog of(Map<String, CommandDescriptor> byType) {
+		List<CommandDescriptor> descriptors = List.copyOf(byType.values());
+		return new GatewayCommandCatalog() {
+			@Override
+			public List<CommandDescriptor> descriptors() {
+				return descriptors;
+			}
+
+			@Override
+			public Optional<CommandDescriptor> find(String commandType) {
+				return Optional.ofNullable(byType.get(commandType));
+			}
+		};
+	}
+}

--- a/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/McpToolNamingTest.java
+++ b/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/McpToolNamingTest.java
@@ -46,7 +46,8 @@ class McpToolNamingTest {
 	void allAdvertisedToolNamesMatchTheMcpPattern() {
 		// Write-enabled so the write tools are advertised and checked too.
 		McpWriteService writes = new McpWriteService(
-				request -> new GatewayResult(request.commandType(), null), objectMapper, true);
+				request -> new GatewayResult(request.commandType(), null),
+				McpTestCatalog.sample(), objectMapper, true);
 		McpReadService service = new McpReadService(new StubProjectQueryGateway(), writes,
 				McpRateLimiter.NOOP, objectMapper);
 
@@ -60,6 +61,6 @@ class McpToolNamingTest {
 						.matches(MCP_TOOL_NAME));
 		// Sanity: both a read and a write tool are present.
 		assertThat(tools).extracting(McpToolDescriptor::name)
-				.contains("listProjects", "createGoal", "runCommand");
+				.contains("listProjects", "EditGoal", "runCommand");
 	}
 }

--- a/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/McpWriteCatalogLockstepTest.java
+++ b/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/McpWriteCatalogLockstepTest.java
@@ -1,0 +1,89 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rreganjr.requel.gateway.CommandDescriptor;
+import com.rreganjr.requel.gateway.GatewayCommandCatalog;
+import com.rreganjr.requel.gateway.GatewayResult;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Lockstep guard (issue #104): the MCP typed write tools are generated <em>from</em> the shared
+ * {@link GatewayCommandCatalog}, so the set of typed write tools must be exactly the catalog's
+ * command types (plus the generic {@code runCommand} escape hatch). This is the {@code MCP tools ⊆
+ * catalog} regression — if the catalog and the advertised tools ever diverge, this fails. The
+ * full-context, real-allowlist version lives in {@code McpToolCatalogLockstepIT} (requel-app).
+ */
+class McpWriteCatalogLockstepTest {
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+	private final GatewayCommandCatalog catalog = McpTestCatalog.sample();
+	private final McpWriteService writes = new McpWriteService(
+			request -> new GatewayResult(request.commandType(), null), catalog, objectMapper, true);
+
+	@Test
+	void everyTypedWriteToolMapsToACatalogCommand() {
+		List<String> catalogTypes = catalog.descriptors().stream()
+				.map(CommandDescriptor::commandType).toList();
+
+		List<String> typedToolNames = writes.toolDescriptors().stream()
+				.map(McpToolDescriptor::name)
+				.filter(name -> !name.equals(McpWriteService.RUN_COMMAND))
+				.toList();
+
+		// Subset (⊆) AND coverage: the typed write surface is exactly the catalog.
+		assertThat(typedToolNames).allSatisfy(name ->
+				assertThat(catalog.find(name)).as("tool '%s' must be in the catalog", name)
+						.isPresent());
+		assertThat(typedToolNames).containsExactlyInAnyOrderElementsOf(catalogTypes);
+	}
+
+	@Test
+	void handlesEveryCatalogCommandAndTheGenericTool() {
+		assertThat(writes.handles(McpWriteService.RUN_COMMAND)).isTrue();
+		catalog.descriptors().forEach(d ->
+				assertThat(writes.handles(d.commandType()))
+						.as("handles('%s')", d.commandType()).isTrue());
+		assertThat(writes.handles("NotACommand")).isFalse();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void toolSchemaIsDerivedFromTheCommandInputDto() {
+		McpToolDescriptor editGoal = writes.toolDescriptors().stream()
+				.filter(t -> t.name().equals("EditGoal")).findFirst().orElseThrow();
+
+		var properties = (java.util.Map<String, Object>) editGoal.inputSchema().get("properties");
+		// EditGoalInput(projectName, goalId, name, text, version) → typed JSON schema properties.
+		assertThat(properties).containsKeys("projectName", "goalId", "name", "text", "version");
+		assertThat(editGoal.inputSchema()).containsEntry("additionalProperties", false);
+
+		// Required is derived from the @NotBlank annotations the command applicator implies:
+		// projectName + name are unconditional; goalId/text/version are create-or-update/optional.
+		var required = (java.util.List<String>) editGoal.inputSchema().get("required");
+		assertThat(required).containsExactlyInAnyOrder("projectName", "name");
+		assertThat(required).doesNotContain("goalId", "text", "version");
+	}
+}

--- a/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/McpWriteServiceSchemaTest.java
+++ b/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/McpWriteServiceSchemaTest.java
@@ -1,0 +1,145 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rreganjr.requel.gateway.CommandDescriptor;
+import com.rreganjr.requel.gateway.GatewayCommandCatalog;
+import com.rreganjr.requel.gateway.GatewayResult;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the input-DTO → JSON-schema generation in {@link McpWriteService#toolDescriptors()}:
+ * every Java-to-JSON type mapping, required-field derivation from {@code @NotNull}/{@code @NotBlank},
+ * the description synthesis, and the empty/{@link Void} input case.
+ */
+class McpWriteServiceSchemaTest {
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	enum Color { RED, GREEN }
+
+	/** A record covering every jsonType branch, with a required String and a required Long. */
+	record RichInput(
+			@NotBlank String name,
+			@NotNull Long id,
+			int count,
+			boolean flag,
+			Double ratio,
+			Color color,
+			List<String> tags,
+			Object blob) {
+	}
+
+	private McpWriteService serviceFor(CommandDescriptor... descriptors) {
+		GatewayCommandCatalog catalog = new GatewayCommandCatalog() {
+			@Override
+			public List<CommandDescriptor> descriptors() {
+				return List.of(descriptors);
+			}
+
+			@Override
+			public Optional<CommandDescriptor> find(String commandType) {
+				return List.of(descriptors).stream()
+						.filter(d -> d.commandType().equals(commandType)).findFirst();
+			}
+		};
+		return new McpWriteService(request -> new GatewayResult(request.commandType(), null),
+				catalog, objectMapper, true);
+	}
+
+	private McpToolDescriptor tool(McpWriteService svc, String name) {
+		return svc.toolDescriptors().stream().filter(t -> t.name().equals(name))
+				.findFirst().orElseThrow();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void mapsEveryJavaTypeToItsJsonType() {
+		McpWriteService svc = serviceFor(
+				new CommandDescriptor("Rich", RichInput.class, "Rich", "Does a thing", true, null));
+		Map<String, Object> schema = tool(svc, "Rich").inputSchema();
+		var props = (Map<String, Object>) schema.get("properties");
+
+		assertThat(props.get("name")).isEqualTo(Map.of("type", "string"));
+		assertThat(props.get("id")).isEqualTo(Map.of("type", "integer"));
+		assertThat(props.get("count")).isEqualTo(Map.of("type", "integer"));   // primitive int
+		assertThat(props.get("flag")).isEqualTo(Map.of("type", "boolean"));    // primitive boolean
+		assertThat(props.get("ratio")).isEqualTo(Map.of("type", "number"));    // Double
+		assertThat(props.get("color")).isEqualTo(Map.of("type", "string"));    // enum → string
+		assertThat(props.get("tags")).isEqualTo(Map.of("type", "array"));      // List → array
+		assertThat(props.get("blob")).isEqualTo(Map.of("type", "object"));     // fallback object
+		assertThat(schema).containsEntry("additionalProperties", false);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void derivesRequiredOnlyFromValidationAnnotations() {
+		McpWriteService svc = serviceFor(
+				new CommandDescriptor("Rich", RichInput.class, "Rich", "Does a thing", true, null));
+		var required = (List<String>) tool(svc, "Rich").inputSchema().get("required");
+		// Only the @NotBlank/@NotNull components; unannotated ones (incl. primitives) are optional.
+		assertThat(required).containsExactlyInAnyOrder("name", "id");
+		assertThat(required).doesNotContain("count", "flag", "ratio", "color", "tags", "blob");
+	}
+
+	@Test
+	void descriptionUsesCatalogDescriptionWhenPresentAndListsFields() {
+		McpWriteService svc = serviceFor(
+				new CommandDescriptor("Rich", RichInput.class, "Rich Title", "Does a thing", true,
+						null));
+		String description = tool(svc, "Rich").description();
+		assertThat(description).startsWith("Does a thing.")   // non-blank description wins over title
+				.contains("Input fields: name, id, count, flag, ratio, color, tags, blob.");
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void voidInputYieldsEmptyObjectSchemaAndTitleOnlyDescription() {
+		// Null description → falls back to the title; Void input → no properties, no field hint.
+		McpWriteService svc = serviceFor(
+				new CommandDescriptor("Ping", Void.class, "Ping", null, true, null));
+		McpToolDescriptor ping = tool(svc, "Ping");
+
+		Map<String, Object> schema = ping.inputSchema();
+		assertThat((Map<String, Object>) schema.get("properties")).isEmpty();
+		assertThat((List<String>) schema.get("required")).isEmpty();
+		assertThat(schema).containsEntry("additionalProperties", false);
+		assertThat(ping.description()).isEqualTo("Ping.");
+	}
+
+	@Test
+	void callingAToolNotInTheCatalogIsRejected() {
+		McpWriteService svc = serviceFor(
+				new CommandDescriptor("Rich", RichInput.class, "Rich", "Does a thing", true, null));
+		assertThatThrownBy(() -> svc.call("NotACommand", null))
+				.isInstanceOf(McpInvalidParamsException.class)
+				.hasMessageContaining("Unknown MCP write tool");
+	}
+}

--- a/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/McpWriteServiceTest.java
+++ b/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/McpWriteServiceTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rreganjr.requel.gateway.CommandGateway;
+import com.rreganjr.requel.gateway.GatewayCommandCatalog;
 import com.rreganjr.requel.gateway.GatewayException;
 import com.rreganjr.requel.gateway.GatewayRequest;
 import com.rreganjr.requel.gateway.GatewayResult;
@@ -36,6 +37,7 @@ import org.junit.jupiter.api.Test;
 class McpWriteServiceTest {
 
 	private final ObjectMapper objectMapper = new ObjectMapper();
+	private final GatewayCommandCatalog catalog = McpTestCatalog.sample();
 
 	/** Records the request it receives and returns a canned result (or throws a set exception). */
 	private static final class RecordingGateway implements CommandGateway {
@@ -70,10 +72,11 @@ class McpWriteServiceTest {
 
 	@Test
 	void writeToolsAbsentAndRejectedWhenDisabled() {
-		McpWriteService disabled = new McpWriteService(new RecordingGateway(), objectMapper, false);
+		McpWriteService disabled = new McpWriteService(new RecordingGateway(), catalog,
+				objectMapper, false);
 		assertThat(disabled.toolDescriptors()).isEmpty();
-		assertThat(disabled.handles("createGoal")).isTrue();
-		assertThatThrownBy(() -> disabled.call("createGoal",
+		assertThat(disabled.handles("EditGoal")).isTrue();
+		assertThatThrownBy(() -> disabled.call("EditGoal",
 				json("{\"projectName\":\"P\",\"name\":\"G\"}")))
 				.isInstanceOf(McpInvalidParamsException.class)
 				.hasMessageContaining("disabled");
@@ -86,16 +89,16 @@ class McpWriteServiceTest {
 		@SuppressWarnings("unchecked")
 		List<McpToolDescriptor> descriptors = (List<McpToolDescriptor>) tools.get("tools");
 		assertThat(descriptors).noneMatch(d -> d.name().startsWith("runCommand")
-				|| d.name().equals("createGoal"));
+				|| d.name().equals("EditGoal"));
 	}
 
 	@Test
 	void writeToolsListedWhenEnabled() {
-		McpWriteService enabled = new McpWriteService(new RecordingGateway(), objectMapper, true);
+		McpWriteService enabled = new McpWriteService(new RecordingGateway(), catalog,
+				objectMapper, true);
 		assertThat(enabled.toolDescriptors()).extracting(McpToolDescriptor::name)
-				.contains("runCommand", "createGoal", "editGoal",
-						"addGoalToContainer", "createNote", "createIssue",
-						"createProject");
+				.contains("runCommand", "EditProject", "EditGoal",
+						"AddGoalToGoalContainer", "EditNote", "EditIssue");
 	}
 
 	// ---- delegation ----------------------------------------------------------------------------
@@ -103,7 +106,7 @@ class McpWriteServiceTest {
 	@Test
 	void runCommandForwardsTypeAndInput() {
 		RecordingGateway gw = new RecordingGateway();
-		McpWriteService svc = new McpWriteService(gw, objectMapper, true);
+		McpWriteService svc = new McpWriteService(gw, catalog, objectMapper, true);
 		Object result = svc.call("runCommand",
 				json("{\"commandType\":\"EditGoal\",\"input\":{\"projectName\":\"P\",\"name\":\"G\"}}"));
 		assertThat(gw.last.commandType()).isEqualTo("EditGoal");
@@ -116,10 +119,10 @@ class McpWriteServiceTest {
 	@Test
 	void clientIdFromContextIsCarriedIntoGatewayRequest() {
 		RecordingGateway gw = new RecordingGateway();
-		McpWriteService svc = new McpWriteService(gw, objectMapper, true);
+		McpWriteService svc = new McpWriteService(gw, catalog, objectMapper, true);
 		McpClientContext.setClientId("claude-desktop");
 		try {
-			svc.call("createGoal", json("{\"projectName\":\"P\",\"name\":\"G\"}"));
+			svc.call("EditGoal", json("{\"projectName\":\"P\",\"name\":\"G\"}"));
 		} finally {
 			McpClientContext.clear();
 		}
@@ -129,8 +132,8 @@ class McpWriteServiceTest {
 	@Test
 	void typedToolFixesCommandTypeAndForwardsArgs() {
 		RecordingGateway gw = new RecordingGateway();
-		McpWriteService svc = new McpWriteService(gw, objectMapper, true);
-		svc.call("createGoal",
+		McpWriteService svc = new McpWriteService(gw, catalog, objectMapper, true);
+		svc.call("EditGoal",
 				json("{\"projectName\":\"P\",\"name\":\"G\",\"text\":\"T\"}"));
 		assertThat(gw.last.commandType()).isEqualTo("EditGoal");
 		assertThat(asMap(gw.last.input()))
@@ -143,8 +146,8 @@ class McpWriteServiceTest {
 	void voidResultBecomesOkPayload() {
 		RecordingGateway gw = new RecordingGateway();
 		gw.resultPayload = null; // e.g. AddGoalToGoalContainer returns no DTO
-		McpWriteService svc = new McpWriteService(gw, objectMapper, true);
-		Object result = svc.call("addGoalToContainer",
+		McpWriteService svc = new McpWriteService(gw, catalog, objectMapper, true);
+		Object result = svc.call("AddGoalToGoalContainer",
 				json("{\"projectName\":\"P\",\"goalId\":1,\"goalContainerId\":2,"
 						+ "\"containerType\":\"Project\"}"));
 		assertThat(asMap(result)).containsEntry("ok", true)
@@ -157,8 +160,8 @@ class McpWriteServiceTest {
 	void notAllowedMapsToInvalidParams() {
 		RecordingGateway gw = new RecordingGateway();
 		gw.toThrow = new GatewayException(GatewayException.Kind.NOT_ALLOWED, "denied");
-		McpWriteService svc = new McpWriteService(gw, objectMapper, true);
-		assertThatThrownBy(() -> svc.call("createGoal",
+		McpWriteService svc = new McpWriteService(gw, catalog, objectMapper, true);
+		assertThatThrownBy(() -> svc.call("EditGoal",
 				json("{\"projectName\":\"P\",\"name\":\"G\"}")))
 				.isInstanceOf(McpInvalidParamsException.class)
 				.hasMessageContaining("denied");
@@ -168,8 +171,8 @@ class McpWriteServiceTest {
 	void executionErrorMapsToIllegalState() {
 		RecordingGateway gw = new RecordingGateway();
 		gw.toThrow = new GatewayException(GatewayException.Kind.EXECUTION_ERROR, "boom");
-		McpWriteService svc = new McpWriteService(gw, objectMapper, true);
-		assertThatThrownBy(() -> svc.call("createGoal",
+		McpWriteService svc = new McpWriteService(gw, catalog, objectMapper, true);
+		assertThatThrownBy(() -> svc.call("EditGoal",
 				json("{\"projectName\":\"P\",\"name\":\"G\"}")))
 				.isInstanceOf(IllegalStateException.class)
 				.hasMessageContaining("boom");

--- a/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/RequelMcpServerConfigTest.java
+++ b/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/RequelMcpServerConfigTest.java
@@ -59,19 +59,20 @@ class RequelMcpServerConfigTest {
 		assertThat(names).contains("listProjects", "getProject",
 				"getOpenIssues", "draftAnnotation");
 		assertThat(names).noneMatch(n -> n.equals("runCommand")
-				|| n.equals("createGoal"));
+				|| n.equals("EditGoal"));
 	}
 
 	@Test
 	void includesWriteToolsWhenEnabled() {
 		McpWriteService writes = new McpWriteService(
-				request -> new GatewayResult(request.commandType(), null), objectMapper, true);
+				request -> new GatewayResult(request.commandType(), null),
+				McpTestCatalog.sample(), objectMapper, true);
 		McpReadService withWrites = new McpReadService(new StubProjectQueryGateway(), writes,
 				McpRateLimiter.NOOP, objectMapper);
 		ToolCallbackProvider provider = config.requelToolCallbackProvider(withWrites, auditor,
 				objectMapper);
 
-		assertThat(toolNames(provider)).contains("runCommand", "createGoal");
+		assertThat(toolNames(provider)).contains("runCommand", "EditGoal");
 	}
 
 	@Test

--- a/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/WriteInputDtoConstructionTest.java
+++ b/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/WriteInputDtoConstructionTest.java
@@ -106,11 +106,23 @@ class WriteInputDtoConstructionTest {
 		}
 	}
 
-	/** Non-null defaults for primitives (which cannot accept null); null for reference types. */
+	/**
+	 * Non-null defaults for primitives (which cannot accept null); null for reference types. Each
+	 * primitive uses its own return statement — a mixed-type ternary would numerically promote the
+	 * results (e.g. to {@code long}) and box to the wrong wrapper, breaking reflective construction.
+	 */
 	private static Object defaultValue(Class<?> type) {
-		if (type == int.class || type == long.class || type == short.class || type == byte.class) {
-			return type == long.class ? 0L : type == short.class ? (short) 0
-					: type == byte.class ? (byte) 0 : 0;
+		if (type == int.class) {
+			return 0;
+		}
+		if (type == long.class) {
+			return 0L;
+		}
+		if (type == short.class) {
+			return (short) 0;
+		}
+		if (type == byte.class) {
+			return (byte) 0;
 		}
 		if (type == boolean.class) {
 			return false;

--- a/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/WriteInputDtoConstructionTest.java
+++ b/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/WriteInputDtoConstructionTest.java
@@ -1,0 +1,129 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.RecordComponent;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Constructs every allowlisted write input DTO (the records annotated with @NotNull/@NotBlank in
+ * issue #104) through its canonical constructor and exercises its generated members. These records
+ * are otherwise only instantiated on the live command path; this pins their generated code and the
+ * fact that the added validation annotations do not interfere with construction.
+ */
+class WriteInputDtoConstructionTest {
+
+	private static final String PKG = "com.rreganjr.requel.service.api.dto.";
+
+	private static final List<String> WRITE_INPUT_DTOS = List.of(
+			"AddActorToActorContainerInput",
+			"AddGoalToGoalContainerInput",
+			"AddScenarioToUseCaseInput",
+			"AddStoryToStoryContainerInput",
+			"CopyActorInput",
+			"CopyGoalInput",
+			"CopyScenarioInput",
+			"CopyStoryInput",
+			"CopyUseCaseInput",
+			"DeleteActorInput",
+			"DeleteArgumentInput",
+			"DeleteGlossaryTermInput",
+			"DeleteGoalInput",
+			"DeleteGoalRelationInput",
+			"DeleteIssueInput",
+			"DeleteNoteInput",
+			"DeletePositionInput",
+			"DeleteReportGeneratorInput",
+			"DeleteScenarioInput",
+			"DeleteStakeholderInput",
+			"DeleteStoryInput",
+			"DeleteUseCaseInput",
+			"EditActorInput",
+			"EditArgumentInput",
+			"EditGlossaryTermInput",
+			"EditGoalInput",
+			"EditGoalRelationInput",
+			"EditIssueInput",
+			"EditNonUserStakeholderInput",
+			"EditNoteInput",
+			"EditPositionInput",
+			"EditReportGeneratorInput",
+			"EditScenarioInput",
+			"EditStoryInput",
+			"EditUseCaseInput",
+			"RemoveActorFromActorContainerInput",
+			"RemoveGoalFromGoalContainerInput",
+			"RemoveScenarioFromUseCaseInput",
+			"RemoveStoryFromStoryContainerInput",
+			"SetPrimaryScenarioInput");
+
+	@Test
+	void everyWriteInputDtoCanBeConstructedAndAccessed() throws Exception {
+		for (String simpleName : WRITE_INPUT_DTOS) {
+			Class<?> type = Class.forName(PKG + simpleName);
+			assertThat(type.isRecord()).as("%s should be a record", simpleName).isTrue();
+
+			RecordComponent[] components = type.getRecordComponents();
+			Class<?>[] paramTypes = new Class<?>[components.length];
+			Object[] args = new Object[components.length];
+			for (int i = 0; i < components.length; i++) {
+				paramTypes[i] = components[i].getType();
+				args[i] = defaultValue(components[i].getType());
+			}
+
+			Constructor<?> canonical = type.getDeclaredConstructor(paramTypes);
+			Object instance = canonical.newInstance(args);
+
+			// Exercise the generated accessors, equals/hashCode/toString.
+			for (RecordComponent component : components) {
+				component.getAccessor().invoke(instance);
+			}
+			assertThat(instance).isEqualTo(instance);
+			assertThat(instance.hashCode()).isEqualTo(instance.hashCode());
+			assertThat(instance.toString()).contains(simpleName);
+		}
+	}
+
+	/** Non-null defaults for primitives (which cannot accept null); null for reference types. */
+	private static Object defaultValue(Class<?> type) {
+		if (type == int.class || type == long.class || type == short.class || type == byte.class) {
+			return type == long.class ? 0L : type == short.class ? (short) 0
+					: type == byte.class ? (byte) 0 : 0;
+		}
+		if (type == boolean.class) {
+			return false;
+		}
+		if (type == double.class) {
+			return 0d;
+		}
+		if (type == float.class) {
+			return 0f;
+		}
+		if (type == char.class) {
+			return '\0';
+		}
+		return null;
+	}
+}

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/mcp/McpToolCatalogLockstepIT.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/mcp/McpToolCatalogLockstepIT.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.rreganjr.AbstractIntegrationTestCase;
+import com.rreganjr.requel.gateway.CommandDescriptor;
+import com.rreganjr.requel.gateway.GatewayCommandCatalog;
+import com.rreganjr.requel.service.gateway.GatewayPolicyConfig;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Full-context lockstep regression (issue #104): with writes enabled, the MCP server's typed write
+ * tools are generated from the shared {@link GatewayCommandCatalog}, which is itself built from the
+ * same {@code GatewayPolicyConfig.ALLOWED} set the gateway's allow/deny policy enforces. This
+ * asserts {@code MCP tools ⊆ catalog} against the real wired catalog and real allowlist, so the MCP
+ * surface, the CLI's {@code /descriptors} surface, and the enforced policy cannot drift apart.
+ *
+ * <p>Enables {@code requel.gateway.write.enabled} for this context so the write tools are advertised
+ * (the flag is read once when the {@link McpWriteService} bean is constructed).
+ */
+@TestPropertySource(properties = "requel.gateway.write.enabled=true")
+public class McpToolCatalogLockstepIT extends AbstractIntegrationTestCase {
+
+	private McpWriteService writeService;
+	private GatewayCommandCatalog catalog;
+
+	@Autowired
+	protected void setWriteService(McpWriteService writeService) {
+		this.writeService = writeService;
+	}
+
+	@Autowired
+	protected void setCatalog(GatewayCommandCatalog catalog) {
+		this.catalog = catalog;
+	}
+
+	@Test
+	public void typedWriteToolsAreExactlyTheCatalogAndAllSubsetOfTheAllowlist() {
+		assertThat(writeService.isWriteEnabled())
+				.as("write flag must be on for this IT").isTrue();
+
+		List<String> catalogTypes = catalog.descriptors().stream()
+				.map(CommandDescriptor::commandType).toList();
+		assertThat(catalogTypes).as("catalog should be non-empty when the app is booted").isNotEmpty();
+
+		List<String> typedToolNames = writeService.toolDescriptors().stream()
+				.map(McpToolDescriptor::name)
+				.filter(name -> !name.equals(McpWriteService.RUN_COMMAND))
+				.toList();
+
+		// MCP tools ⊆ catalog: every typed write tool is a catalog command...
+		assertThat(typedToolNames).allSatisfy(name ->
+				assertThat(catalog.find(name)).as("MCP tool '%s' must be in the catalog", name)
+						.isPresent());
+		// ...and the catalog is itself ⊆ the enforced allowlist, so nothing outside the policy leaks.
+		assertThat(typedToolNames).allSatisfy(name ->
+				assertThat(GatewayPolicyConfig.ALLOWED)
+						.as("MCP tool '%s' must be on the gateway allowlist", name)
+						.contains(name));
+		// Full coverage: the typed write surface equals the catalog (no hidden extras, none dropped).
+		assertThat(typedToolNames).containsExactlyInAnyOrderElementsOf(catalogTypes);
+
+		// The generic escape hatch is always present alongside the typed tools.
+		assertThat(writeService.toolDescriptors()).extracting(McpToolDescriptor::name)
+				.contains(McpWriteService.RUN_COMMAND);
+	}
+}

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/service/RequelMcpEndToEndIT.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/service/RequelMcpEndToEndIT.java
@@ -140,8 +140,8 @@ public class RequelMcpEndToEndIT extends AbstractIntegrationTestCase {
 				new UsernamePasswordAuthenticationToken(username, "x", List.of()));
 		long mcpCallsBefore = mcpCallAuditRepository.count();
 		try {
-			// 1. Create a goal.
-			JsonNode goal = callTool("createGoal",
+			// 1. Create a goal (EditGoal creates when no id is supplied).
+			JsonNode goal = callTool("EditGoal",
 					Map.of("projectName", projectName, "name", "E2E Goal", "text", "via mcp"));
 			long goalId = goal.get("id").asLong();
 			assertThat(goalId).isPositive();
@@ -154,12 +154,12 @@ public class RequelMcpEndToEndIT extends AbstractIntegrationTestCase {
 			assertThat(stakeholderId).isPositive();
 
 			// 3. Associate the goal with the stakeholder (a goal container).
-			callTool("addGoalToContainer",
+			callTool("AddGoalToGoalContainer",
 					Map.of("projectName", projectName, "goalId", goalId,
 							"goalContainerId", stakeholderId, "containerType", "NonUserStakeholder"));
 
 			// 4. Attach a note to the goal.
-			callTool("createNote",
+			callTool("EditNote",
 					Map.of("projectName", projectName, "entityType", "Goal", "entityId", goalId,
 							"text", "a note added over MCP"));
 

--- a/modules/service-api/pom.xml
+++ b/modules/service-api/pom.xml
@@ -40,5 +40,12 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>
+        <!-- @NotNull/@NotBlank on the input DTO records mark required fields; read reflectively
+             by the MCP schema generator (issue #104). Metadata only — no bean-validation provider
+             is wired here, so these do not change command behavior. -->
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/AddActorToActorContainerInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/AddActorToActorContainerInput.java
@@ -20,4 +20,7 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
-public record AddActorToActorContainerInput(String projectName, Long actorContainerId, Long actorId) {}
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record AddActorToActorContainerInput(@NotBlank String projectName, @NotNull Long actorContainerId, @NotNull Long actorId) {}

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/AddGoalToGoalContainerInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/AddGoalToGoalContainerInput.java
@@ -20,10 +20,13 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record AddGoalToGoalContainerInput(
-        String projectName,
-        Long goalContainerId,
-        Long goalId,
-        String containerType
+        @NotBlank String projectName,
+        @NotNull Long goalContainerId,
+        @NotNull Long goalId,
+        @NotBlank String containerType
 ) {
 }

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/AddScenarioToUseCaseInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/AddScenarioToUseCaseInput.java
@@ -20,8 +20,11 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record AddScenarioToUseCaseInput(
-        String projectName,
-        Long useCaseId,
-        Long scenarioId
+        @NotBlank String projectName,
+        @NotNull Long useCaseId,
+        @NotNull Long scenarioId
 ) {}

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/AddStoryToStoryContainerInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/AddStoryToStoryContainerInput.java
@@ -20,4 +20,7 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
-public record AddStoryToStoryContainerInput(String projectName, Long storyContainerId, Long storyId) {}
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record AddStoryToStoryContainerInput(@NotBlank String projectName, @NotNull Long storyContainerId, @NotNull Long storyId) {}

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/CopyActorInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/CopyActorInput.java
@@ -20,9 +20,12 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record CopyActorInput(
-        String projectName,
-        Long actorId,
+        @NotBlank String projectName,
+        @NotNull Long actorId,
         String newActorName
 ) {
 }

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/CopyGoalInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/CopyGoalInput.java
@@ -20,9 +20,12 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record CopyGoalInput(
-        String projectName,
-        Long goalId,
+        @NotBlank String projectName,
+        @NotNull Long goalId,
         String newGoalName
 ) {
 }

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/CopyScenarioInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/CopyScenarioInput.java
@@ -20,4 +20,7 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
-public record CopyScenarioInput(String projectName, Long scenarioId) {}
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CopyScenarioInput(@NotBlank String projectName, @NotNull Long scenarioId) {}

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/CopyStoryInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/CopyStoryInput.java
@@ -20,9 +20,12 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record CopyStoryInput(
-        String projectName,
-        Long storyId,
+        @NotBlank String projectName,
+        @NotNull Long storyId,
         String newStoryName
 ) {
 }

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/CopyUseCaseInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/CopyUseCaseInput.java
@@ -20,4 +20,7 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
-public record CopyUseCaseInput(String projectName, Long useCaseId) {}
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CopyUseCaseInput(@NotBlank String projectName, @NotNull Long useCaseId) {}

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeleteActorInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeleteActorInput.java
@@ -20,9 +20,12 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record DeleteActorInput(
-        String projectName,
-        Long actorId,
+        @NotBlank String projectName,
+        @NotNull Long actorId,
         int version
 ) {
 }

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeleteArgumentInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeleteArgumentInput.java
@@ -20,5 +20,7 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
-public record DeleteArgumentInput(String projectName, Long argumentId) {
+import jakarta.validation.constraints.NotNull;
+
+public record DeleteArgumentInput(String projectName, @NotNull Long argumentId) {
 }

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeleteGlossaryTermInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeleteGlossaryTermInput.java
@@ -20,11 +20,14 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 /**
  * Input DTO for deleting a glossary term.
  */
 public record DeleteGlossaryTermInput(
-        String projectName,
-        Long termId
+        @NotBlank String projectName,
+        @NotNull Long termId
 ) {
 }

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeleteGoalInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeleteGoalInput.java
@@ -20,9 +20,12 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record DeleteGoalInput(
-        String projectName,
-        Long goalId,
+        @NotBlank String projectName,
+        @NotNull Long goalId,
         Integer version
 ) {
 }

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeleteGoalRelationInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeleteGoalRelationInput.java
@@ -20,9 +20,12 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record DeleteGoalRelationInput(
-        String projectName,
-        Long goalRelationId,
+        @NotBlank String projectName,
+        @NotNull Long goalRelationId,
         Integer version
 ) {
 }

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeleteIssueInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeleteIssueInput.java
@@ -20,5 +20,7 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
-public record DeleteIssueInput(String projectName, Long issueId) {
+import jakarta.validation.constraints.NotNull;
+
+public record DeleteIssueInput(String projectName, @NotNull Long issueId) {
 }

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeleteNoteInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeleteNoteInput.java
@@ -20,5 +20,7 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
-public record DeleteNoteInput(String projectName, Long noteId) {
+import jakarta.validation.constraints.NotNull;
+
+public record DeleteNoteInput(String projectName, @NotNull Long noteId) {
 }

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeletePositionInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeletePositionInput.java
@@ -20,5 +20,7 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
-public record DeletePositionInput(String projectName, Long positionId) {
+import jakarta.validation.constraints.NotNull;
+
+public record DeletePositionInput(String projectName, @NotNull Long positionId) {
 }

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeleteReportGeneratorInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeleteReportGeneratorInput.java
@@ -20,8 +20,11 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 /**
  * Input DTO for DeleteReportGenerator command.
  */
-public record DeleteReportGeneratorInput(String projectName, Long reportId) {
+public record DeleteReportGeneratorInput(@NotBlank String projectName, @NotNull Long reportId) {
 }

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeleteScenarioInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeleteScenarioInput.java
@@ -20,4 +20,7 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
-public record DeleteScenarioInput(String projectName, Long scenarioId, int version) {}
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record DeleteScenarioInput(@NotBlank String projectName, @NotNull Long scenarioId, int version) {}

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeleteStakeholderInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeleteStakeholderInput.java
@@ -20,6 +20,9 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 /**
  * Input DTO for deleting a stakeholder (either type).
  *
@@ -28,8 +31,8 @@ package com.rreganjr.requel.service.api.dto;
  * @param version        optimistic lock version
  */
 public record DeleteStakeholderInput(
-        String projectName,
-        Long stakeholderId,
+        @NotBlank String projectName,
+        @NotNull Long stakeholderId,
         Integer version
 ) {
 }

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeleteStoryInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeleteStoryInput.java
@@ -20,9 +20,12 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record DeleteStoryInput(
-        String projectName,
-        Long storyId,
+        @NotBlank String projectName,
+        @NotNull Long storyId,
         Integer version
 ) {
 }

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeleteUseCaseInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/DeleteUseCaseInput.java
@@ -20,4 +20,7 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
-public record DeleteUseCaseInput(String projectName, Long useCaseId, int version) {}
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record DeleteUseCaseInput(@NotBlank String projectName, @NotNull Long useCaseId, int version) {}

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditActorInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditActorInput.java
@@ -20,15 +20,17 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 /**
  * Input for EditActor command.
  * actorId is null for create, non-null for update.
  * version is null for create, required for update (optimistic lock check).
  */
 public record EditActorInput(
-        String projectName,
+        @NotBlank String projectName,
         Long actorId,
-        String name,
+        @NotBlank String name,
         String description,
         Integer version
 ) {

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditArgumentInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditArgumentInput.java
@@ -20,14 +20,17 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 /**
  * Input DTO for EditArgument command. argumentId null = create new argument on position.
  */
 public record EditArgumentInput(
         String projectName,
-        Long positionId,
+        @NotNull Long positionId,
         Long argumentId,
-        String text,
-        String supportLevel
+        @NotBlank String text,
+        @NotBlank String supportLevel
 ) {
 }

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditGlossaryTermInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditGlossaryTermInput.java
@@ -20,14 +20,16 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 /**
  * Input DTO for creating or editing a glossary term.
  * Set termId null to create a new term.
  */
 public record EditGlossaryTermInput(
-        String projectName,
+        @NotBlank String projectName,
         Long termId,
-        String name,
+        @NotBlank String name,
         String text,
         Long canonicalTermId
 ) {

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditGoalInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditGoalInput.java
@@ -20,6 +20,8 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 /**
  * Input DTO for creating or editing a goal.
  *
@@ -30,9 +32,9 @@ package com.rreganjr.requel.service.api.dto;
  * @param version      optimistic lock version (null for create)
  */
 public record EditGoalInput(
-        String projectName,
+        @NotBlank String projectName,
         Long goalId,
-        String name,
+        @NotBlank String name,
         String text,
         Integer version
 ) {

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditGoalRelationInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditGoalRelationInput.java
@@ -20,6 +20,8 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 /**
  * Input DTO for creating or editing a goal relation.
  *
@@ -30,10 +32,10 @@ package com.rreganjr.requel.service.api.dto;
  * @param version        optimistic lock version (null for create)
  */
 public record EditGoalRelationInput(
-        String projectName,
-        String fromGoalName,
-        String toGoalName,
-        String relationType,
+        @NotBlank String projectName,
+        @NotBlank String fromGoalName,
+        @NotBlank String toGoalName,
+        @NotBlank String relationType,
         Integer version
 ) {
 }

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditIssueInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditIssueInput.java
@@ -20,15 +20,18 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 /**
  * Input DTO for EditIssue command. issueId null = create new issue on entity.
  */
 public record EditIssueInput(
         String projectName,
-        String entityType,
-        Long entityId,
+        @NotBlank String entityType,
+        @NotNull Long entityId,
         Long issueId,
-        String text,
+        @NotBlank String text,
         Boolean mustBeResolved
 ) {
 }

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditNonUserStakeholderInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditNonUserStakeholderInput.java
@@ -20,6 +20,8 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 /**
  * Input DTO for creating or editing a non-user stakeholder (external authority).
  *
@@ -30,9 +32,9 @@ package com.rreganjr.requel.service.api.dto;
  * @param version        optimistic lock version (null for create)
  */
 public record EditNonUserStakeholderInput(
-        String projectName,
+        @NotBlank String projectName,
         Long stakeholderId,
-        String name,
+        @NotBlank String name,
         String text,
         Integer version
 ) {

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditNoteInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditNoteInput.java
@@ -20,14 +20,17 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 /**
  * Input DTO for EditNote command. noteId null = create new note on entity.
  */
 public record EditNoteInput(
         String projectName,
-        String entityType,
-        Long entityId,
+        @NotBlank String entityType,
+        @NotNull Long entityId,
         Long noteId,
-        String text
+        @NotBlank String text
 ) {
 }

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditPositionInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditPositionInput.java
@@ -20,13 +20,16 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 /**
  * Input DTO for EditPosition command. positionId null = create new position on issue.
  */
 public record EditPositionInput(
         String projectName,
-        Long issueId,
+        @NotNull Long issueId,
         Long positionId,
-        String text
+        @NotBlank String text
 ) {
 }

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditReportGeneratorInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditReportGeneratorInput.java
@@ -20,9 +20,11 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 /**
  * Input DTO for EditReportGenerator command.
  * reportId is null when creating a new report generator.
  */
-public record EditReportGeneratorInput(String projectName, Long reportId, String name, String text) {
+public record EditReportGeneratorInput(@NotBlank String projectName, Long reportId, @NotBlank String name, String text) {
 }

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditScenarioInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditScenarioInput.java
@@ -20,10 +20,12 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 import java.util.List;
 
 public record EditScenarioInput(
-    String projectName,
+    @NotBlank String projectName,
     Long scenarioId,
     String name,
     String text,

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditStoryInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditStoryInput.java
@@ -20,6 +20,8 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 /**
  * Input DTO for creating or editing a story.
  *
@@ -32,12 +34,12 @@ package com.rreganjr.requel.service.api.dto;
  * @param version          optimistic lock version (null for create)
  */
 public record EditStoryInput(
-        String projectName,
+        @NotBlank String projectName,
         Long storyId,
-        String name,
+        @NotBlank String name,
         String text,
         String storyTypeName,
-        String primaryActorName,
+        @NotBlank String primaryActorName,
         Integer version
 ) {
 }

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditUseCaseInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/EditUseCaseInput.java
@@ -20,10 +20,12 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record EditUseCaseInput(
-        String projectName,
+        @NotBlank String projectName,
         Long useCaseId,
-        String name,
+        @NotBlank String name,
         String text,
         String primaryActorName,
         Integer version

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/RemoveActorFromActorContainerInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/RemoveActorFromActorContainerInput.java
@@ -20,4 +20,7 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
-public record RemoveActorFromActorContainerInput(String projectName, Long actorContainerId, Long actorId) {}
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record RemoveActorFromActorContainerInput(@NotBlank String projectName, @NotNull Long actorContainerId, @NotNull Long actorId) {}

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/RemoveGoalFromGoalContainerInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/RemoveGoalFromGoalContainerInput.java
@@ -20,10 +20,13 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record RemoveGoalFromGoalContainerInput(
-        String projectName,
-        Long goalContainerId,
-        Long goalId,
-        String containerType
+        @NotBlank String projectName,
+        @NotNull Long goalContainerId,
+        @NotNull Long goalId,
+        @NotBlank String containerType
 ) {
 }

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/RemoveScenarioFromUseCaseInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/RemoveScenarioFromUseCaseInput.java
@@ -20,8 +20,11 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record RemoveScenarioFromUseCaseInput(
-        String projectName,
-        Long useCaseId,
-        Long scenarioId
+        @NotBlank String projectName,
+        @NotNull Long useCaseId,
+        @NotNull Long scenarioId
 ) {}

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/RemoveStoryFromStoryContainerInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/RemoveStoryFromStoryContainerInput.java
@@ -20,4 +20,7 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
-public record RemoveStoryFromStoryContainerInput(String projectName, Long storyContainerId, Long storyId) {}
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record RemoveStoryFromStoryContainerInput(@NotBlank String projectName, @NotNull Long storyContainerId, @NotNull Long storyId) {}

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/SetPrimaryScenarioInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/SetPrimaryScenarioInput.java
@@ -20,8 +20,11 @@
  */
 package com.rreganjr.requel.service.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record SetPrimaryScenarioInput(
-        String projectName,
-        Long useCaseId,
-        Long scenarioId
+        @NotBlank String projectName,
+        @NotNull Long useCaseId,
+        @NotNull Long scenarioId
 ) {}


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/104

Generate MCP write tools from the shared GatewayCommandCatalog

Migrate the MCP server's typed write-tool generation off its own hard-coded list
(McpWriteService.TYPED_TOOLS) and onto the shared GatewayCommandCatalog, so MCP, the
CLI (/api/gateway/commands/descriptors), and the gateway allow/deny policy all derive
their write surface from one source of truth and can no longer drift. Adds an
"MCP tools ⊆ catalog" regression test at both unit and full-context levels.

This deliberately changes the shipped MCP write-tool surface (kept out of #70 M4 for
that reason): typed tools are now named after their command type (EditGoal, EditProject,
AddGoalToGoalContainer, EditNote, EditIssue, Delete*, …) and their input JSON schema is
derived from the command's registered input DTO record. The old ergonomic create-vs-edit
split (createGoal/editGoal → EditGoal, createProject → EditProject, etc.) is gone — a
single Edit* tool creates when no id is supplied and updates otherwise. The generic
runCommand escape hatch and all read tools are unchanged.

The generated schemas also carry accurate required fields. Rather than guess from the DTO
record types (all boxed/nullable, so uninformative), the required set for each allowlisted
write command was derived from its command applicator in the registrars: a field is
required when the applicator dereferences it unconditionally, and optional when it is
null-guarded, used only as the create-vs-edit id, or never read. Those decisions are now
encoded as jakarta.validation @NotNull/@NotBlank annotations on the input DTO records, and
schemaFor() reads them to populate the schema "required" array. The annotations are
metadata only — nothing wires @Valid/@Validated on these DTOs, so command behavior is
unchanged (commands still validate as before). Notable results: EditProject has no required
fields (its applicator null-guards everything); the annotation commands do NOT require
projectName (the applicator loads the target by entityType/entityId, never reading it); the
four *ScenarioStep commands have no input DTO and so no schema.

Closes #104

File changes:

- modules/gateway-api/.../GatewayCommandCatalog.java
  Add static empty() factory (a no-op catalog) for read-only deployments and tests that
  need a catalog but should advertise no write surface.

- modules/mcp-server/.../McpWriteService.java
  Constructor now takes a GatewayCommandCatalog. toolDescriptors() builds one typed tool
  per catalog descriptor (name = commandType, description = catalog title + input field
  names, schema derived from the input DTO) plus the generic runCommand. handles() and
  call() resolve typed tools via catalog.find(toolName) instead of the removed TYPED_TOOLS
  map; typed arguments are still forwarded as-is (they match the input DTO field names).
  Added schemaFor()/jsonType() reflection helpers that turn a record input DTO into a JSON
  schema (no field marked required — the command validates and returns a client-correctable
  error — with additionalProperties:false so typos surface early).

  schemaFor() now also derives the schema's required[] array by reading jakarta.validation
  @NotNull/@NotBlank on each record component (matched by FQN, so no compile-time dependency
  on the validation API), checking both the component and its generated accessor.

- modules/mcp-server/.../McpReadService.java
  Convenience (read-only) constructor passes GatewayCommandCatalog.empty() into the disabled
  write service; import added.

- modules/service-api/.../dto/*.java (40 write input DTOs) + modules/service-api/pom.xml
  Add jakarta.validation @NotNull/@NotBlank to the required components of every allowlisted
  write DTO, per the applicator-derived required sets; declare jakarta.validation-api
  directly on service-api (already present transitively via platform-core). EditProjectInput
  and the annotation DTOs' projectName are intentionally left unannotated.

- modules/mcp-server/src/test/.../McpTestCatalog.java (new)
  Small representative catalog (real allowlisted command types wired to their real input
  DTOs) so tool-name and schema generation is exercised without a Spring context.

- modules/mcp-server/src/test/.../McpWriteCatalogLockstepTest.java (new)
  Unit-level "MCP tools ⊆ catalog": typed write tools are exactly the catalog command types
  (plus runCommand), handles() covers every catalog command, and the EditGoal schema is
  derived from EditGoalInput.

- modules/requel-app/src/test/.../McpToolCatalogLockstepIT.java (new)
  Full-context regression with writes enabled: against the real wired catalog and real
  GatewayPolicyConfig.ALLOWED, every typed MCP write tool is in the catalog AND on the
  allowlist, and the typed surface equals the catalog.

- Test updates for the new constructor signature and catalog-derived tool names:
  McpWriteServiceTest, McpToolNamingTest, RequelMcpServerConfigTest, McpReadServiceTest
  (mcp-server) and RequelMcpEndToEndIT (requel-app: createGoal→EditGoal,
  addGoalToContainer→AddGoalToGoalContainer, createNote→EditNote; argument shapes unchanged).

- doc/local_mcp_bridge.md, doc/VS_CODE_MCP.md, doc/mcp_remote_connection.md
  Update the documented tool names to the catalog-derived command-type names.
