### PR TITLE
Issue tracker → goals workflow + v1 reconciliation (#71)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ node_modules/
 
 # Local draft files (not for version control)
 /commit.md
+/pr.md
 /ticket.md
 
 # macOS Finder metadata (appears anywhere directories get browsed)

--- a/doc/71-issue-tracker-goals-plan.md
+++ b/doc/71-issue-tracker-goals-plan.md
@@ -1,0 +1,175 @@
+# Issue #71 — Issue Tracker → Goals Workflow + v1 Reconciliation (Implementation Plan)
+
+Design doc: `doc/local_mcp_bridge.md`. Ticket 3 of 5 in the v2.0 MCP command-gateway series.
+Depends on ticket 1 (Command Gateway + write tools + goal query), which is landed on
+`release/2.0` (gateway-api, service-impl in-process impl, gateway-rest-client, mcp-server typed
+tools generated from `GatewayCommandCatalog`, read tools in `McpReadService`/`QueryGateway`).
+
+## Summary
+
+Deliver the motivating end-to-end workflow: an AI client reads an issue from any tracker,
+extracts discrete requirement statements, and hands them to Requel, which creates **one flat goal
+per requirement** on a target project. Each goal carries a machine-parseable **provenance note**
+back to the source issue. A first-cut ("v1") **reconciliation** makes re-runs update existing
+goals by id rather than blindly duplicate them.
+
+The workflow is **source-agnostic**. Requel never talks to the tracker; the client reads the
+issue via its own connector and passes Requel discrete statements plus a small source descriptor
+(`sourceSystem`, `sourceRef`, `sourceUrl`).
+
+## Agreed design decisions
+
+1. **Distinct typed tool** — ship `requel.upsertGoalFromRequirement(...)` as a real gateway tool
+   that owns goal-id resolution server-side, so no caller can hit the `EditGoal` uniqueness
+   conflict. (Chosen over a documented multi-call client recipe.)
+2. **Provenance = JSON-in-note behind a stable marker** — a fenced ` ```requel-provenance ` block
+   inside a `NOTE`'s text. Uses the existing `EditNote` command; no new annotation type, no
+   migration. Ticket 4 (smart matching) parses the same block.
+3. **Version handling: rely on loaded entity state for v1.** The upsert tool loads the goal to
+   resolve its id immediately before updating, so the lock window is small. Explicit
+   caller-supplied optimistic-lock enforcement on `Edit*` is deferred to **#108**.
+4. **Name derivation** — deterministic from the requirement: first clause/sentence, trim +
+   collapse whitespace, cap at 120 chars; on collision within the project append `"-" +
+   first 6 chars of criterionHash`.
+5. **criterionHash** — SHA-256 (hex) over canonically normalized criterion text: trim → collapse
+   internal whitespace to single spaces → lowercase → strip trailing punctuation. Kept minimal so
+   it stays predictable and identical across this ticket and #108/#4.
+
+## Correctness constraint (why the tool owns lookup)
+
+`EditGoalCommandImpl` is **not** an upsert-by-name: it throws a uniqueness conflict when creating
+a goal whose name already exists in the project/domain, and updates only when a `goalId` is
+supplied. `EditNoteCommandImpl` likewise creates a new note when `noteId` is null (reusing only on
+an exact grouping-object/annotatable/text match). Therefore the convenience tool must resolve an
+existing goal id (and an existing note id) **before** editing, and pass those ids to update.
+
+Current DTOs (unchanged by this ticket):
+
+```java
+public record EditGoalInput(String projectName, Long goalId, String name,
+                            String text, Integer version) {}   // version not enforced yet — see #108
+public record EditNoteInput(String projectName, String entityType, Long entityId,
+                            Long noteId, String text) {}
+```
+
+## Provenance note format
+
+A note whose text contains exactly one fenced block behind the marker `requel-provenance`:
+
+````
+```requel-provenance
+{
+  "v": 1,
+  "client": "claude-desktop",
+  "sourceSystem": "jira",
+  "sourceRef": "PROJ-123#ac2",
+  "sourceUrl": "https://.../browse/PROJ-123",
+  "criterionRef": "AC-2",
+  "criterionHash": "<sha256-hex>"
+}
+```
+````
+
+- `v` is a format version for forward compatibility.
+- Human-readable prose may precede the block; only the fenced `requel-provenance` block is
+  parsed. Plain prose alone is insufficient (ticket 4 scopes matches by parsing this block).
+- The parser and its exact format are covered by unit tests **shared with ticket 4**.
+
+## Goal-id resolution (v1 reconciliation)
+
+Given `projectName, criterionText, sourceSystem, sourceRef, sourceUrl, criterionRef` (with
+optional `name` / `text` / `criterionHash` overrides — derived from `criterionText` when omitted):
+
+1. **Provenance match:** enumerate the project's goals (`QueryGateway.searchProjectEntities` with
+   an empty query returns all goals as type+id+name) and read each one's notes
+   (`getAnnotations`), parse `requel-provenance` blocks, and match on `sourceSystem` +
+   `sourceRef` + `criterionHash`. A match is the same requirement on a re-run → **update that
+   goal by id** and update its matched provenance note by id.
+2. **No match → create:** create a new goal (no `goalId`). If the derived name already belongs to
+   some *other* goal, apply the collision rule (`disambiguate`: append `-` + first 6 chars of the
+   `criterionHash`) so the create can never trip the `EditGoal` uniqueness conflict, then attach a
+   fresh provenance note.
+
+**Design note (refinement of the ticket's candidate keys).** The ticket lists "exact name match →
+update" as a v1 key alongside provenance. We fold name into the *create* path rather than the
+*update* path: matching purely on name is unsafe (two distinct requirements can derive the same
+name, and a name-only update would silently collapse them or hijack a manually-created goal). So
+**provenance (sourceSystem + sourceRef + criterionHash) is the sole update key**, and an exact name
+collision on the create path triggers disambiguation instead of an update. This satisfies the AC —
+resolve an existing id before editing, update by id, never rely on name-based auto-create — while
+being collision-safe.
+
+No read-side changes are required: goal enumeration/name lookup uses `searchProjectEntities`,
+provenance uses `getAnnotations`. (Full goal *text* is not exposed by current queries — that is a
+ticket 4 concern for similarity matching, not needed for v1 exact-key matching.) The provenance
+scan reads each goal's notes (O(#goals) reads per upsert); ticket 4 adds a candidate query to
+narrow it.
+
+Then: call `EditGoal` with the resolved id (or none) → on the returned goal id, `EditNote` with the
+matched provenance note id to update it, or with a null id to create one.
+
+### Known limitation (accepted for v1)
+
+A minor edit to a requirement changes both the derived name and the `criterionHash`, so v1's
+exact-key lookup will not recognize it as the same requirement: it creates a new goal and leaves
+the prior one as a discoverable orphan (same `sourceRef`, different `criterionHash`). Fuzzy
+resolution is ticket 4 (`requel.findBestGoalMatch`).
+
+## Where the code goes
+
+- **Provenance format + parser + hash + name derivation:** a small value/util set in
+  `gateway-api` (pure, no Spring/JPA), so all front-ends and both gateway impls share it and the
+  ticket-4 matcher can reuse the parser.
+- **`upsertGoalFromRequirement` orchestration:** in the gateway (uses `CommandGateway` for
+  `EditGoal`/`EditNote` and `QueryGateway` for lookup). Exposed as a typed tool via the same
+  catalog/registrar path the other typed tools already use, and reachable from `requel-cli`.
+- **No domain or command changes** — reuses existing `EditGoal`/`EditNote` and read tools.
+
+## Implementation steps
+
+1. Provenance-note format + marker; parser + tests (shared with #4).
+2. Deterministic name derivation (max length, collision rule) + `criterionHash` algorithm and
+   canonical normalization; unit tests.
+3. `requel.upsertGoalFromRequirement`: goal-id resolution (provenance match + exact name) →
+   `EditGoal` (create or update-by-id) → provenance `EditNote` (create or update-by-id).
+4. Document the client workflow (resolve project → load existing goals → upsert per requirement →
+   report created vs updated), covering AC-section vs inferred-requirement extraction, with Jira
+   and GitHub Issues as worked examples.
+5. Tests (below).
+
+## Testing strategy
+
+- **Idempotency:** run the same requirement set twice; assert update-by-id, no duplicates, no
+  uniqueness conflict thrown.
+- **Negative:** a create with a colliding name and no resolved id surfaces the uniqueness conflict
+  cleanly — proving the lookup path is required and exercised.
+- **Provenance round-trip:** a parseable block is attached; a re-run updates the same note id
+  rather than appending a duplicate.
+- **Provenance parser:** unit tests over the exact documented format (shared with #4).
+- **Edited-requirement:** assert the documented v1 limitation (new goal + discoverable orphan).
+- **Source-agnostic:** a fixture issue with no explicit AC section yields discrete goals from
+  inferred requirements.
+
+## Boundaries / security
+
+- Writes are the authenticated user's, bounded by existing command authorization (unchanged from
+  ticket 1). Provenance is mandatory for auto-generated goals.
+- Cap goal name/text/note lengths at the tool boundary before dispatch.
+- No user/identity management; goals attach only to the `Project` (`GoalContainer`) — the source
+  issue does **not** become a parent goal/container in v1 (a later assistant pass may add
+  hierarchy).
+
+## Related issues
+
+- **#69** — command gateway + write tools (dependency, landed).
+- **#104 / #107** — shared `GatewayCommandCatalog` + generated typed write tools (landed).
+- **#108** — wire optimistic-lock `version` through `Edit*`; this ticket relies on loaded entity
+  state and defers explicit version enforcement to it.
+- **Ticket 4** — `requel.findBestGoalMatch` smart/fuzzy reconciliation; consumes this ticket's
+  provenance parser and lifts the edited-requirement limitation.
+
+## Open questions — resolved
+
+- Distinct tool vs. multi-call recipe → **distinct typed tool**.
+- Provenance format → **JSON-in-note behind a marker**.
+- Version handling on update → **rely on loaded state; enforcement deferred to #108**.

--- a/doc/tracker-to-goals-workflow.md
+++ b/doc/tracker-to-goals-workflow.md
@@ -1,0 +1,216 @@
+# Issue Tracker → Goals Workflow
+
+How an external client (an AI assistant such as Claude Desktop/Code, or a script) turns an issue
+from any tracker into one provenance-noted goal per requirement on a Requel project, and how
+re-runs reconcile instead of duplicating. Companion to the design in `doc/local_mcp_bridge.md` and
+the implementation plan in `doc/71-issue-tracker-goals-plan.md` (issue #71).
+
+## Principle: source-agnostic
+
+Requel never talks to the tracker. The **client** reads the issue through its own connector (Jira,
+GitHub Issues, Linear, Azure Boards, a pasted description — anything), extracts discrete
+requirement statements, and hands each one to Requel together with a small, generic source
+descriptor:
+
+- `sourceSystem` — the tracker family, e.g. `jira`, `github`, `linear`.
+- `sourceRef` — a source-specific reference to the item (and, where useful, the specific
+  criterion), e.g. `PROJ-123` or `PROJ-123#ac2`.
+- `sourceUrl` — an openable link to the source item (optional).
+
+Because only this descriptor is source-specific, the same workflow works for every tracker; the
+worked examples below differ only in how the client reads the issue.
+
+## What Requel provides
+
+A single convenience capability, `requel.upsertGoalFromRequirement`, backed by
+`RequirementGoalUpserter`. Given one requirement plus its source descriptor it:
+
+1. resolves whether a goal for this requirement already exists (by provenance),
+2. creates the goal or updates the existing one **by id**, and
+3. creates or updates a machine-parseable **provenance note** on that goal.
+
+Inputs (only the first four are required; the rest are derived or optional):
+
+| field | required | meaning |
+|-------|----------|---------|
+| `projectName` | yes | target project |
+| `criterionText` | yes | the requirement / acceptance-criterion statement |
+| `sourceSystem` | yes | tracker family |
+| `sourceRef` | yes | reference to the source item/criterion |
+| `name` | no | explicit goal name (derived from `criterionText` if omitted) |
+| `text` | no | goal body (defaults to `criterionText`) |
+| `sourceUrl` | no | link to the source item |
+| `criterionRef` | no | human-readable criterion label, e.g. `AC-2` |
+| `client` | no | external-client id for audit attribution, e.g. `claude-desktop` |
+| `criterionHash` | no | precomputed reconciliation key (computed from `criterionText` if omitted) |
+
+Result: the goal id, its final name (possibly disambiguated), the provenance note id, a
+`created` flag (created vs updated), and the `criterionHash`.
+
+The goal `name` is derived deterministically from `criterionText`: the leading clause (up to the
+first line break, then the first sentence terminator), whitespace-collapsed, trailing punctuation
+stripped, capped at 120 characters. The `criterionHash` is SHA-256 over a canonical normalization
+of the text (trim → collapse whitespace → lowercase → strip trailing `. , ; : ! ?`).
+
+### Scope in v1
+
+All generated goals attach **flat** to the project (a `GoalContainer`). The source issue does
+**not** become a parent goal or container, and per-requirement goals are not grouped into a parent
+feature goal — that is a later assistant pass. Do not assume any hierarchy from the issue is
+preserved.
+
+## Requirement extraction (client-side)
+
+The client decides what counts as a requirement before calling Requel:
+
+- **Explicit acceptance-criteria section.** If the issue has an "Acceptance Criteria" (or
+  equivalent) section, use each listed item as one `criterionText`, and set `criterionRef` to a
+  stable label if the source has one (e.g. `AC-1`, `AC-2`).
+- **Inferred requirements.** If there is no AC section, infer discrete requirement statements from
+  the issue body — one clear, testable statement per goal. Requel receives discrete statements
+  regardless of source format.
+
+Keep each `criterionText` to a single requirement; the goal name is derived from its leading
+clause, so front-load the statement with the essential capability.
+
+## The workflow
+
+1. **Resolve the target project** — `requel.getProject` / `requel.listProjects`.
+2. **Load existing goals** — `requel.getProjectContext` (or `requel.searchProjectEntities`) so you
+   can report created-vs-updated meaningfully. (The upsert tool also does its own resolution; this
+   load is for your report and for a human preview.)
+3. **For each requirement, upsert** — call `requel.upsertGoalFromRequirement` with the requirement
+   and source descriptor. The tool resolves an existing goal id and updates it, or creates a new
+   goal, and (re)writes its provenance note.
+4. **Report** — collect each result's `created` flag, goal id, final name, and `sourceRef`, and
+   present a created-vs-updated summary for review.
+
+## Reconciliation (v1)
+
+- **Update key is provenance:** `sourceSystem` + `sourceRef` + `criterionHash`. A re-run of the
+  same requirement matches its existing goal and **updates in place** (same goal id, same
+  provenance note id) — no duplicates, and no `EditGoal` uniqueness conflict.
+- **Name collisions on create are disambiguated:** if a new requirement's derived name already
+  belongs to a different goal, the tool appends a short disambiguator (`-` + the first six
+  characters of the `criterionHash`) so distinct requirements never collapse into one goal.
+
+### Known limitation (accepted for v1)
+
+A minor edit to a requirement changes both its derived name and its `criterionHash`, so it matches
+neither existing provenance nor an existing name. The tool creates a **new** goal and leaves the
+prior one as a discoverable orphan (same `sourceRef`, different `criterionHash`). Fuzzy resolution
+of edited requirements is ticket 4 (`requel.findBestGoalMatch`). If you need to clean up an orphan
+in the meantime, find goals with the same `sourceRef` but a stale hash and delete or merge them
+manually.
+
+## Provenance note format
+
+Each generated goal carries a `NOTE` containing a fenced block behind the marker
+`requel-provenance`:
+
+````
+Auto-generated from a source tracker item. Do not edit the block below — it is used by Requel to
+reconcile this goal on re-runs.
+
+```requel-provenance
+{
+  "v" : 1,
+  "client" : "claude-desktop",
+  "sourceSystem" : "jira",
+  "sourceRef" : "PROJ-123#ac2",
+  "sourceUrl" : "https://acme.atlassian.net/browse/PROJ-123",
+  "criterionRef" : "AC-2",
+  "criterionHash" : "…sha256 hex…"
+}
+```
+````
+
+The block is the machine-parseable contract used for reconciliation (and by ticket 4). Human prose
+may precede it; only the fenced block is parsed. Unknown fields are ignored, so notes written by a
+newer format version still parse.
+
+## Worked example: Jira
+
+Source ticket `PROJ-123` with an explicit acceptance-criteria section:
+
+> **Acceptance Criteria**
+> 1. The system shall allow a user to sign in with email and password.
+> 2. A failed sign-in shows an error without revealing which field was wrong.
+
+The client reads the ticket via its Jira connector, then calls the tool once per criterion:
+
+```jsonc
+// criterion 1
+{
+  "projectName": "Acme Auth",
+  "criterionText": "The system shall allow a user to sign in with email and password.",
+  "sourceSystem": "jira",
+  "sourceRef": "PROJ-123#ac1",
+  "sourceUrl": "https://acme.atlassian.net/browse/PROJ-123",
+  "criterionRef": "AC-1",
+  "client": "claude-desktop"
+}
+// criterion 2
+{
+  "projectName": "Acme Auth",
+  "criterionText": "A failed sign-in shows an error without revealing which field was wrong.",
+  "sourceSystem": "jira",
+  "sourceRef": "PROJ-123#ac2",
+  "sourceUrl": "https://acme.atlassian.net/browse/PROJ-123",
+  "criterionRef": "AC-2",
+  "client": "claude-desktop"
+}
+```
+
+First run creates two goals ("The system shall allow a user to sign in with email and password",
+"A failed sign-in shows an error without revealing which field was wrong"), each with a provenance
+note. Re-running after editing the ticket's *wording* of criterion 2 creates a third goal and
+leaves the original criterion-2 goal as an orphan (the v1 limitation); re-running with the ticket
+*unchanged* updates both goals in place.
+
+## Worked example: GitHub Issues
+
+Source issue `acme/app#42` with **no** acceptance-criteria section — just a prose body:
+
+> We need CSV export on the reports page. Users should be able to pick a date range, and the
+> export should include the same columns shown on screen.
+
+The client infers discrete requirements from the prose and calls the tool per inferred statement:
+
+```jsonc
+{
+  "projectName": "Acme Reports",
+  "criterionText": "Users can export the reports page to CSV.",
+  "sourceSystem": "github",
+  "sourceRef": "acme/app#42",
+  "sourceUrl": "https://github.com/acme/app/issues/42",
+  "client": "claude-desktop"
+}
+{
+  "projectName": "Acme Reports",
+  "criterionText": "The CSV export supports selecting a date range.",
+  "sourceSystem": "github",
+  "sourceRef": "acme/app#42",
+  "sourceUrl": "https://github.com/acme/app/issues/42",
+  "client": "claude-desktop"
+}
+{
+  "projectName": "Acme Reports",
+  "criterionText": "The CSV export includes the same columns shown on screen.",
+  "sourceSystem": "github",
+  "sourceRef": "acme/app#42",
+  "sourceUrl": "https://github.com/acme/app/issues/42",
+  "client": "claude-desktop"
+}
+```
+
+Because there is no per-criterion id in the source, all three share `sourceRef` `acme/app#42`; the
+`criterionHash` (derived from each statement) is what distinguishes them for reconciliation.
+
+## Prerequisites
+
+- Gateway **writes enabled** for the deployment (`requel.gateway.write.enabled=true`), ideally
+  per-project. Default is off.
+- The caller is authenticated; every write executes as that user and is bounded by the same
+  stakeholder authorization and audit as the Angular UI. Provenance is mandatory for
+  auto-generated goals.

--- a/doc/tracker-to-goals-workflow.md
+++ b/doc/tracker-to-goals-workflow.md
@@ -47,6 +47,23 @@ Inputs (only the first four are required; the rest are derived or optional):
 Result: the goal id, its final name (possibly disambiguated), the provenance note id, a
 `created` flag (created vs updated), and the `criterionHash`.
 
+### How to invoke it
+
+Two front-ends expose the same `RequirementGoalUpserter` core:
+
+- **MCP write tool** `upsertGoalFromRequirement` — advertised in `tools/list` only when gateway
+  writes are enabled (`requel.gateway.write.enabled=true`). The tool arguments are the fields in
+  the table above except `client`, which is taken from the MCP client context (the
+  `X-Requel-Client` identity), not the arguments. This is the path AI clients (Claude Desktop /
+  Code, the remote connector) use.
+- **CLI** `requel upsert-goal` — for scripting/bulk import, e.g.
+  `requel upsert-goal --project "Acme Auth" --criterion "The system shall allow login." --source-system jira --source-ref PROJ-123#ac1 --source-url https://acme.atlassian.net/browse/PROJ-123 --criterion-ref AC-1`.
+  Prints created-vs-updated with the goal and provenance-note ids (or the full result with
+  `--output json`). The CLI reports its client id as `requel-cli`.
+
+Both go through the same gateway command/authorization/audit path; there is no separate write
+path.
+
 The goal `name` is derived deterministically from `criterionText`: the leading clause (up to the
 first line break, then the first sentence terminator), whitespace-collapsed, trailing punctuation
 stripped, capped at 120 characters. The `criterionHash` is SHA-256 over a canonical normalization

--- a/modules/gateway-api/pom.xml
+++ b/modules/gateway-api/pom.xml
@@ -23,5 +23,17 @@
             <artifactId>service-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- Provenance notes are a machine-parseable JSON block behind a marker (issue #71). A
+             plain JSON library (not Spring MVC / JPA / a provider SDK) keeps this module pure per
+             its charter. Version managed by the spring-boot-starter-parent BOM. -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/modules/gateway-api/src/main/java/com/rreganjr/requel/gateway/provenance/CriterionHash.java
+++ b/modules/gateway-api/src/main/java/com/rreganjr/requel/gateway/provenance/CriterionHash.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.provenance;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * The stable reconciliation key for a requirement: a SHA-256 hex digest over a canonically
+ * normalized form of the criterion text (issue #71).
+ *
+ * <p><b>Canonical normalization</b>, applied in this exact order so the key is reproducible across
+ * this ticket and the ticket-4 similarity matcher:</p>
+ * <ol>
+ *   <li>trim leading/trailing whitespace,</li>
+ *   <li>collapse each internal run of whitespace to a single space,</li>
+ *   <li>lowercase (using {@link Locale#ROOT}), and</li>
+ *   <li>strip trailing sentence punctuation and whitespace (the characters
+ *       {@code . , ; : ! ?}).</li>
+ * </ol>
+ *
+ * <p>Because the criterion text has no stable per-item id in free-text trackers, this hash is the
+ * v1 provenance match key. A minor edit to the requirement changes the hash — the accepted v1
+ * limitation documented in the plan.</p>
+ *
+ * <p>Stateless and thread-safe.</p>
+ */
+public final class CriterionHash {
+
+    /** Trailing punctuation/whitespace stripped during normalization. */
+    private static final String TRAILING_STRIP = "[.,;:!?\\s]+$";
+
+    private CriterionHash() {
+    }
+
+    /**
+     * Canonically normalize {@code criterionText} per the class contract. Exposed for reuse by the
+     * ticket-4 matcher and for test assertions.
+     *
+     * @throws NullPointerException if {@code criterionText} is null
+     */
+    public static String normalize(String criterionText) {
+        Objects.requireNonNull(criterionText, "criterionText");
+        String s = criterionText.strip();
+        s = s.replaceAll("\\s+", " ");
+        s = s.toLowerCase(Locale.ROOT);
+        s = s.replaceAll(TRAILING_STRIP, "");
+        return s;
+    }
+
+    /**
+     * The SHA-256 hex digest (lowercase) of the {@linkplain #normalize normalized} criterion text.
+     *
+     * @throws NullPointerException if {@code criterionText} is null
+     */
+    public static String of(String criterionText) {
+        String normalized = normalize(criterionText);
+        byte[] digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-256")
+                    .digest(normalized.getBytes(StandardCharsets.UTF_8));
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is a required algorithm on every JVM; this cannot happen.
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+        StringBuilder hex = new StringBuilder(digest.length * 2);
+        for (byte b : digest) {
+            hex.append(Character.forDigit((b >> 4) & 0xF, 16));
+            hex.append(Character.forDigit(b & 0xF, 16));
+        }
+        return hex.toString();
+    }
+}

--- a/modules/gateway-api/src/main/java/com/rreganjr/requel/gateway/provenance/GoalNameDerivation.java
+++ b/modules/gateway-api/src/main/java/com/rreganjr/requel/gateway/provenance/GoalNameDerivation.java
@@ -1,0 +1,136 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.provenance;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Derives a deterministic goal name from a requirement statement (issue #71).
+ *
+ * <p>Derivation: take the leading clause — the text up to the first line break, then up to the
+ * first sentence terminator ({@code . ! ?} followed by whitespace or end) — collapse whitespace,
+ * strip trailing sentence punctuation, and cap at {@link #MAX_NAME_LENGTH} characters on a word
+ * boundary where possible.</p>
+ *
+ * <p><b>Collision rule.</b> Two requirements can derive the same name. When the caller detects a
+ * collision within the target project it appends a short, stable disambiguator via
+ * {@link #disambiguate(String, String)}: {@code "-" + } the first six characters of the
+ * requirement's {@code criterionHash}, truncating the base name if needed to stay within the
+ * length cap.</p>
+ *
+ * <p>Stateless and thread-safe.</p>
+ */
+public final class GoalNameDerivation {
+
+    /** Maximum derived goal-name length. */
+    public static final int MAX_NAME_LENGTH = 120;
+
+    /** Length of the criterionHash prefix used as a collision disambiguator. */
+    public static final int DISAMBIGUATOR_LEN = 6;
+
+    private static final Pattern SENTENCE_END = Pattern.compile("[.!?](\\s|$)");
+    private static final String TRAILING_STRIP = "[.,;:!?\\s]+$";
+
+    private GoalNameDerivation() {
+    }
+
+    /**
+     * Derive a goal name from {@code requirement}.
+     *
+     * @throws IllegalArgumentException if {@code requirement} is null/blank or yields no usable
+     *                                  name
+     */
+    public static String deriveName(String requirement) {
+        if (requirement == null || requirement.isBlank()) {
+            throw new IllegalArgumentException("requirement text is required to derive a goal name");
+        }
+        String name = stripTrailing(collapse(firstClause(requirement)));
+        if (name.isBlank()) {
+            // Leading clause was only punctuation/whitespace; fall back to the whole statement.
+            name = stripTrailing(collapse(requirement));
+        }
+        name = cap(name);
+        if (name.isBlank()) {
+            throw new IllegalArgumentException(
+                    "could not derive a goal name from requirement: " + requirement);
+        }
+        return name;
+    }
+
+    /**
+     * Append a stable disambiguator derived from {@code criterionHash} to {@code baseName},
+     * truncating the base if necessary so the result stays within {@link #MAX_NAME_LENGTH}.
+     *
+     * @throws IllegalArgumentException if {@code criterionHash} is shorter than
+     *                                  {@link #DISAMBIGUATOR_LEN}
+     */
+    public static String disambiguate(String baseName, String criterionHash) {
+        if (criterionHash == null || criterionHash.length() < DISAMBIGUATOR_LEN) {
+            throw new IllegalArgumentException(
+                    "criterionHash must be at least " + DISAMBIGUATOR_LEN + " characters");
+        }
+        String suffix = "-" + criterionHash.substring(0, DISAMBIGUATOR_LEN);
+        String base = baseName == null ? "" : baseName;
+        int room = MAX_NAME_LENGTH - suffix.length();
+        if (base.length() > room) {
+            base = stripTrailing(base.substring(0, room));
+        }
+        return base + suffix;
+    }
+
+    private static String firstClause(String text) {
+        int nl = text.length();
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (c == '\n' || c == '\r') {
+                nl = i;
+                break;
+            }
+        }
+        String line = text.substring(0, nl);
+        Matcher m = SENTENCE_END.matcher(line);
+        if (m.find()) {
+            return line.substring(0, m.start());
+        }
+        return line;
+    }
+
+    private static String collapse(String s) {
+        return s.strip().replaceAll("\\s+", " ");
+    }
+
+    private static String stripTrailing(String s) {
+        return s.replaceAll(TRAILING_STRIP, "");
+    }
+
+    private static String cap(String s) {
+        if (s.length() <= MAX_NAME_LENGTH) {
+            return s;
+        }
+        String cut = s.substring(0, MAX_NAME_LENGTH);
+        int lastSpace = cut.lastIndexOf(' ');
+        if (lastSpace > 0) {
+            cut = cut.substring(0, lastSpace);
+        }
+        return stripTrailing(cut);
+    }
+}

--- a/modules/gateway-api/src/main/java/com/rreganjr/requel/gateway/provenance/ProvenanceDescriptor.java
+++ b/modules/gateway-api/src/main/java/com/rreganjr/requel/gateway/provenance/ProvenanceDescriptor.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.provenance;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * The machine-parseable payload recorded on an auto-generated goal's provenance {@code NOTE},
+ * linking it back to the source tracker item it was derived from (issue #71). It is serialized as
+ * a small JSON object inside a fenced {@code requel-provenance} block by {@link ProvenanceNotes};
+ * the reconciliation lookup and the ticket-4 similarity matcher both read it back by parsing that
+ * block.
+ *
+ * <p>The workflow is source-agnostic: {@code sourceSystem}/{@code sourceRef}/{@code sourceUrl}
+ * form a generic descriptor that works for Jira, GitHub Issues, Linear, or any tracker. Requel
+ * never talks to the tracker itself.</p>
+ *
+ * <p>Field components are annotated with {@link JsonProperty} so JSON binding does not depend on
+ * the {@code -parameters} compiler flag, and unknown properties are ignored so a note written by a
+ * newer format version still parses.</p>
+ *
+ * @param version       provenance format version (current: {@link #CURRENT_VERSION})
+ * @param client        the external client that authored the goal (e.g. {@code claude-desktop})
+ * @param sourceSystem  the tracker family (e.g. {@code jira}, {@code github})
+ * @param sourceRef     a source-specific reference to the item/criterion (e.g. {@code PROJ-123})
+ * @param sourceUrl     a human-openable URL to the source item (nullable)
+ * @param criterionRef  a human-readable reference to the specific criterion (e.g. {@code AC-2},
+ *                      nullable)
+ * @param criterionHash SHA-256 hex over the canonically normalized criterion text; the stable
+ *                      key used for provenance-based reconciliation
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "v", "client", "sourceSystem", "sourceRef", "sourceUrl", "criterionRef",
+        "criterionHash" })
+public record ProvenanceDescriptor(
+        @JsonProperty("v") int version,
+        @JsonProperty("client") String client,
+        @JsonProperty("sourceSystem") String sourceSystem,
+        @JsonProperty("sourceRef") String sourceRef,
+        @JsonProperty("sourceUrl") String sourceUrl,
+        @JsonProperty("criterionRef") String criterionRef,
+        @JsonProperty("criterionHash") String criterionHash
+) {
+
+    /** The provenance format version emitted by this build. */
+    public static final int CURRENT_VERSION = 1;
+
+    public ProvenanceDescriptor {
+        Objects.requireNonNull(sourceSystem, "sourceSystem");
+        Objects.requireNonNull(sourceRef, "sourceRef");
+        Objects.requireNonNull(criterionHash, "criterionHash");
+    }
+
+    /**
+     * Convenience factory stamping the payload with {@link #CURRENT_VERSION}.
+     */
+    public static ProvenanceDescriptor of(String client, String sourceSystem, String sourceRef,
+            String sourceUrl, String criterionRef, String criterionHash) {
+        return new ProvenanceDescriptor(CURRENT_VERSION, client, sourceSystem, sourceRef, sourceUrl,
+                criterionRef, criterionHash);
+    }
+}

--- a/modules/gateway-api/src/main/java/com/rreganjr/requel/gateway/provenance/ProvenanceNotes.java
+++ b/modules/gateway-api/src/main/java/com/rreganjr/requel/gateway/provenance/ProvenanceNotes.java
@@ -1,0 +1,133 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.provenance;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+/**
+ * Renders and parses the provenance block embedded in an auto-generated goal's {@code NOTE}
+ * (issue #71).
+ *
+ * <p>The note text carries a single fenced code block behind the stable marker
+ * {@value #MARKER}:</p>
+ *
+ * <pre>
+ * ```requel-provenance
+ * { "v": 1, "sourceSystem": "jira", "sourceRef": "PROJ-123", "criterionHash": "..." }
+ * ```
+ * </pre>
+ *
+ * <p>Human-readable prose may precede the block; only the fenced {@value #MARKER} block is
+ * parsed. This is the exact, documented, machine-parseable contract that the reconciliation
+ * lookup and the ticket-4 similarity matcher rely on, so it is covered by parser tests.</p>
+ *
+ * <p>This type is stateless and thread-safe.</p>
+ */
+public final class ProvenanceNotes {
+
+    /** The fence info-string marking the provenance block. */
+    public static final String MARKER = "requel-provenance";
+
+    /** Default prose shown above the machine block so the note reads sensibly in the UI. */
+    private static final String DEFAULT_PREAMBLE =
+            "Auto-generated from a source tracker item. Do not edit the block below — it is used "
+                    + "by Requel to reconcile this goal on re-runs.";
+
+    /**
+     * Matches a fenced block whose info string is exactly the marker (optionally surrounded by
+     * spaces), capturing the block body. DOTALL so the body may span lines; the opening fence must
+     * start at the beginning of a line.
+     */
+    private static final Pattern BLOCK = Pattern.compile(
+            "(?m)^```[ \\t]*" + Pattern.quote(MARKER) + "[ \\t]*\\r?\\n(.*?)\\r?\\n```",
+            Pattern.DOTALL);
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .enable(SerializationFeature.INDENT_OUTPUT);
+
+    private ProvenanceNotes() {
+    }
+
+    /**
+     * Build note text for {@code descriptor}: the default preamble followed by the fenced
+     * provenance block.
+     */
+    public static String render(ProvenanceDescriptor descriptor) {
+        return render(descriptor, DEFAULT_PREAMBLE);
+    }
+
+    /**
+     * Build note text with a caller-supplied {@code preamble} (may be {@code null}/blank to emit
+     * the bare block).
+     */
+    public static String render(ProvenanceDescriptor descriptor, String preamble) {
+        Objects.requireNonNull(descriptor, "descriptor");
+        String json;
+        try {
+            json = MAPPER.writeValueAsString(descriptor);
+        } catch (JsonProcessingException e) {
+            // ProvenanceDescriptor is a plain record of strings/int; serialization cannot fail in
+            // practice. Rethrow unchecked so callers are not forced to handle an impossible case.
+            throw new IllegalStateException("Failed to serialize provenance descriptor", e);
+        }
+        StringBuilder sb = new StringBuilder();
+        if (preamble != null && !preamble.isBlank()) {
+            sb.append(preamble.strip()).append("\n\n");
+        }
+        sb.append("```").append(MARKER).append('\n');
+        sb.append(json).append('\n');
+        sb.append("```");
+        return sb.toString();
+    }
+
+    /**
+     * Extract the provenance descriptor from {@code noteText}, if it contains a well-formed
+     * {@value #MARKER} block. Returns empty when the marker is absent or the block body is not
+     * parseable as a {@link ProvenanceDescriptor} (e.g. a note authored by a human).
+     */
+    public static Optional<ProvenanceDescriptor> parse(String noteText) {
+        if (noteText == null || noteText.isEmpty()) {
+            return Optional.empty();
+        }
+        Matcher m = BLOCK.matcher(noteText);
+        if (!m.find()) {
+            return Optional.empty();
+        }
+        String body = m.group(1).strip();
+        try {
+            return Optional.ofNullable(MAPPER.readValue(body, ProvenanceDescriptor.class));
+        } catch (JsonProcessingException | IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+
+    /** True when {@code noteText} carries a parseable provenance block. */
+    public static boolean hasProvenance(String noteText) {
+        return parse(noteText).isPresent();
+    }
+}

--- a/modules/gateway-api/src/main/java/com/rreganjr/requel/gateway/tracker/RequirementGoalUpserter.java
+++ b/modules/gateway-api/src/main/java/com/rreganjr/requel/gateway/tracker/RequirementGoalUpserter.java
@@ -1,0 +1,210 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.tracker;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import com.rreganjr.requel.gateway.CommandGateway;
+import com.rreganjr.requel.gateway.GatewayException;
+import com.rreganjr.requel.gateway.GatewayRequest;
+import com.rreganjr.requel.gateway.GatewayResult;
+import com.rreganjr.requel.gateway.QueryGateway;
+import com.rreganjr.requel.gateway.provenance.CriterionHash;
+import com.rreganjr.requel.gateway.provenance.GoalNameDerivation;
+import com.rreganjr.requel.gateway.provenance.ProvenanceDescriptor;
+import com.rreganjr.requel.gateway.provenance.ProvenanceNotes;
+import com.rreganjr.requel.service.api.dto.AnnotationsDto;
+import com.rreganjr.requel.service.api.dto.EditGoalInput;
+import com.rreganjr.requel.service.api.dto.EditNoteInput;
+import com.rreganjr.requel.service.api.dto.EntityReferenceDto;
+import com.rreganjr.requel.service.api.dto.GoalDto;
+import com.rreganjr.requel.service.api.dto.NoteDto;
+
+/**
+ * Implements the convenience {@code requel.upsertGoalFromRequirement} capability (issue #71):
+ * turn one discrete requirement into a provenance-noted goal, resolving an existing goal id first
+ * so a re-run <em>updates</em> rather than duplicates.
+ *
+ * <p>This is deliberately front-end-agnostic: it composes the existing {@link CommandGateway}
+ * (writes) and {@link QueryGateway} (reads) plus the shared provenance utilities, so the MCP
+ * tools, the CLI, and the remote connector can all reuse it. It adds no new write path — every
+ * mutation still goes through {@code EditGoal}/{@code EditNote} and the normal
+ * authorization/audit/SSE chain.</p>
+ *
+ * <h2>Resolution (v1)</h2>
+ * <ol>
+ *   <li><b>Provenance match:</b> scan the project's goals' notes for a {@code requel-provenance}
+ *       block whose {@code sourceSystem} + {@code sourceRef} + {@code criterionHash} equal this
+ *       request's. A match is the same requirement on a re-run → update that goal by id and
+ *       update its provenance note by id.</li>
+ *   <li><b>No match → create:</b> create a new goal. If the derived name already belongs to some
+ *       other goal, apply the collision rule (append a short {@code criterionHash} disambiguator)
+ *       so the create never trips the {@code EditGoal} uniqueness conflict, then attach a fresh
+ *       provenance note.</li>
+ * </ol>
+ *
+ * <p><b>Accepted v1 limitation:</b> a minor edit to a requirement changes both the derived name
+ * and the hash, so it neither matches provenance nor collides by name — it creates a new goal and
+ * leaves the prior one as a discoverable orphan (same {@code sourceRef}, different hash). Fuzzy
+ * resolution is ticket 4.</p>
+ *
+ * <p><b>Cost:</b> the provenance scan reads the notes of each goal in the project (O(#goals) read
+ * calls) per upsert. This is correctness-first for v1; ticket 4 adds a candidate query to narrow
+ * it.</p>
+ */
+public class RequirementGoalUpserter {
+
+    private static final String GOAL_TYPE = "Goal";
+    /** Upper bound on goal body text accepted at the tool boundary (client text is untrusted). */
+    static final int MAX_TEXT_LENGTH = 20_000;
+
+    private final CommandGateway commandGateway;
+    private final QueryGateway queryGateway;
+
+    public RequirementGoalUpserter(CommandGateway commandGateway, QueryGateway queryGateway) {
+        this.commandGateway = Objects.requireNonNull(commandGateway, "commandGateway");
+        this.queryGateway = Objects.requireNonNull(queryGateway, "queryGateway");
+    }
+
+    /**
+     * Create or update the goal for {@code request}'s requirement and (re)attach its provenance
+     * note.
+     *
+     * @throws GatewayException if an underlying command is rejected, unauthorized, or fails
+     */
+    public UpsertGoalResult upsert(UpsertGoalRequest request) throws GatewayException {
+        Objects.requireNonNull(request, "request");
+
+        String project = request.projectName();
+        String hash = request.criterionHash() != null && !request.criterionHash().isBlank()
+                ? request.criterionHash()
+                : CriterionHash.of(request.criterionText());
+        String derivedName = request.name() != null && !request.name().isBlank()
+                ? capName(request.name())
+                : GoalNameDerivation.deriveName(request.criterionText());
+        String text = capText(request.text() != null ? request.text() : request.criterionText());
+
+        List<EntityReferenceDto> goals = goalRefs(project);
+        Match match = findProvenanceMatch(project, goals, request.sourceSystem(),
+                request.sourceRef(), hash);
+
+        ProvenanceDescriptor provenance = new ProvenanceDescriptor(
+                ProvenanceDescriptor.CURRENT_VERSION, request.client(), request.sourceSystem(),
+                request.sourceRef(), request.sourceUrl(), request.criterionRef(), hash);
+        String noteText = ProvenanceNotes.render(provenance);
+
+        long goalId;
+        String finalName;
+        boolean created;
+        Long existingNoteId;
+        if (match != null) {
+            // Same requirement, re-run: update the goal in place and refresh its provenance note.
+            GoalDto goal = editGoal(project, match.goalId(), derivedName, text, request.client());
+            goalId = goal.id();
+            finalName = goal.name();
+            existingNoteId = match.noteId();
+            created = false;
+        } else {
+            // New requirement: create, disambiguating the name only if it collides with an
+            // unrelated goal so the create cannot hit the uniqueness conflict.
+            finalName = nameContained(goals, derivedName)
+                    ? GoalNameDerivation.disambiguate(derivedName, hash)
+                    : derivedName;
+            GoalDto goal = editGoal(project, null, finalName, text, request.client());
+            goalId = goal.id();
+            finalName = goal.name();
+            existingNoteId = null;
+            created = true;
+        }
+
+        NoteDto note = editNote(project, goalId, existingNoteId, noteText, request.client());
+        return new UpsertGoalResult(goalId, finalName, note.id(), created, hash);
+    }
+
+    private Match findProvenanceMatch(String project, List<EntityReferenceDto> goals,
+            String sourceSystem, String sourceRef, String hash) {
+        for (EntityReferenceDto ref : goals) {
+            AnnotationsDto annotations = queryGateway.getAnnotations(project, GOAL_TYPE, ref.id());
+            if (annotations == null || annotations.notes() == null) {
+                continue;
+            }
+            for (NoteDto note : annotations.notes()) {
+                Optional<ProvenanceDescriptor> parsed = ProvenanceNotes.parse(note.text());
+                if (parsed.isPresent() && matches(parsed.get(), sourceSystem, sourceRef, hash)) {
+                    return new Match(ref.id(), note.id());
+                }
+            }
+        }
+        return null;
+    }
+
+    private static boolean matches(ProvenanceDescriptor p, String sourceSystem, String sourceRef,
+            String hash) {
+        return Objects.equals(p.sourceSystem(), sourceSystem)
+                && Objects.equals(p.sourceRef(), sourceRef)
+                && Objects.equals(p.criterionHash(), hash);
+    }
+
+    private List<EntityReferenceDto> goalRefs(String project) {
+        // Empty query matches every entity; keep only goals.
+        return queryGateway.searchProjectEntities(project, "").stream()
+                .filter(ref -> GOAL_TYPE.equals(ref.entityType()))
+                .toList();
+    }
+
+    private static boolean nameContained(List<EntityReferenceDto> goals, String name) {
+        return goals.stream().anyMatch(ref -> name.equals(ref.name()));
+    }
+
+    private GoalDto editGoal(String project, Long goalId, String name, String text, String client)
+            throws GatewayException {
+        GatewayResult result = commandGateway.execute(new GatewayRequest("EditGoal",
+                new EditGoalInput(project, goalId, name, text, null), client));
+        return (GoalDto) result.result();
+    }
+
+    private NoteDto editNote(String project, long goalId, Long noteId, String text, String client)
+            throws GatewayException {
+        GatewayResult result = commandGateway.execute(new GatewayRequest("EditNote",
+                new EditNoteInput(project, GOAL_TYPE, goalId, noteId, text), client));
+        return (NoteDto) result.result();
+    }
+
+    private static String capName(String name) {
+        String stripped = name.strip();
+        return stripped.length() <= GoalNameDerivation.MAX_NAME_LENGTH
+                ? stripped
+                : stripped.substring(0, GoalNameDerivation.MAX_NAME_LENGTH).strip();
+    }
+
+    private static String capText(String text) {
+        if (text == null) {
+            return null;
+        }
+        return text.length() <= MAX_TEXT_LENGTH ? text : text.substring(0, MAX_TEXT_LENGTH);
+    }
+
+    /** A resolved existing goal and its provenance note. */
+    private record Match(long goalId, Long noteId) {
+    }
+}

--- a/modules/gateway-api/src/main/java/com/rreganjr/requel/gateway/tracker/UpsertGoalRequest.java
+++ b/modules/gateway-api/src/main/java/com/rreganjr/requel/gateway/tracker/UpsertGoalRequest.java
@@ -1,0 +1,81 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.tracker;
+
+/**
+ * Input to {@link RequirementGoalUpserter#upsert(UpsertGoalRequest)} (issue #71): one discrete
+ * requirement statement plus the source descriptor needed for provenance and reconciliation.
+ *
+ * <p>The workflow is source-agnostic — {@code sourceSystem}/{@code sourceRef}/{@code sourceUrl}
+ * describe any tracker (Jira, GitHub, Linear, …); Requel never contacts the tracker.</p>
+ *
+ * <p>Only {@code projectName}, {@code criterionText}, {@code sourceSystem} and {@code sourceRef}
+ * are required. When {@code name}, {@code text} or {@code criterionHash} are omitted they are
+ * derived deterministically from {@code criterionText} by the upserter, so callers cannot drift
+ * from the reconciliation key.</p>
+ *
+ * @param projectName   target project
+ * @param criterionText the requirement / acceptance-criterion statement (source of the derived
+ *                      name and hash)
+ * @param name          optional explicit goal name (derived from {@code criterionText} if null)
+ * @param text          optional goal body (defaults to {@code criterionText} if null)
+ * @param sourceSystem  tracker family (e.g. {@code jira}, {@code github})
+ * @param sourceRef     source-specific reference to the item/criterion
+ * @param sourceUrl     optional human-openable URL to the source item
+ * @param criterionRef  optional human-readable criterion reference (e.g. {@code AC-2})
+ * @param client        optional external-client id for audit attribution (e.g.
+ *                      {@code claude-desktop})
+ * @param criterionHash optional precomputed hash (computed from {@code criterionText} if null)
+ */
+public record UpsertGoalRequest(
+        String projectName,
+        String criterionText,
+        String name,
+        String text,
+        String sourceSystem,
+        String sourceRef,
+        String sourceUrl,
+        String criterionRef,
+        String client,
+        String criterionHash
+) {
+
+    public UpsertGoalRequest {
+        requireText("projectName", projectName);
+        requireText("criterionText", criterionText);
+        requireText("sourceSystem", sourceSystem);
+        requireText("sourceRef", sourceRef);
+    }
+
+    private static void requireText(String field, String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " is required");
+        }
+    }
+
+    /** Convenience factory for the common case where name/text/hash are derived. */
+    public static UpsertGoalRequest of(String projectName, String criterionText,
+            String sourceSystem, String sourceRef, String sourceUrl, String criterionRef,
+            String client) {
+        return new UpsertGoalRequest(projectName, criterionText, null, null, sourceSystem,
+                sourceRef, sourceUrl, criterionRef, client, null);
+    }
+}

--- a/modules/gateway-api/src/main/java/com/rreganjr/requel/gateway/tracker/UpsertGoalResult.java
+++ b/modules/gateway-api/src/main/java/com/rreganjr/requel/gateway/tracker/UpsertGoalResult.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.tracker;
+
+/**
+ * Outcome of a single {@link RequirementGoalUpserter#upsert(UpsertGoalRequest)} call (issue #71),
+ * suitable for the client's created-vs-updated report.
+ *
+ * @param goalId        the created or updated goal's id
+ * @param goalName      the goal's final name (may be a disambiguated form on a name collision)
+ * @param noteId        the provenance note's id
+ * @param created       {@code true} if a new goal was created, {@code false} if an existing goal
+ *                      was updated in place
+ * @param criterionHash the reconciliation key recorded in the provenance note
+ */
+public record UpsertGoalResult(
+        Long goalId,
+        String goalName,
+        Long noteId,
+        boolean created,
+        String criterionHash
+) {
+}

--- a/modules/gateway-api/src/test/java/com/rreganjr/requel/gateway/provenance/CriterionHashTest.java
+++ b/modules/gateway-api/src/test/java/com/rreganjr/requel/gateway/provenance/CriterionHashTest.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.provenance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Canonical-normalization and SHA-256 vector tests for {@link CriterionHash} (issue #71). The
+ * concrete digest pins the exact algorithm so this ticket and the ticket-4 matcher agree.
+ */
+class CriterionHashTest {
+
+    // Independently computed: sha256("the system shall allow login").
+    private static final String LOGIN_HASH =
+            "d5fbdd1a9886a8098c9dc2b75c4fb7c8f33a68ec666df3ad0a33deb795599a05";
+
+    @Test
+    void normalizeTrimsCollapsesLowercasesAndStripsTrailingPunctuation() {
+        assertThat(CriterionHash.normalize("  The System   SHALL allow Login.  "))
+                .isEqualTo("the system shall allow login");
+    }
+
+    @Test
+    void normalizeIsIdempotentAcrossCaseWhitespaceAndTrailingPunctuation() {
+        String a = CriterionHash.normalize("The System SHALL allow Login.");
+        String b = CriterionHash.normalize("the   system shall allow login");
+        assertThat(a).isEqualTo(b);
+    }
+
+    @Test
+    void hashMatchesKnownVector() {
+        assertThat(CriterionHash.of("  The System   SHALL allow Login.  "))
+                .isEqualTo(LOGIN_HASH);
+        // Trivial-variant inputs collapse to the same key.
+        assertThat(CriterionHash.of("the system shall allow login")).isEqualTo(LOGIN_HASH);
+    }
+
+    @Test
+    void hashIsLowercase64CharHex() {
+        String h = CriterionHash.of("User can reset password!");
+        assertThat(h).hasSize(64).matches("[0-9a-f]{64}");
+    }
+
+    @Test
+    void differentTextProducesDifferentHash() {
+        assertThat(CriterionHash.of("User can reset password"))
+                .isNotEqualTo(CriterionHash.of("User can change password"));
+    }
+
+    @Test
+    void normalizeRejectsNull() {
+        assertThatNullPointerException().isThrownBy(() -> CriterionHash.normalize(null));
+    }
+}

--- a/modules/gateway-api/src/test/java/com/rreganjr/requel/gateway/provenance/GoalNameDerivationTest.java
+++ b/modules/gateway-api/src/test/java/com/rreganjr/requel/gateway/provenance/GoalNameDerivationTest.java
@@ -1,0 +1,110 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.provenance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Deterministic goal-name derivation and collision-disambiguator tests (issue #71).
+ */
+class GoalNameDerivationTest {
+
+    @Test
+    void takesLeadingSentenceAndStripsTerminatingPunctuation() {
+        assertThat(GoalNameDerivation.deriveName(
+                "The system shall allow login. It must respond within 2 seconds."))
+                .isEqualTo("The system shall allow login");
+    }
+
+    @Test
+    void stopsAtFirstLineBreak() {
+        assertThat(GoalNameDerivation.deriveName("Allow password reset\nvia email link"))
+                .isEqualTo("Allow password reset");
+    }
+
+    @Test
+    void collapsesInternalWhitespace() {
+        assertThat(GoalNameDerivation.deriveName("  Support   \t multiple  \n sessions "))
+                .isEqualTo("Support multiple");
+    }
+
+    @Test
+    void preservesCaseOfTheRequirement() {
+        assertThat(GoalNameDerivation.deriveName("MFA is required for admin users"))
+                .isEqualTo("MFA is required for admin users");
+    }
+
+    @Test
+    void capsAtMaxLengthOnAWordBoundary() {
+        String longClause = "The system shall support "
+                + "extremely detailed configuration options ".repeat(10);
+
+        String name = GoalNameDerivation.deriveName(longClause);
+
+        assertThat(name.length()).isLessThanOrEqualTo(GoalNameDerivation.MAX_NAME_LENGTH);
+        assertThat(name).doesNotEndWith(" ");
+        assertThat(longClause).startsWith(name); // prefix, not mangled
+    }
+
+    @Test
+    void blankOrNullRequirementIsRejected() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> GoalNameDerivation.deriveName("   "));
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> GoalNameDerivation.deriveName(null));
+    }
+
+    @Test
+    void disambiguateAppendsHashPrefix() {
+        assertThat(GoalNameDerivation.disambiguate("Allow login", "abcdef1234567890"))
+                .isEqualTo("Allow login-abcdef");
+    }
+
+    @Test
+    void disambiguateStaysWithinMaxLength() {
+        String base = "x".repeat(GoalNameDerivation.MAX_NAME_LENGTH);
+
+        String result = GoalNameDerivation.disambiguate(base, "abcdef1234567890");
+
+        assertThat(result.length()).isLessThanOrEqualTo(GoalNameDerivation.MAX_NAME_LENGTH);
+        assertThat(result).endsWith("-abcdef");
+    }
+
+    @Test
+    void disambiguateRejectsShortHash() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> GoalNameDerivation.disambiguate("Allow login", "abc"));
+    }
+
+    @Test
+    void twoRequirementsCanDeriveTheSameBaseNameThenDivergeWithDisambiguator() {
+        String a = GoalNameDerivation.deriveName("Allow login. Via SSO.");
+        String b = GoalNameDerivation.deriveName("Allow login. Via password.");
+        assertThat(a).isEqualTo(b); // collision
+
+        String da = GoalNameDerivation.disambiguate(a, CriterionHash.of("Allow login via SSO"));
+        String db = GoalNameDerivation.disambiguate(b, CriterionHash.of("Allow login via password"));
+        assertThat(da).isNotEqualTo(db); // disambiguated
+    }
+}

--- a/modules/gateway-api/src/test/java/com/rreganjr/requel/gateway/provenance/ProvenanceNotesTest.java
+++ b/modules/gateway-api/src/test/java/com/rreganjr/requel/gateway/provenance/ProvenanceNotesTest.java
@@ -1,0 +1,147 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.provenance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Parser/renderer tests over the exact documented provenance-note format (issue #71). Shared
+ * contract with the ticket-4 similarity matcher, so these lock the format down.
+ */
+class ProvenanceNotesTest {
+
+    private static final ProvenanceDescriptor SAMPLE = ProvenanceDescriptor.of(
+            "claude-desktop", "jira", "PROJ-123#ac2",
+            "https://example.atlassian.net/browse/PROJ-123", "AC-2", "abc123def456");
+
+    @Test
+    void renderThenParseRoundTrips() {
+        String note = ProvenanceNotes.render(SAMPLE);
+
+        Optional<ProvenanceDescriptor> parsed = ProvenanceNotes.parse(note);
+
+        assertThat(parsed).contains(SAMPLE);
+        assertThat(ProvenanceNotes.hasProvenance(note)).isTrue();
+    }
+
+    @Test
+    void renderEmitsTheDocumentedMarkerBlock() {
+        String note = ProvenanceNotes.render(SAMPLE);
+
+        // Assert on structure/content, not on JSON pretty-printer whitespace (which varies across
+        // Jackson versions): the marked fence is present, the payload keys/values are there, and
+        // the block is closed.
+        assertThat(note).contains("```" + ProvenanceNotes.MARKER);
+        assertThat(note).contains("\"sourceSystem\"").contains("\"jira\"");
+        assertThat(note).contains("\"criterionHash\"").contains("\"abc123def456\"");
+        assertThat(note.trim()).endsWith("```");
+    }
+
+    @Test
+    void parseToleratesHumanProseBeforeTheBlock() {
+        String note = ProvenanceNotes.render(SAMPLE); // default preamble prose precedes the block
+
+        assertThat(note).startsWith("Auto-generated");
+        assertThat(ProvenanceNotes.parse(note)).contains(SAMPLE);
+    }
+
+    @Test
+    void parseWithCustomPreambleStillRoundTrips() {
+        String note = ProvenanceNotes.render(SAMPLE, "See PROJ-123 for the source.");
+
+        assertThat(note).startsWith("See PROJ-123 for the source.");
+        assertThat(ProvenanceNotes.parse(note)).contains(SAMPLE);
+    }
+
+    @Test
+    void parseIgnoresUnknownFieldsForForwardCompatibility() {
+        String note = """
+                ```requel-provenance
+                {
+                  "v": 2,
+                  "sourceSystem": "github",
+                  "sourceRef": "org/repo#42",
+                  "criterionHash": "deadbeef",
+                  "futureField": "ignored"
+                }
+                ```
+                """;
+
+        Optional<ProvenanceDescriptor> parsed = ProvenanceNotes.parse(note);
+
+        assertThat(parsed).isPresent();
+        assertThat(parsed.get().version()).isEqualTo(2);
+        assertThat(parsed.get().sourceSystem()).isEqualTo("github");
+        assertThat(parsed.get().sourceRef()).isEqualTo("org/repo#42");
+        assertThat(parsed.get().criterionHash()).isEqualTo("deadbeef");
+    }
+
+    @Test
+    void parseReturnsEmptyWhenMarkerAbsent() {
+        assertThat(ProvenanceNotes.parse("just a plain human note, no block")).isEmpty();
+        assertThat(ProvenanceNotes.parse("```java\nSystem.out.println();\n```")).isEmpty();
+    }
+
+    @Test
+    void parseReturnsEmptyForNullOrBlank() {
+        assertThat(ProvenanceNotes.parse(null)).isEmpty();
+        assertThat(ProvenanceNotes.parse("")).isEmpty();
+    }
+
+    @Test
+    void parseReturnsEmptyWhenBlockBodyIsNotJson() {
+        String note = """
+                ```requel-provenance
+                this is not json
+                ```
+                """;
+
+        assertThat(ProvenanceNotes.parse(note)).isEmpty();
+    }
+
+    @Test
+    void parseReturnsEmptyWhenRequiredFieldsMissing() {
+        // Missing sourceSystem/sourceRef/criterionHash -> the descriptor's constructor rejects it,
+        // so an incomplete block is treated as not-a-provenance-note rather than a partial parse.
+        String note = """
+                ```requel-provenance
+                { "v": 1, "client": "claude-desktop" }
+                ```
+                """;
+
+        assertThat(ProvenanceNotes.parse(note)).isEmpty();
+    }
+
+    @Test
+    void parsesFirstBlockWhenMultiplePresent() {
+        String note = ProvenanceNotes.render(SAMPLE) + "\n\n"
+                + ProvenanceNotes.render(ProvenanceDescriptor.of("cli", "linear", "LIN-9", null,
+                        null, "9999"));
+
+        // v1 attaches a single provenance note per goal; if two blocks ever coexist, the parser is
+        // deterministic and returns the first.
+        assertThat(ProvenanceNotes.parse(note)).contains(SAMPLE);
+    }
+}

--- a/modules/gateway-api/src/test/java/com/rreganjr/requel/gateway/tracker/InMemoryGateway.java
+++ b/modules/gateway-api/src/test/java/com/rreganjr/requel/gateway/tracker/InMemoryGateway.java
@@ -1,0 +1,188 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.tracker;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import com.rreganjr.requel.gateway.CommandGateway;
+import com.rreganjr.requel.gateway.GatewayException;
+import com.rreganjr.requel.gateway.GatewayRequest;
+import com.rreganjr.requel.gateway.GatewayResult;
+import com.rreganjr.requel.gateway.QueryGateway;
+import com.rreganjr.requel.service.api.dto.AnnotationsDto;
+import com.rreganjr.requel.service.api.dto.EditGoalInput;
+import com.rreganjr.requel.service.api.dto.EditNoteInput;
+import com.rreganjr.requel.service.api.dto.EntityReferenceDto;
+import com.rreganjr.requel.service.api.dto.GoalDto;
+import com.rreganjr.requel.service.api.dto.NoteDto;
+
+/**
+ * In-memory {@link CommandGateway} + {@link QueryGateway} double for {@link RequirementGoalUpserter}
+ * tests. It models just enough of Requel's goal/note behavior — crucially the
+ * <b>{@code EditGoal} uniqueness conflict on create by name</b> — to exercise the upserter's
+ * resolution logic without Spring or JPA.
+ */
+class InMemoryGateway implements CommandGateway, QueryGateway {
+
+    private record GoalRow(long id, int version, String name, String text) {
+    }
+
+    private record NoteRow(long id, int version, String text, long goalId) {
+    }
+
+    private final Map<Long, GoalRow> goals = new LinkedHashMap<>();
+    private final Map<Long, NoteRow> notes = new LinkedHashMap<>();
+    private long nextGoalId = 1;
+    private long nextNoteId = 1;
+
+    int goalCount() {
+        return goals.size();
+    }
+
+    int noteCount() {
+        return notes.size();
+    }
+
+    @Override
+    public GatewayResult execute(GatewayRequest request) throws GatewayException {
+        return switch (request.commandType()) {
+            case "EditGoal" -> new GatewayResult("EditGoal", editGoal((EditGoalInput) request.input()));
+            case "EditNote" -> new GatewayResult("EditNote", editNote((EditNoteInput) request.input()));
+            default -> throw new GatewayException(GatewayException.Kind.NOT_FOUND,
+                    "unknown command " + request.commandType());
+        };
+    }
+
+    private GoalDto editGoal(EditGoalInput i) throws GatewayException {
+        if (i.goalId() == null) {
+            // Create: mirror EditGoalCommandImpl's uniqueness conflict on duplicate name.
+            boolean nameTaken = goals.values().stream().anyMatch(g -> g.name().equals(i.name()));
+            if (nameTaken) {
+                throw new GatewayException(GatewayException.Kind.EXECUTION_ERROR,
+                        "a goal named '" + i.name() + "' already exists");
+            }
+            long id = nextGoalId++;
+            goals.put(id, new GoalRow(id, 0, i.name(), i.text()));
+            return goalDto(goals.get(id));
+        }
+        GoalRow existing = goals.get(i.goalId());
+        if (existing == null) {
+            throw new GatewayException(GatewayException.Kind.NOT_FOUND, "no goal " + i.goalId());
+        }
+        GoalRow updated = new GoalRow(existing.id(), existing.version() + 1, i.name(), i.text());
+        goals.put(updated.id(), updated);
+        return goalDto(updated);
+    }
+
+    private NoteDto editNote(EditNoteInput i) throws GatewayException {
+        if (i.noteId() == null) {
+            long id = nextNoteId++;
+            notes.put(id, new NoteRow(id, 0, i.text(), i.entityId()));
+            return noteDto(notes.get(id));
+        }
+        NoteRow existing = notes.get(i.noteId());
+        if (existing == null) {
+            throw new GatewayException(GatewayException.Kind.NOT_FOUND, "no note " + i.noteId());
+        }
+        NoteRow updated = new NoteRow(existing.id(), existing.version() + 1, i.text(),
+                existing.goalId());
+        notes.put(updated.id(), updated);
+        return noteDto(updated);
+    }
+
+    @Override
+    public List<EntityReferenceDto> searchProjectEntities(String projectName, String query) {
+        String needle = query == null ? "" : query.toLowerCase(Locale.ROOT);
+        List<EntityReferenceDto> out = new ArrayList<>();
+        for (GoalRow g : goals.values()) {
+            if (g.name().toLowerCase(Locale.ROOT).contains(needle)) {
+                out.add(new EntityReferenceDto("Goal", g.id(), g.name()));
+            }
+        }
+        return out;
+    }
+
+    @Override
+    public AnnotationsDto getAnnotations(String projectName, String entityType, long entityId) {
+        List<NoteDto> goalNotes = notes.values().stream()
+                .filter(n -> n.goalId() == entityId)
+                .map(InMemoryGateway::noteDto)
+                .toList();
+        return new AnnotationsDto(goalNotes, List.of());
+    }
+
+    private static GoalDto goalDto(GoalRow g) {
+        return new GoalDto(g.id(), g.version(), g.name(), g.text(), "tester", null, null, null);
+    }
+
+    private static NoteDto noteDto(NoteRow n) {
+        return new NoteDto(n.id(), n.version(), n.text(), "tester");
+    }
+
+    // --- unused QueryGateway surface -------------------------------------------------------
+
+    @Override
+    public List<com.rreganjr.requel.service.api.dto.ProjectDto> listProjects() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public com.rreganjr.requel.service.api.dto.ProjectDto getProject(String projectName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<com.rreganjr.requel.service.api.dto.ProjectTreeNodeDto> getProjectTree(
+            String projectName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<com.rreganjr.requel.service.api.dto.GlossaryTermDto> getGlossaryTerms(
+            String projectName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<com.rreganjr.requel.service.api.dto.OpenIssueDto> getOpenIssues(String projectName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getEntity(String projectName, String entityType, long entityId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, List<EntityReferenceDto>> getEntityNeighbors(String projectName,
+            String entityType, long entityId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, Object> getProjectContext(String projectName) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/modules/gateway-api/src/test/java/com/rreganjr/requel/gateway/tracker/RequirementGoalUpserterTest.java
+++ b/modules/gateway-api/src/test/java/com/rreganjr/requel/gateway/tracker/RequirementGoalUpserterTest.java
@@ -1,0 +1,144 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway.tracker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.rreganjr.requel.gateway.GatewayException;
+import com.rreganjr.requel.gateway.GatewayRequest;
+import com.rreganjr.requel.gateway.provenance.CriterionHash;
+import com.rreganjr.requel.gateway.provenance.GoalNameDerivation;
+import com.rreganjr.requel.gateway.provenance.ProvenanceDescriptor;
+import com.rreganjr.requel.gateway.provenance.ProvenanceNotes;
+import com.rreganjr.requel.service.api.dto.EditGoalInput;
+
+/**
+ * Behavioural tests for {@link RequirementGoalUpserter} (issue #71) over the in-memory gateway
+ * double, covering the issue's testing strategy: idempotency, the edited-requirement orphan, name
+ * collision, provenance-note update-by-id, and the raw create conflict that proves the lookup path
+ * is required.
+ */
+class RequirementGoalUpserterTest {
+
+    private InMemoryGateway gateway;
+    private RequirementGoalUpserter upserter;
+
+    @BeforeEach
+    void setUp() {
+        gateway = new InMemoryGateway();
+        upserter = new RequirementGoalUpserter(gateway, gateway);
+    }
+
+    private static UpsertGoalRequest req(String criterionText, String sourceRef) {
+        return UpsertGoalRequest.of("Demo", criterionText, "jira", sourceRef,
+                "https://example/browse/" + sourceRef, "AC-1", "claude-desktop");
+    }
+
+    @Test
+    void createsGoalWithParseableProvenanceNote() throws Exception {
+        UpsertGoalResult result = upserter.upsert(req("The system shall allow login.", "PROJ-1#1"));
+
+        assertThat(result.created()).isTrue();
+        assertThat(result.goalId()).isNotNull();
+        assertThat(result.noteId()).isNotNull();
+        assertThat(result.goalName()).isEqualTo("The system shall allow login");
+        assertThat(gateway.goalCount()).isEqualTo(1);
+        assertThat(gateway.noteCount()).isEqualTo(1);
+
+        ProvenanceDescriptor prov = provenanceOn(result.goalId());
+        assertThat(prov.sourceSystem()).isEqualTo("jira");
+        assertThat(prov.sourceRef()).isEqualTo("PROJ-1#1");
+        assertThat(prov.criterionHash())
+                .isEqualTo(CriterionHash.of("The system shall allow login."));
+    }
+
+    @Test
+    void derivesNameAndHashWhenOmitted() throws Exception {
+        UpsertGoalResult result = upserter.upsert(req("Users can export reports to CSV", "GH-9"));
+
+        assertThat(result.goalName())
+                .isEqualTo(GoalNameDerivation.deriveName("Users can export reports to CSV"));
+        assertThat(result.criterionHash())
+                .isEqualTo(CriterionHash.of("Users can export reports to CSV"));
+    }
+
+    @Test
+    void reRunUpdatesInPlaceWithNoDuplicateAndSameIds() throws Exception {
+        UpsertGoalRequest request = req("The system shall allow login.", "PROJ-1#1");
+
+        UpsertGoalResult first = upserter.upsert(request);
+        UpsertGoalResult second = upserter.upsert(request);
+
+        assertThat(second.created()).isFalse();
+        assertThat(second.goalId()).isEqualTo(first.goalId());
+        assertThat(second.noteId()).isEqualTo(first.noteId()); // provenance note updated, not added
+        assertThat(gateway.goalCount()).isEqualTo(1);
+        assertThat(gateway.noteCount()).isEqualTo(1);
+    }
+
+    @Test
+    void editedRequirementCreatesNewGoalAndLeavesPriorAsOrphan() throws Exception {
+        UpsertGoalResult original = upserter.upsert(req("The system shall allow login.", "PROJ-1#1"));
+        // Same source ref, minor edit to the text -> different derived name and hash.
+        UpsertGoalResult edited =
+                upserter.upsert(req("The system shall allow secure login.", "PROJ-1#1"));
+
+        assertThat(edited.created()).isTrue();
+        assertThat(edited.goalId()).isNotEqualTo(original.goalId());
+        assertThat(gateway.goalCount()).isEqualTo(2); // prior goal discoverable as an orphan
+    }
+
+    @Test
+    void distinctRequirementsSharingADerivedNameAreDisambiguated() throws Exception {
+        UpsertGoalResult a = upserter.upsert(req("Allow login. Via SSO.", "PROJ-1#1"));
+        UpsertGoalResult b = upserter.upsert(req("Allow login. Via password.", "PROJ-2#1"));
+
+        assertThat(a.goalName()).isEqualTo("Allow login");
+        assertThat(b.created()).isTrue();
+        assertThat(b.goalName()).isNotEqualTo(a.goalName());
+        assertThat(b.goalName()).startsWith("Allow login-");
+        assertThat(gateway.goalCount()).isEqualTo(2); // no uniqueness conflict, both persisted
+    }
+
+    @Test
+    void rawCreateWithCollidingNameSurfacesUniquenessConflict() throws Exception {
+        // Proves why the upserter must resolve an id: a bare second create by the same name fails.
+        gateway.execute(new GatewayRequest("EditGoal",
+                new EditGoalInput("Demo", null, "Allow login", "x", null), null));
+
+        assertThatExceptionOfType(GatewayException.class).isThrownBy(() ->
+                gateway.execute(new GatewayRequest("EditGoal",
+                        new EditGoalInput("Demo", null, "Allow login", "y", null), null)));
+    }
+
+    private ProvenanceDescriptor provenanceOn(Long goalId) {
+        return gateway.getAnnotations("Demo", "Goal", goalId).notes().stream()
+                .map(n -> ProvenanceNotes.parse(n.text()))
+                .filter(java.util.Optional::isPresent)
+                .map(java.util.Optional::get)
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/modules/mcp-server/src/main/java/com/rreganjr/requel/mcp/McpWriteService.java
+++ b/modules/mcp-server/src/main/java/com/rreganjr/requel/mcp/McpWriteService.java
@@ -25,7 +25,9 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -37,6 +39,9 @@ import com.rreganjr.requel.gateway.GatewayCommandCatalog;
 import com.rreganjr.requel.gateway.GatewayException;
 import com.rreganjr.requel.gateway.GatewayRequest;
 import com.rreganjr.requel.gateway.GatewayResult;
+import com.rreganjr.requel.gateway.QueryGateway;
+import com.rreganjr.requel.gateway.tracker.RequirementGoalUpserter;
+import com.rreganjr.requel.gateway.tracker.UpsertGoalRequest;
 
 /**
  * MCP write tools, backed by the {@link CommandGateway}. Exposes a generic
@@ -60,18 +65,46 @@ public class McpWriteService {
 	/** Generic escape hatch: run any allowlisted command by type + input. */
 	static final String RUN_COMMAND = "runCommand";
 
+	/** Convenience tool: create/update a goal from a requirement + provenance (issue #71). */
+	static final String UPSERT_GOAL = "upsertGoalFromRequirement";
+
+	/**
+	 * Composite convenience tools — multi-command orchestrations that are NOT single catalog
+	 * commands, so the "typed write tools == catalog" lockstep checks exclude them. They are still
+	 * gated by the write flag and every underlying write still goes through the gateway's policy,
+	 * authorization, and audit.
+	 */
+	static final Set<String> COMPOSITE_TOOLS = Set.of(UPSERT_GOAL);
+
 	private final CommandGateway commandGateway;
+	private final QueryGateway queryGateway;
 	private final GatewayCommandCatalog catalog;
 	private final ObjectMapper objectMapper;
 	private final boolean writeEnabled;
 
-	public McpWriteService(CommandGateway commandGateway, GatewayCommandCatalog catalog,
-			ObjectMapper objectMapper,
+	/** Lazily built (only when the upsert tool is called), so a null command/query gateway in
+	 * read-only mode never triggers construction. */
+	private RequirementGoalUpserter upserter;
+
+	@Autowired
+	public McpWriteService(CommandGateway commandGateway, QueryGateway queryGateway,
+			GatewayCommandCatalog catalog, ObjectMapper objectMapper,
 			@Value("${requel.gateway.write.enabled:false}") boolean writeEnabled) {
 		this.commandGateway = commandGateway;
+		this.queryGateway = queryGateway;
 		this.catalog = catalog;
 		this.objectMapper = objectMapper;
 		this.writeEnabled = writeEnabled;
+	}
+
+	/**
+	 * Convenience constructor without a {@link QueryGateway} (used by read-only deployments and by
+	 * tests that never exercise the composite {@code upsertGoalFromRequirement} tool). The upsert
+	 * tool requires a query gateway and will fail fast if invoked through this path.
+	 */
+	public McpWriteService(CommandGateway commandGateway, GatewayCommandCatalog catalog,
+			ObjectMapper objectMapper, boolean writeEnabled) {
+		this(commandGateway, null, catalog, objectMapper, writeEnabled);
 	}
 
 	public boolean isWriteEnabled() {
@@ -80,7 +113,8 @@ public class McpWriteService {
 
 	/** @return true if {@code toolName} is a write tool (regardless of the opt-in flag). */
 	public boolean handles(String toolName) {
-		return RUN_COMMAND.equals(toolName) || catalog.find(toolName).isPresent();
+		return RUN_COMMAND.equals(toolName) || COMPOSITE_TOOLS.contains(toolName)
+				|| catalog.find(toolName).isPresent();
 	}
 
 	/** Write tool descriptors for {@code tools/list}; empty when the write flag is disabled. */
@@ -100,6 +134,8 @@ public class McpWriteService {
 			tools.add(new McpToolDescriptor(descriptor.commandType(), describe(descriptor),
 					schemaFor(descriptor.inputType())));
 		}
+		// Composite convenience tools (orchestrations over several commands; issue #71).
+		tools.add(upsertGoalDescriptor());
 		return tools;
 	}
 
@@ -117,6 +153,9 @@ public class McpWriteService {
 			JsonNode input = arguments == null ? null : arguments.get("input");
 			return execute(commandType, input == null || input.isNull() ? Map.of() : toMap(input));
 		}
+		if (UPSERT_GOAL.equals(toolName)) {
+			return upsertGoalFromRequirement(arguments);
+		}
 		// Typed tool: the tool name IS the catalog command type, and its argument names already
 		// match the command input DTO field names, so forward the arguments as-is.
 		if (catalog.find(toolName).isEmpty()) {
@@ -132,14 +171,54 @@ public class McpWriteService {
 			return result.result() != null ? result.result()
 					: Map.of("ok", true, "commandType", commandType);
 		} catch (GatewayException e) {
-			throw switch (e.getKind()) {
-				// Client-correctable failures map to JSON-RPC INVALID_PARAMS.
-				case NOT_ALLOWED, NOT_FOUND, INVALID_INPUT, UNAUTHORIZED ->
-						new McpInvalidParamsException(e.getMessage());
-				// Server-side execution failure maps to INTERNAL_ERROR.
-				case EXECUTION_ERROR -> new IllegalStateException(e.getMessage(), e);
-			};
+			throw mapGatewayException(e);
 		}
+	}
+
+	/**
+	 * Composite tool: create or update a goal from one requirement and (re)attach its provenance
+	 * note (issue #71). The per-client identity is taken from the request context, not the
+	 * arguments, mirroring {@link #execute}.
+	 */
+	private Object upsertGoalFromRequirement(JsonNode arguments) {
+		UpsertGoalRequest request;
+		try {
+			request = new UpsertGoalRequest(
+					requiredText(arguments, "projectName"),
+					requiredText(arguments, "criterionText"),
+					optionalText(arguments, "name"),
+					optionalText(arguments, "text"),
+					requiredText(arguments, "sourceSystem"),
+					requiredText(arguments, "sourceRef"),
+					optionalText(arguments, "sourceUrl"),
+					optionalText(arguments, "criterionRef"),
+					McpClientContext.clientId(),
+					optionalText(arguments, "criterionHash"));
+		} catch (IllegalArgumentException e) {
+			throw new McpInvalidParamsException(e.getMessage());
+		}
+		try {
+			return upserter().upsert(request);
+		} catch (GatewayException e) {
+			throw mapGatewayException(e);
+		}
+	}
+
+	private RequirementGoalUpserter upserter() {
+		if (upserter == null) {
+			upserter = new RequirementGoalUpserter(commandGateway, queryGateway);
+		}
+		return upserter;
+	}
+
+	private static RuntimeException mapGatewayException(GatewayException e) {
+		return switch (e.getKind()) {
+			// Client-correctable failures map to JSON-RPC INVALID_PARAMS.
+			case NOT_ALLOWED, NOT_FOUND, INVALID_INPUT, UNAUTHORIZED ->
+					new McpInvalidParamsException(e.getMessage());
+			// Server-side execution failure maps to INTERNAL_ERROR.
+			case EXECUTION_ERROR -> new IllegalStateException(e.getMessage(), e);
+		};
 	}
 
 	// ---- schema + description helpers ----------------------------------------------------------
@@ -159,6 +238,34 @@ public class McpWriteService {
 				"commandType", stringType(),
 				"input", Map.of("type", "object")),
 				List.of("commandType"));
+	}
+
+	private static McpToolDescriptor upsertGoalDescriptor() {
+		return new McpToolDescriptor(UPSERT_GOAL,
+				"Create or update a project goal from one requirement / acceptance criterion and"
+						+ " attach a machine-parseable provenance note linking it to the source"
+						+ " tracker item. Resolves an existing goal by provenance"
+						+ " (sourceSystem + sourceRef + criterionHash) and updates it in place on a"
+						+ " re-run; otherwise creates a new goal (disambiguating the name on a"
+						+ " collision). name, text and criterionHash are derived from criterionText"
+						+ " when omitted. Subject to the caller's Goal Edit permission.",
+				upsertGoalSchema());
+	}
+
+	private static Map<String, Object> upsertGoalSchema() {
+		Map<String, Object> properties = new LinkedHashMap<>();
+		properties.put("projectName", stringType());
+		properties.put("criterionText", stringType());
+		properties.put("sourceSystem", stringType());
+		properties.put("sourceRef", stringType());
+		properties.put("name", stringType());
+		properties.put("text", stringType());
+		properties.put("sourceUrl", stringType());
+		properties.put("criterionRef", stringType());
+		properties.put("criterionHash", stringType());
+		// client is intentionally omitted: it is taken from the MCP client context, not arguments.
+		return objectSchema(properties,
+				List.of("projectName", "criterionText", "sourceSystem", "sourceRef"));
 	}
 
 	/**
@@ -268,5 +375,10 @@ public class McpWriteService {
 			throw new McpInvalidParamsException("Missing required string field: " + fieldName);
 		}
 		return params.get(fieldName).asText();
+	}
+
+	private static String optionalText(JsonNode params, String fieldName) {
+		JsonNode value = params == null ? null : params.get(fieldName);
+		return value == null || value.isNull() || !value.isTextual() ? null : value.asText();
 	}
 }

--- a/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/McpWriteCatalogLockstepTest.java
+++ b/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/McpWriteCatalogLockstepTest.java
@@ -51,6 +51,7 @@ class McpWriteCatalogLockstepTest {
 		List<String> typedToolNames = writes.toolDescriptors().stream()
 				.map(McpToolDescriptor::name)
 				.filter(name -> !name.equals(McpWriteService.RUN_COMMAND))
+				.filter(name -> !McpWriteService.COMPOSITE_TOOLS.contains(name))
 				.toList();
 
 		// Subset (⊆) AND coverage: the typed write surface is exactly the catalog.

--- a/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/McpWriteServiceTest.java
+++ b/modules/mcp-server/src/test/java/com/rreganjr/requel/mcp/McpWriteServiceTest.java
@@ -30,6 +30,11 @@ import com.rreganjr.requel.gateway.GatewayCommandCatalog;
 import com.rreganjr.requel.gateway.GatewayException;
 import com.rreganjr.requel.gateway.GatewayRequest;
 import com.rreganjr.requel.gateway.GatewayResult;
+import com.rreganjr.requel.gateway.tracker.UpsertGoalResult;
+import com.rreganjr.requel.service.api.dto.EditGoalInput;
+import com.rreganjr.requel.service.api.dto.EditNoteInput;
+import com.rreganjr.requel.service.api.dto.GoalDto;
+import com.rreganjr.requel.service.api.dto.NoteDto;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -98,7 +103,80 @@ class McpWriteServiceTest {
 				objectMapper, true);
 		assertThat(enabled.toolDescriptors()).extracting(McpToolDescriptor::name)
 				.contains("runCommand", "EditProject", "EditGoal",
-						"AddGoalToGoalContainer", "EditNote", "EditIssue");
+						"AddGoalToGoalContainer", "EditNote", "EditIssue",
+						McpWriteService.UPSERT_GOAL);
+	}
+
+	// ---- composite tool: upsertGoalFromRequirement (issue #71) ---------------------------------
+
+	/** CommandGateway double returning real Goal/Note DTOs and recording the carried client id. */
+	private static final class UpsertRecordingGateway implements CommandGateway {
+		String editGoalClientId;
+		long nextGoalId = 1;
+		long nextNoteId = 1;
+
+		@Override
+		public GatewayResult execute(GatewayRequest request) {
+			return switch (request.commandType()) {
+				case "EditGoal" -> {
+					EditGoalInput i = (EditGoalInput) request.input();
+					editGoalClientId = request.clientId();
+					long id = i.goalId() != null ? i.goalId() : nextGoalId++;
+					yield new GatewayResult("EditGoal",
+							new GoalDto(id, 0, i.name(), i.text(), "t", null, null, null));
+				}
+				case "EditNote" -> {
+					EditNoteInput i = (EditNoteInput) request.input();
+					long id = i.noteId() != null ? i.noteId() : nextNoteId++;
+					yield new GatewayResult("EditNote", new NoteDto(id, 0, i.text(), "t"));
+				}
+				default -> throw new IllegalArgumentException(request.commandType());
+			};
+		}
+	}
+
+	@Test
+	void upsertRejectedWhenDisabled() {
+		McpWriteService disabled = new McpWriteService(new RecordingGateway(), catalog,
+				objectMapper, false);
+		assertThatThrownBy(() -> disabled.call(McpWriteService.UPSERT_GOAL,
+				json("{\"projectName\":\"P\",\"criterionText\":\"x\",\"sourceSystem\":\"jira\","
+						+ "\"sourceRef\":\"R\"}")))
+				.isInstanceOf(McpInvalidParamsException.class)
+				.hasMessageContaining("disabled");
+	}
+
+	@Test
+	void upsertMissingRequiredArgMapsToInvalidParams() {
+		McpWriteService svc = new McpWriteService(new UpsertRecordingGateway(),
+				new StubProjectQueryGateway(), catalog, objectMapper, true);
+		// sourceRef omitted.
+		assertThatThrownBy(() -> svc.call(McpWriteService.UPSERT_GOAL,
+				json("{\"projectName\":\"P\",\"criterionText\":\"x\",\"sourceSystem\":\"jira\"}")))
+				.isInstanceOf(McpInvalidParamsException.class)
+				.hasMessageContaining("sourceRef");
+	}
+
+	@Test
+	void upsertCreatesGoalAndCarriesClientIdFromContext() {
+		UpsertRecordingGateway gw = new UpsertRecordingGateway();
+		McpWriteService svc = new McpWriteService(gw, new StubProjectQueryGateway(), catalog,
+				objectMapper, true);
+		McpClientContext.setClientId("claude-desktop");
+		Object result;
+		try {
+			result = svc.call(McpWriteService.UPSERT_GOAL,
+					json("{\"projectName\":\"P\",\"criterionText\":\"Users can export CSV.\","
+							+ "\"sourceSystem\":\"jira\",\"sourceRef\":\"R-1\"}"));
+		} finally {
+			McpClientContext.clear();
+		}
+		assertThat(result).isInstanceOf(UpsertGoalResult.class);
+		UpsertGoalResult upsert = (UpsertGoalResult) result;
+		assertThat(upsert.created()).isTrue();
+		assertThat(upsert.goalId()).isNotNull();
+		assertThat(upsert.noteId()).isNotNull();
+		assertThat(gw.editGoalClientId).isEqualTo("claude-desktop");
 	}
 
 	// ---- delegation ----------------------------------------------------------------------------

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/mcp/McpToolCatalogLockstepIT.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/mcp/McpToolCatalogLockstepIT.java
@@ -69,6 +69,7 @@ public class McpToolCatalogLockstepIT extends AbstractIntegrationTestCase {
 		List<String> typedToolNames = writeService.toolDescriptors().stream()
 				.map(McpToolDescriptor::name)
 				.filter(name -> !name.equals(McpWriteService.RUN_COMMAND))
+				.filter(name -> !McpWriteService.COMPOSITE_TOOLS.contains(name))
 				.toList();
 
 		// MCP tools ⊆ catalog: every typed write tool is a catalog command...

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/RequelCli.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/RequelCli.java
@@ -37,7 +37,7 @@ import picocli.CommandLine.Option;
  */
 @Command(name = "requel", mixinStandardHelpOptions = true, version = "requel-cli 2.0.0-dev",
         description = "Command-line access to a Requel server via the gateway.",
-        subcommands = {RunCommand.class, CommandsCommand.class,
+        subcommands = {RunCommand.class, UpsertGoalCommand.class, CommandsCommand.class,
                 ProjectsCommand.class, ProjectCommand.class, GlossaryCommand.class,
                 OpenIssuesCommand.class, SearchCommand.class, EntityCommand.class, ContextCommand.class,
                 LoginCommand.class, LogoutCommand.class})

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/UpsertGoalCommand.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/UpsertGoalCommand.java
@@ -1,0 +1,137 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rreganjr.requel.gateway.CommandGateway;
+import com.rreganjr.requel.gateway.GatewayException;
+import com.rreganjr.requel.gateway.QueryGateway;
+import com.rreganjr.requel.gateway.rest.RestCommandGateway;
+import com.rreganjr.requel.gateway.rest.RestQueryGateway;
+import com.rreganjr.requel.gateway.tracker.RequirementGoalUpserter;
+import com.rreganjr.requel.gateway.tracker.UpsertGoalRequest;
+import com.rreganjr.requel.gateway.tracker.UpsertGoalResult;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+
+/**
+ * {@code requel upsert-goal} — create or update a project goal from one requirement / acceptance
+ * criterion, attaching a machine-parseable provenance note that links it to the source tracker
+ * item (issue #71). Orchestrates the REST-backed {@link CommandGateway} (writes) and
+ * {@link QueryGateway} (reads) through {@link RequirementGoalUpserter}: it resolves an existing
+ * goal by provenance and updates it in place on a re-run, otherwise creates a new goal. Useful for
+ * scripting bulk requirement import from any tracker; the client reads the issue, this command
+ * hands Requel one discrete statement at a time.
+ */
+@Command(name = "upsert-goal",
+        description = "Create or update a goal from a requirement, with a provenance note linking "
+                + "it to a source tracker item.")
+public class UpsertGoalCommand implements Callable<Integer> {
+
+    @ParentCommand
+    RequelCli parent;
+
+    @Option(names = {"--project", "-p"}, required = true, paramLabel = "NAME",
+            description = "Target project name.")
+    String project;
+
+    @Option(names = "--criterion", required = true, paramLabel = "TEXT",
+            description = "The requirement / acceptance-criterion statement.")
+    String criterionText;
+
+    @Option(names = "--source-system", required = true, paramLabel = "SYSTEM",
+            description = "Tracker family, e.g. jira, github, linear.")
+    String sourceSystem;
+
+    @Option(names = "--source-ref", required = true, paramLabel = "REF",
+            description = "Reference to the source item/criterion, e.g. PROJ-123#ac2.")
+    String sourceRef;
+
+    @Option(names = "--name", paramLabel = "NAME",
+            description = "Explicit goal name (derived from --criterion when omitted).")
+    String name;
+
+    @Option(names = "--text", paramLabel = "TEXT",
+            description = "Goal body (defaults to --criterion).")
+    String text;
+
+    @Option(names = "--source-url", paramLabel = "URL",
+            description = "Openable link to the source item.")
+    String sourceUrl;
+
+    @Option(names = "--criterion-ref", paramLabel = "REF",
+            description = "Human-readable criterion label, e.g. AC-2.")
+    String criterionRef;
+
+    @Option(names = "--criterion-hash", paramLabel = "HASH",
+            description = "Precomputed reconciliation hash (computed from --criterion when omitted).")
+    String criterionHash;
+
+    /** Test seams: when set, used instead of building REST-backed gateways from the parent. */
+    CommandGateway commandGatewayOverride;
+    QueryGateway queryGatewayOverride;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public Integer call() {
+        CommandGateway command = commandGatewayOverride != null ? commandGatewayOverride
+                : new RestCommandGateway(parent.url, parent.tokenSource());
+        QueryGateway query = queryGatewayOverride != null ? queryGatewayOverride
+                : new RestQueryGateway(parent.url, parent.tokenSource());
+
+        UpsertGoalRequest request;
+        try {
+            request = new UpsertGoalRequest(project, criterionText, name, text, sourceSystem,
+                    sourceRef, sourceUrl, criterionRef, "requel-cli", criterionHash);
+        } catch (IllegalArgumentException e) {
+            System.err.println("Invalid input: " + e.getMessage());
+            return ExitCode.USAGE;
+        }
+
+        try {
+            UpsertGoalResult result = new RequirementGoalUpserter(command, query).upsert(request);
+            print(result);
+            return ExitCode.SUCCESS;
+        } catch (GatewayException e) {
+            parent.printError(e);
+            return ExitCode.forKind(e.getKind());
+        }
+    }
+
+    private void print(UpsertGoalResult result) {
+        if (parent.output == OutputFormat.JSON) {
+            try {
+                System.out.println(mapper.writerWithDefaultPrettyPrinter()
+                        .writeValueAsString(result));
+            } catch (JsonProcessingException e) {
+                System.out.println(String.valueOf(result));
+            }
+            return;
+        }
+        System.out.println((result.created() ? "Created" : "Updated") + " goal "
+                + result.goalId() + " \"" + result.goalName() + "\" (provenance note "
+                + result.noteId() + ")");
+    }
+}

--- a/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/UpsertGoalCommandTest.java
+++ b/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/UpsertGoalCommandTest.java
@@ -1,0 +1,153 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.rreganjr.requel.gateway.CommandGateway;
+import com.rreganjr.requel.gateway.GatewayException;
+import com.rreganjr.requel.gateway.GatewayResult;
+import com.rreganjr.requel.gateway.QueryGateway;
+import com.rreganjr.requel.service.api.dto.AnnotationsDto;
+import com.rreganjr.requel.service.api.dto.EditGoalInput;
+import com.rreganjr.requel.service.api.dto.EditNoteInput;
+import com.rreganjr.requel.service.api.dto.EntityReferenceDto;
+import com.rreganjr.requel.service.api.dto.GoalDto;
+import com.rreganjr.requel.service.api.dto.NoteDto;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class UpsertGoalCommandTest {
+
+    /** Query side with an empty project, so the upserter always takes the create path. */
+    private static final class EmptyQueryGateway implements QueryGateway {
+        @Override
+        public List<EntityReferenceDto> searchProjectEntities(String projectName, String query) {
+            return List.of();
+        }
+
+        @Override
+        public AnnotationsDto getAnnotations(String projectName, String entityType, long entityId) {
+            return new AnnotationsDto(List.of(), List.of());
+        }
+
+        @Override
+        public List<com.rreganjr.requel.service.api.dto.ProjectDto> listProjects() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public com.rreganjr.requel.service.api.dto.ProjectDto getProject(String projectName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<com.rreganjr.requel.service.api.dto.ProjectTreeNodeDto> getProjectTree(
+                String projectName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<com.rreganjr.requel.service.api.dto.GlossaryTermDto> getGlossaryTerms(
+                String projectName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<com.rreganjr.requel.service.api.dto.OpenIssueDto> getOpenIssues(
+                String projectName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Object getEntity(String projectName, String entityType, long entityId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<String, List<EntityReferenceDto>> getEntityNeighbors(String projectName,
+                String entityType, long entityId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<String, Object> getProjectContext(String projectName) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /** Command side that satisfies EditGoal (create) + EditNote with real DTOs. */
+    private static CommandGateway creatingGateway() {
+        return request -> switch (request.commandType()) {
+            case "EditGoal" -> {
+                EditGoalInput i = (EditGoalInput) request.input();
+                yield new GatewayResult("EditGoal",
+                        new GoalDto(1L, 0, i.name(), i.text(), "t", null, null, null));
+            }
+            case "EditNote" -> {
+                EditNoteInput i = (EditNoteInput) request.input();
+                yield new GatewayResult("EditNote", new NoteDto(1L, 0, i.text(), "t"));
+            }
+            default -> throw new IllegalStateException("unexpected " + request.commandType());
+        };
+    }
+
+    private static UpsertGoalCommand command(CommandGateway command, QueryGateway query) {
+        RequelCli parent = new RequelCli();
+        parent.url = "http://localhost:8080";
+        parent.output = OutputFormat.TEXT;
+        UpsertGoalCommand cmd = new UpsertGoalCommand();
+        cmd.parent = parent;
+        cmd.project = "Demo";
+        cmd.criterionText = "Users can export reports to CSV.";
+        cmd.sourceSystem = "jira";
+        cmd.sourceRef = "PROJ-1#1";
+        cmd.commandGatewayOverride = command;
+        cmd.queryGatewayOverride = query;
+        return cmd;
+    }
+
+    @Test
+    void successReturnsZero() {
+        UpsertGoalCommand cmd = command(creatingGateway(), new EmptyQueryGateway());
+        assertThat(cmd.call()).isEqualTo(ExitCode.SUCCESS);
+    }
+
+    @Test
+    void unauthorizedReturnsAuthCode() {
+        CommandGateway denies = request -> {
+            throw new GatewayException(GatewayException.Kind.UNAUTHORIZED, "nope");
+        };
+        UpsertGoalCommand cmd = command(denies, new EmptyQueryGateway());
+        assertThat(cmd.call()).isEqualTo(ExitCode.AUTH);
+    }
+
+    @Test
+    void blankRequiredInputReturnsUsageWithoutCallingGateway() {
+        CommandGateway neverCalled = request -> {
+            throw new AssertionError("gateway must not be called for invalid input");
+        };
+        UpsertGoalCommand cmd = command(neverCalled, new EmptyQueryGateway());
+        cmd.project = "   "; // blank -> UpsertGoalRequest rejects it
+        assertThat(cmd.call()).isEqualTo(ExitCode.USAGE);
+    }
+}


### PR DESCRIPTION
Issue tracker → goals workflow + v1 reconciliation (issue #71)

Deliver the source-agnostic "read an issue, derive its requirements, create one provenance-noted
goal per requirement" workflow with v1 reconciliation, and surface it end to end as an MCP write
tool and a requel-cli subcommand. The reconciliation/provenance core lives in the pure gateway-api
module so every front-end shares it and the ticket-4 similarity matcher can reuse the provenance
parser. No domain or command changes: goals/notes are still written through the existing
EditGoal/EditNote commands and the normal authorization/audit/SSE chain.

The workflow is source-agnostic — Requel never talks to the tracker. The client reads the issue via
its own connector (Jira, GitHub Issues, Linear, …), extracts discrete requirement statements, and
hands Requel each statement plus a generic source descriptor
(sourceSystem / sourceRef / sourceUrl).

## Provenance format + parser (gateway-api, com.rreganjr.requel.gateway.provenance)

- ProvenanceDescriptor: the JSON payload recorded on an auto-generated goal's NOTE
  (v, client, sourceSystem, sourceRef, sourceUrl, criterionRef, criterionHash). Ignores unknown
  fields for forward-compat; requires sourceSystem/sourceRef/criterionHash. @JsonProperty on each
  component so binding does not rely on the -parameters compiler flag.
- ProvenanceNotes: renders/parses a fenced ```requel-provenance JSON block behind a stable marker.
  Tolerates human prose before the block; returns empty for non-provenance notes. The
  machine-parseable contract shared with ticket 4.

## Deterministic derivation (same package)

- CriterionHash: SHA-256 hex over canonical normalization (trim → collapse whitespace → lowercase
  → strip trailing . , ; : ! ?). The v1 reconciliation key; a concrete vector is pinned in tests so
  this ticket and ticket 4 cannot drift.
- GoalNameDerivation: deterministic goal name from a requirement (leading clause → collapse
  whitespace → strip trailing punctuation → cap at 120 chars on a word boundary), plus
  disambiguate(base, hash) appending "-" + first 6 hash chars within the length cap.

## Upsert core (gateway-api, com.rreganjr.requel.gateway.tracker)

- RequirementGoalUpserter composes CommandGateway (writes) + QueryGateway (reads) + the provenance
  utils. Resolution is provenance-only for updates (sourceSystem + sourceRef + criterionHash): a
  match updates the goal and its provenance note by id; otherwise it creates a new goal,
  disambiguating the derived name only if it collides with another goal so EditGoal's
  uniqueness-conflict-on-create can never fire. Derives name/hash/text when omitted and caps text at
  the tool boundary (client text is untrusted).
- Design refinement vs the ticket's candidate keys: "exact name match" is folded into the create
  path (disambiguation) rather than the update path, because a name-only update is unsafe (two
  distinct requirements can derive the same name). Provenance is the sole update key; this still
  satisfies the AC (resolve an id before editing, update by id, never rely on name-based
  auto-create). Documented in doc/71-issue-tracker-goals-plan.md.
- UpsertGoalRequest / UpsertGoalResult: the tool's input/output value types.
- Accepted v1 limitation: a minor edit to a requirement changes both the derived name and the hash,
  so it neither matches provenance nor collides by name — it creates a new goal and leaves the prior
  one as a discoverable orphan (same sourceRef, different hash). Fuzzy resolution is ticket 4.

## MCP write tool (mcp-server, McpWriteService)

- New composite tool upsertGoalFromRequirement, advertised in tools/list only when
  requel.gateway.write.enabled=true and gated/audited like the other write tools. Its client id
  comes from the MCP client context (not arguments); name/text/criterionHash are derived when
  omitted. GatewayException maps to JSON-RPC errors as for the other write tools.
- McpWriteService gains a QueryGateway via a new @Autowired 5-arg constructor; the prior 4-arg
  constructor is retained for read-only/test callers and delegates with a null query gateway. The
  RequirementGoalUpserter is built lazily so a null command/query gateway in read-only mode never
  triggers construction.
- COMPOSITE_TOOLS marks orchestration tools that are intentionally NOT in the GatewayCommandCatalog,
  and the #104 "typed write tools == catalog" lockstep checks (McpWriteCatalogLockstepTest,
  McpToolCatalogLockstepIT) now exclude them.

## CLI subcommand (requel-cli)

- requel upsert-goal over the same core (RestCommandGateway + RestQueryGateway →
  RequirementGoalUpserter), reporting created-vs-updated with goal/note ids (or --output json), and
  reporting its client id as requel-cli. Registered in RequelCli's subcommand list.

## Tests

- gateway-api: ProvenanceNotesTest, CriterionHashTest, GoalNameDerivationTest, and
  RequirementGoalUpserterTest + InMemoryGateway (a CommandGateway/QueryGateway double reproducing the
  real EditGoal name-conflict) covering idempotent re-run (update-by-id, same note id, no duplicate),
  edited-requirement orphan, name-collision disambiguation, provenance round-trip, and the
  raw-create conflict proving the lookup path is required.
- mcp-server: McpWriteServiceTest adds upsert listed-when-enabled, rejected-when-disabled,
  missing-required-arg → INVALID_PARAMS, and create + client-id-from-context delegation; the two
  lockstep tests exclude COMPOSITE_TOOLS.
- requel-cli: UpsertGoalCommandTest covers success, unauthorized → exit code, and blank-required →
  usage.

## Build

- modules/gateway-api/pom.xml: add jackson-databind (compile) for the provenance JSON and
  spring-boot-starter-test (test); the module otherwise stays pure (service-api only).

## Docs

- doc/71-issue-tracker-goals-plan.md: implementation plan and the resolution-rule refinement.
- doc/tracker-to-goals-workflow.md: the source-agnostic client workflow (resolve → load goals →
  upsert per requirement → report), how to invoke it (MCP tool + requel upsert-goal), AC-section vs
  inferred extraction, provenance format, v1 reconciliation + known limitation, and worked Jira and
  GitHub Issues examples.

Relates to #108 (optimistic-lock version enforcement on Edit*, deferred; v1 relies on loaded entity
state).

Closes #71
