### PR TITLE
requel-cli: dynamic typed write subcommands from command descriptors

### DIFF
--- a/doc/103-typed-subcommands-plan.md
+++ b/doc/103-typed-subcommands-plan.md
@@ -1,0 +1,188 @@
+# requel-cli — dynamic typed write subcommands from command descriptors (issue #103)
+
+Follow-up to #70 Phase A (Milestone 4). M4 shipped the generic `requel run <Type> --input '{...}'`
+plus the `requel commands` discovery listing, and explicitly **deferred** the richer form: a picocli
+subcommand *per command* with per-field flags (e.g. `requel edit-goal --project Demo --name G`)
+generated at runtime from each command's input DTO schema. This plan implements that deferred form.
+
+Prerequisites are in place: #70 Phase A (CLI + gateway REST client), #101 (read subcommands), and
+#104 (MCP write tools generated from the shared `GatewayCommandCatalog`, which also built a working 
+record-DTO → JSON-schema generator we will reuse).
+
+## Status
+
+Implemented on branch `103-typed-subcommands`: M1 (shared `CommandInputSchema` in `gateway-api`, MCP
+refactored onto it), M2 (`schema` on the descriptor endpoint `DescriptorView` + client `CommandInfo`),
+and M3 (`TypedCommands` — runtime-registered typed write subcommands with schema-derived flags,
+raw-JSON for nested fields, offline fallback). M4 here is docs. The end-to-end CLI-against-live-server
+integration test from the testing strategy remains an optional follow-up (the generation, dispatch,
+required-flag, raw-JSON, and fetch-gating paths are covered by `TypedCommandsTest`; endpoint schema by
+`GatewayCommandControllerTest`/`RestGatewayCatalogTest`; the shared generator by
+`CommandInputSchemaTest`).
+
+## Summary
+
+Two moves, server then client:
+
+1. **Server:** extend the descriptor endpoint (`GET /api/gateway/commands/descriptors`) so each
+   descriptor carries a **JSON schema** for its `inputType`, derived from the command's registered
+   input DTO record (types + `required` array). The schema-generation logic already exists inside
+   `McpWriteService` (from #104); extract it into a shared class in `gateway-api` and have both the
+   MCP server and the descriptor endpoint use it, so MCP, the CLI, and the gateway policy stay in
+   lockstep on one source of truth.
+2. **Client:** at startup the CLI fetches the catalog and **registers a typed picocli subcommand per
+   write command**, mapping each schema field to a typed `--flag`, with `required` flags taken from
+   the schema. Each typed subcommand assembles the input map and dispatches through the REST
+   `CommandGateway`. When the server is unreachable, no typed subcommands are registered and the
+   generic `run` remains the fallback.
+
+## Grounding: what actually exists today (verified in-tree)
+
+- **`CommandDescriptor`** (`gateway-api`, record): `commandType`, `inputType` (the input DTO
+  `Class<?>`, `Void.class` when none), `title`, `description`, `write`, `authorizationHint`. Its
+  javadoc already anticipates this work: *"the `inputType` is the command's registered input DTO
+  class, from which a JSON schema can be derived."*
+- **`GatewayCommandCatalog`** (`gateway-api`, interface): `descriptors()` / `find(commandType)` /
+  `empty()`. The single source of truth, built in `service-impl` from the same `ALLOWED` set the
+  gateway policy enforces.
+- **`GatewayCommandController`** (`service-impl`): `GET /api/gateway/commands/descriptors` returns
+  `List<DescriptorView>`; `DescriptorView(commandType, inputType-as-simpleName, title, description,
+  write, authorizationHint)` — **no schema field yet.** Write-flag-gated (empty list when writes
+  off).
+- **`McpWriteService`** (`mcp-server`): generates one typed tool per catalog descriptor. Contains
+  the schema generator we will extract — all currently `private static`:
+  - `schemaFor(Class<?>)` → `{type:object, properties, required, additionalProperties:false}`.
+  - `jsonType(Class<?>)` → string/integer/number/boolean/array/object (enums → string).
+  - `isRequired(RecordComponent)` / `hasRequiredAnnotation(...)` — a field is required when the
+    component **or** its accessor carries `jakarta.validation` `@NotNull`/`@NotBlank`, matched by
+    fully-qualified name so the module needs no compile-time dependency on the validation API.
+  - `objectSchema` / `stringType` / `integerType` / `booleanType`, and `fieldNames(Class<?>)`.
+  - Covered today by `McpWriteServiceSchemaTest`, `McpWriteCatalogLockstepTest`, and the
+    full-context `McpToolCatalogLockstepIT`.
+- **`RestGatewayCatalog`** + **`CommandInfo`** (`gateway-rest-client`): client fetches the endpoint
+  into `CommandInfo(commandType, inputType, title, description, write, authorizationHint)` — **no
+  schema field yet.**
+- **`CommandsCommand`** (`requel-cli`): prints the catalog (text / `--output json`).
+- **`RunCommand`** (`requel-cli`): generic `run <CommandType> --input`.
+- **`UpsertGoalCommand`** (`requel-cli`): a **hand-written typed subcommand** — the concrete template
+  this work generalizes. `implements Callable<Integer>`, `@ParentCommand RequelCli parent`, one
+  `@Option` per field, builds a `RestCommandGateway` from `parent.url` + `parent.tokenSource()`. Note
+  it is a *composite* orchestration (create-or-update via `RequirementGoalUpserter`), not a single
+  command dispatch, so it stays bespoke and is **not** one of the generated subcommands.
+- **`RequelCli`** (`requel-cli`): `@Command(subcommands = { ... })` static list; `main()` does
+  `new CommandLine(new RequelCli()).execute(args)`. Typed subcommands must be added to that
+  `CommandLine` **before** `execute()`.
+- **Module deps:** `mcp-server`, `service-impl`, `requel-cli`, and `gateway-rest-client` all depend
+  on `gateway-api` — so `gateway-api` is the correct shared home for the extracted generator (it adds
+  only `java.lang.reflect` + `java.util`, no new dependencies).
+
+## Decided
+
+- **Schema generator extracted to `gateway-api` (decision 1a).** New pure-JDK class (working name
+  `CommandInputSchema`) exposing `static Map<String,Object> of(Class<?> inputType)`, moved verbatim
+  from `McpWriteService` (reflection over record components, validation annotations matched by FQN).
+  `McpWriteService` is refactored to delegate to it — behavior identical, existing MCP schema/lockstep
+  tests stay green. This preserves the single-source-of-truth #104 established rather than
+  duplicating schema logic.
+- **The schema is computed server-side and embedded in the descriptor JSON.** The endpoint carries
+  it; the CLI consumes it. So `DescriptorView` (server) and `CommandInfo` (client) each gain a
+  `schema` field (a JSON object). `inputType` (simple name) is kept for humans.
+- **Typed subcommands are registered at runtime from the fetched catalog.** No build-time codegen.
+  Offline / server-unreachable: register none; `run` + read subcommands + built-ins still work, and
+  `--help` reflects only what is available. (Mirrors the #70 M4 decision.)
+- **Generated subcommands are named in kebab-case** derived from the command type
+  (`EditGoal` → `edit-goal`), matching the existing CLI subcommand style (`upsert-goal`,
+  `open-issues`). The canonical form stays available as `run EditGoal`.
+- **Lockstep guard.** A test asserts the CLI's generated flags for a command are exactly the schema's
+  property names (CLI flags == schema properties), analogous to #104's `MCP tools ⊆ catalog`.
+
+## Server-side changes (`gateway-api`, `service-impl`, `mcp-server`)
+
+1. **`gateway-api`:** add `CommandInputSchema.of(Class<?>)` (extracted generator). Optionally expose a
+   convenience on `CommandDescriptor` (e.g. `Map<String,Object> inputSchema()` delegating to it) so
+   callers don't re-derive it.
+2. **`mcp-server`:** replace `McpWriteService`'s private `schemaFor`/`jsonType`/`isRequired`/… with
+   calls to `CommandInputSchema`. Delete the now-dead privates. No behavior change; keep
+   `McpWriteServiceSchemaTest` / `McpWriteCatalogLockstepTest` / `McpToolCatalogLockstepIT` green.
+3. **`service-impl`:** add `schema` to `GatewayCommandController.DescriptorView` (populated from
+   `CommandInputSchema.of(d.inputType())`); update the controller/catalog tests
+   (`GatewayCommandCatalogImplTest` and the controller MockMvc test) to assert the schema is present
+   and its `required` array matches the DTO's `@NotNull`/`@NotBlank` fields.
+
+## Client-side changes (`gateway-rest-client`, `requel-cli`)
+
+4. **`gateway-rest-client`:** add `schema` (e.g. `Map<String,Object>`) to `CommandInfo` so
+   `RestGatewayCatalog.descriptors()` deserializes it.
+5. **`requel-cli`:** dynamic typed-subcommand registration.
+   - **Two-phase startup in `main()`:** resolve `--url` / `--token` (flags → `REQUEL_URL` /
+     `REQUEL_TOKEN` env → stored creds) enough to fetch the catalog; build the `CommandLine`, then for
+     each **write** descriptor `addSubcommand(kebab(commandType), buildTypedSubcommand(descriptor))`;
+     finally `execute(args)`. If the fetch fails (offline / auth / writes-disabled → empty list),
+     register nothing and proceed.
+   - **Generated subcommand** (a small `CommandSpec` built programmatically, or a reusable
+     `Callable<Integer>` holder configured from the descriptor): one `--flag` per schema property,
+     `--kebab-case` of the field name; type mapped from the schema (`string`→String, `integer`→
+     Integer/Long, `number`→Double, `boolean`→Boolean; `array`/`object`→raw JSON string, documented);
+     `required(true)` when the field is in the schema's `required` array. `call()` assembles the input
+     map (parsing raw-JSON flags with Jackson), dispatches via `RestCommandGateway`
+     (`parent.url` + `parent.tokenSource()`), and reuses `parent.printResult` / `printError` /
+     `ExitCode.forKind`.
+   - Keep `run`, `commands`, the read subcommands, `login`/`logout`, and the bespoke `upsert-goal`
+     unchanged.
+
+## Milestones (incremental, each independently testable)
+
+1. **Extract + refactor.** `CommandInputSchema` in `gateway-api`; `McpWriteService` delegates to it.
+   `mvn clean verify` green with existing MCP tests unchanged. *(No user-visible change.)*
+2. **Endpoint carries schema.** `DescriptorView.schema` + `CommandInfo.schema`; controller/catalog
+   tests assert schema + `required`. `requel commands --output json` now shows schemas.
+3. **Typed subcommands.** Runtime registration + generated dispatch; `requel edit-goal --project …`
+   works against a live server.
+4. **Offline fallback + docs.** No typed subcommands when unreachable; `--help` correct. Update
+   `doc/70-requel-cli-plan.md` (mark the deferred item done), `doc/70-requel-cli-verification.md`
+   runbook, and the README/CLI docs with typed-subcommand examples.
+
+## Testing strategy
+
+- **Unit — schema generator (`gateway-api`):** record → schema (types, `additionalProperties:false`);
+  `required` from `@NotNull`/`@NotBlank` on component or accessor; primitives, boxed, `char`, enums
+  (→ string), collections/arrays (→ array), nested record (→ object); `Void`/non-record → empty
+  object. (Port the intent of `McpWriteServiceSchemaTest`.)
+- **Unit — endpoint:** `descriptors()` includes a correct schema per command; empty list when writes
+  disabled.
+- **Unit — CLI generation:** mirror `CommandsCommandTest` / `UpsertGoalCommandTest` with a stubbed
+  catalog + gateway: assert a descriptor produces the expected flags (names, types, required), that
+  invoking a generated subcommand sends the expected input map to the gateway, and the
+  flags-==-schema-properties lockstep. Offline: fetch failure → only built-ins registered, `run`
+  still works.
+- **Integration:** `@SpringBootTest(webEnvironment = RANDOM_PORT)` driving CLI `main()` (PAT auth): a
+  generated typed **create** then **edit** on a project the test user can edit, and a **denied** write
+  → assert output + exit codes; assert typed subcommands appear when
+  `requel.gateway.write.enabled=true` and are absent when `false`.
+
+## Sub-decisions (resolved during implementation)
+
+- **Nested object/array fields → raw JSON (as recommended).** Array/object schema types map to a
+  `String` option, parsed with Jackson at dispatch (invalid JSON → usage error, exit 2). Documented in
+  the flag description, which appends `" (array as raw JSON)"` / `"(object as raw JSON)"` so it shows
+  in `--help`. Dotted sub-flags remain a later enhancement.
+- **`Long` for the `integer` schema type.** `javaType("integer")` returns `Long.class` (headroom for
+  ids). The "derive from the DTO component's actual type" alternative was **not** taken: the wire
+  schema only carries `"integer"` (not `Integer`/`Long`/`Short`), and the CLI has no access to the DTO
+  class — surfacing the precise numeric type would widen the schema for little gain. `Long` is safe
+  because Jackson narrows it to the target DTO field on the server when binding.
+- **Subcommand help text: `title` + `description`; `authorizationHint` omitted.** `describe()` builds
+  the usage from `title` (falling back to `commandType`) plus `description` when present.
+  `authorizationHint` is deliberately not surfaced in `--help` — it is an informational permission
+  hint, not enforcement, and would clutter the usage. Trivial to add later if wanted.
+- **Startup cost: gate the fetch; no cache.** `probe(...)`/`wantsTypedSubcommand(...)` skips the
+  catalog round-trip for built-in subcommands (`run`, `login`, `logout`, reads, `commands`),
+  `--help`/`--version`, and empty invocations, fetching only when the args look like a typed
+  candidate. The on-disk URL-keyed cache was **not** added — the gating already removes the round-trip
+  from the common paths; revisit if typed invocations feel slow.
+
+## Out of scope
+
+- Build-time static generation of subcommands (still deferred; only matters for offline typed help).
+- Any change to the MCP tool surface (done in #104) beyond the internal delegation refactor.
+- Remote MCP connector ops (#100) and the persistent AS signing key (#105).

--- a/doc/70-requel-cli-plan.md
+++ b/doc/70-requel-cli-plan.md
@@ -61,9 +61,11 @@ Two layers, so the CLI works offline *and* stays in lockstep with the server:
      write, authorizationHint`). Served by `GatewayCommandController`, gated by the write flag.
    - **Client side (done):** `RestGatewayCatalog` in `gateway-rest-client` fetches it;
      `requel commands` prints it (text or `--output json`).
-   - **Deferred (richer form):** dynamically *registering picocli subcommands* per command (with
-     per-field flags derived from the input DTO's JSON schema). MVP uses the generic
-     `requel run <CommandType> --input` for invocation; `requel commands` for discovery.
+   - **Deferred (richer form) — done in #103:** dynamically *registering picocli subcommands* per
+     command (with per-field flags derived from the input DTO's JSON schema). MVP used the generic
+     `requel run <CommandType> --input` for invocation; `requel commands` for discovery. The typed
+     form (`requel edit-goal --project-name … --name …`) is now implemented — see
+     `doc/103-typed-subcommands-plan.md`.
    - Offline / server-unreachable: only `run` + built-ins show in `--help`; that's acceptable.
 
 (This refines the earlier "static-primary" decision: because the catalog is server-side with no

--- a/doc/70-requel-cli-verification.md
+++ b/doc/70-requel-cli-verification.md
@@ -15,7 +15,8 @@ Build the fat jar (also gives the `requel` wrapper a jar to find):
 ```bash
 mvn -pl modules/requel-cli -am package
 alias requel='modules/requel-cli/src/main/scripts/requel'   # or: java -jar modules/requel-cli/target/requel-cli-2.0.0-dev.jar
-requel --help    # lists run, commands, login, logout
+requel --help    # lists run, commands, read subcommands (projects/project/…), login, logout
+                 # (plus typed write subcommands, e.g. edit-goal, when a server is reachable — #103)
 ```
 
 Start the server with the CLI OAuth client seeded **and** gateway writes enabled (so `commands` and a
@@ -86,10 +87,22 @@ requel --url http://localhost:8080 search "<name>" goal        # find entities b
 requel --url http://localhost:8080 run EditGoal --input '{"projectName":"<name>","name":"CLI smoke goal"}'
 #   expect: OK EditGoal: … (id=…). The goal is created/edited as your user, through the gateway
 #   (allow/deny policy + per-stakeholder authorization enforced server-side).
+
+# Typed subcommands (#103): at startup the CLI fetches the write catalog and registers a typed
+# subcommand per command, with per-field flags derived from each command's input JSON schema — so the
+# same write needs no hand-written JSON:
+requel --url http://localhost:8080 edit-goal --project-name "<name>" --name "CLI typed goal"
+#   expect: OK EditGoal: … (id=…) — identical result to the `run EditGoal` above.
+requel --url http://localhost:8080 edit-goal --help
+#   expect: a usage listing generated from the schema — --project-name (required), --name, … .
+#   Nested object/array fields take a raw-JSON string, e.g. --tags '["a","b"]'.
+#   Offline / server unreachable: typed subcommands are simply not registered (only run + built-ins
+#   show), so `requel run <Type> --input` stays the always-available fallback.
 ```
 
 **Pass:** `commands` lists the catalog and `projects` lists your projects using the stored token; the
-write succeeds and is attributed to the logged-in user.
+typed `edit-goal` subcommand appears (with schema-derived flags) and the write succeeds and is
+attributed to the logged-in user — matching the generic `run EditGoal`.
 
 ## C. Writes-disabled and denylist behavior (optional, restart-gated)
 

--- a/doc/project-entity-categorization.md
+++ b/doc/project-entity-categorization.md
@@ -1,0 +1,264 @@
+# Project Entity Categorization (Tags & Categories)
+
+Status: Draft / proposal for discussion. Not yet tied to a release issue.
+Author: Ron (with Claude)
+Related patterns: `annotation-domain` / `annotation-jpa`, `AnnotatableTypeRegistry`, quik `tag` / `tagEntity`.
+
+## Summary
+
+Add a small, cross-cutting **tagging/categorization** capability that can attach tags to any
+Requel project entity (`Goal`, `Project`, `Actor`, `Story`, `Scenario`, `Stakeholder`, `UseCase`,
+…). The primary driver is segmenting **Goals** by kind — a goal is generic prose that might be a
+business rule, a performance expectation, or a technical guideline — without spawning a new
+near-duplicate entity type for each variant. The same mechanism categorizes **Projects** (e.g.
+`product` vs `feature`) and is open for user-defined categories we haven't anticipated.
+
+Recommendation: **build a generic tagging module, not new sibling entities.** This document argues
+why, surveys prior art, and proposes a data model, rules, and an implementation approach that reuses
+the decoupled polymorphic-attachment pattern the annotation module already proves out in this
+codebase.
+
+Two product decisions are settled and baked into this plan:
+
+- **Scope:** tags are **per-project, plus an optional global (system) set** shared across projects.
+- **Shape:** tags are **both flat and namespaced** — a tag may be a plain label (`performance`) or
+  carry an optional **category key** (`type=business-rule`, `projectKind=product`).
+
+## 1. Is tagging better than new entities?
+
+Yes, for this problem. "A goal is prose; a business-rule-goal is a goal that happens to be a
+business rule" is a *classification*, not a new aggregate. Modeling each variant as its own
+`@Entity` (a `BusinessRuleGoal`, `PerformanceGoal`, `TechnicalGuidelineGoal`) would mean:
+
+- Duplicated persistence, repositories, commands, DTOs, and query endpoints per variant.
+- A rigid, developer-only taxonomy — every new category is a schema change and a release.
+- Awkward cross-cutting queries ("all goals of any performance-ish kind").
+- Combinatorial blow-up when a second dimension appears (kind × priority × source).
+
+A tag/category layer instead gives you:
+
+- **One** reusable mechanism across all entity types (Goals today, Projects, Actors, Stories next).
+- **Data-driven** taxonomy — users/admins add categories without code changes.
+- **Multi-dimensional** classification (a goal can be `type=business-rule` *and* `domain=billing`).
+- Clean segmentation queries ("goals where `type=performance`").
+
+When a "category" would carry real behavior, structured fields, its own lifecycle, or relationships
+of its own, it deserves a first-class entity — tags are the wrong tool there. That is the one line
+to hold: **tags classify; entities model behavior and structure.** Goal-kind, project-kind, and
+ad-hoc user labels are classification, so they belong in tags.
+
+## 2. Prior art (how others do this)
+
+The dominant open-source pattern is exactly what you proposed — a **tag definition** table plus a
+**polymorphic mapping** table:
+
+- **acts-as-taggable-on** (Rails): a `tags` table and a polymorphic `taggings` join table
+  (`taggable_id` + `taggable_type` + optional `context`/`tagger`). The `context` column is a
+  built-in *namespace* — the same idea as our category key (e.g. `:skills`, `:interests`).
+- **django-taggit**: a `Tag` model plus a `TaggedItem` "through" model using Django's generic
+  foreign key (`content_type` + `object_id`) — a soft-polymorphic reference. It explicitly supports
+  swapping in a custom through model to add fields (e.g. "official") or real FKs — the same
+  extension seam we want.
+- **GitLab / Jira / GitHub labels**: a label definition scoped to a project (or group), attached to
+  issues/MRs via a join. **GitLab scoped labels** (`key::value`, e.g. `priority::high`) are the
+  productized version of namespaced tags and mutually-exclusive dimensions — directly analogous to
+  our `type=business-rule`.
+- **Discourse tags**: flat tags plus **tag groups**, where a group can enforce "only one tag from
+  this group" — again, category-as-dimension with optional exclusivity.
+
+Our own **quik** backend already ships this pattern (`com.platformq.tag`): a `tag` definition table
+(unique name, `siteId` scope, soft-delete, audit columns) and a single polymorphic `tagEntity`
+junction (`type` discriminator enum `EVENT|PRESENTATION|SITE|INSTANCE` + loose `entity_id`, unique
+on `(type, tag_id, entity_id)`), with a scope hierarchy resolved as tag *inheritance* at query time.
+Requel should mirror the shape but improve two things quik left on the table: give the category/key
+a real home (quik has no namespace, color, or description columns), and make the polymorphic binding
+type-safe via Hibernate `@ManyToAny` + a registry rather than raw native SQL against a soft
+reference.
+
+## 3. Proposed model
+
+### 3.1 Concepts
+
+- **Tag** — a reusable definition: an optional **category key** + a **value/label**, a scope
+  (project or global), plus audit/soft-delete metadata. Examples: `(type, business-rule)`,
+  `(type, performance)`, `(projectKind, product)`, or plain `(null, performance)`.
+- **Category** (a.k.a. key / dimension / namespace) — for the first cut this is simply the `key`
+  string on a Tag (like acts-as-taggable-on `context` or a GitLab scoped-label key). We can promote
+  it to its own `tag_category` table later if we need per-category rules (exclusivity, allowed
+  entity types, display order, controlled value lists). Starting with a string keeps v1 small and
+  matches the "users define their own" goal.
+- **Tag assignment** — the polymorphic link between one Tag and one taggable entity.
+
+### 3.2 The reusable attachment pattern (reuse, don't reinvent)
+
+The annotation module already solves "attach a cross-cutting thing to any project entity without the
+cross-cutting module depending on `project-jpa` impls." We copy that exact seam:
+
+- A generic marker interface `Taggable` (analogous to `Annotatable`), which the project entities
+  opt into. Note every `ProjectOrDomainEntity` *already* implements `Annotatable`; `Taggable` is the
+  same one-method style marker.
+- A Hibernate `@ManyToAny` mapping on the assignment side with `@AnyDiscriminator(STRING)` +
+  `@AnyKeyJavaClass(Long.class)` and **no inline `@AnyDiscriminatorValue` entries** — the
+  discriminator→class map is injected at Hibernate bootstrap.
+- A runtime SPI registry `TaggableTypeRegistry` (copy of `AnnotatableTypeRegistry` /
+  `DefaultAnnotatableTypeRegistry`) resolving `discriminator string ⇄ Class` for controllers.
+- A `TagMetadataContributor implements org.hibernate.boot.spi.AdditionalMappingContributor` (copy of
+  `ProjectAnnotatableMetadataContributor`) that walks the tagging persistent classes and injects the
+  discriminator metadata at boot — registered via
+  `requel-app/src/main/resources/META-INF/services/org.hibernate.boot.spi.AdditionalMappingContributor`.
+- A single `@Configuration` in `project-jpa` (copy of `ProjectAnnotatableRegistryConfiguration`)
+  that declares which project impls are taggable and pushes that map both to the contributor
+  (static, for Hibernate boot) and the runtime registry (via `InitializingBean`).
+
+This deliberately adopts the **decoupled contributor** style over the older coupled inline
+`@AnyDiscriminatorValue` style still seen in `GoalImpl.getReferers()`. The contributor style is what
+keeps `tagging-jpa` free of any dependency on `project-jpa` impl classes.
+
+### 3.3 Tables
+
+Two tables, mirroring quik but with a real category column and a proper polymorphic join.
+
+`tag` — the definition (the vocabulary):
+
+| column | notes |
+|---|---|
+| `id` bigint PK | `GenerationType.IDENTITY`, matching every other entity |
+| `version` int | optimistic locking, init `1` |
+| `category` varchar(255) NULL | the key / namespace / dimension; NULL = a flat tag |
+| `value` varchar(255) NOT NULL | the label |
+| `project_id` bigint NULL | owning project; NULL = global/system tag |
+| `description` varchar(...) NULL | optional human description |
+| `color` varchar(16) NULL | optional UI hint (quik lacks this; cheap to add now) |
+| `created_by` / `created_on` / soft-delete cols | follow existing audit conventions |
+| unique `(project_id, category, value)` | see rules below |
+
+`tag_taggable` — the polymorphic assignment (copy `annotation_annotatable` shape):
+
+| column | notes |
+|---|---|
+| `tag_id` bigint | FK → `tag.id` |
+| `taggable_type` varchar(255) | discriminator string (`Goal`, `Project`, …) from the registry |
+| `taggable_id` bigint | the tagged entity's id (soft reference, like the annotation join) |
+| PK `(tag_id, taggable_type, taggable_id)` | one assignment per (tag, entity) |
+
+Flyway migration lands as the next version in
+`modules/requel-app/src/main/resources/db/migration/` (currently
+`V13__tagging.sql`; confirm the highest existing `V` at implementation time).
+
+### 3.4 Segmentation examples
+
+- **Goal kinds:** tags `(type, business-rule)`, `(type, performance)`,
+  `(type, technical-guideline)` assigned to `GoalImpl` rows. "Show all performance goals" =
+  goals joined to a `type=performance` tag. A goal may hold several `type` values only if we allow
+  it; typically `type` is a single-value dimension (see exclusivity rule).
+- **Project kinds:** tags `(projectKind, product)`, `(projectKind, feature)` on `ProjectImpl`.
+- **Ad-hoc user labels:** flat tag `(null, billing)` across goals, stories, and actors that all
+  touch billing — the multi-entity, multi-dimension case that new entities can't express.
+
+## 4. Rules & guardrails
+
+Naming / identity
+
+- A tag's identity is `(category, value)` within its scope. `category` is optional; `value` is
+  required and non-empty.
+- **Normalize** on write: trim; store `category` and `value` in a canonical case (recommend
+  lowercase-with-hyphens slugs, e.g. `business-rule`) while keeping a display form if desired. quik
+  only trims and relies on convention — we should enforce it in the command layer.
+- **Uniqueness** is `(project_id, category, value)`. A project may shadow a global tag value only if
+  we decide to; default is that global and project tags are distinct rows and the resolver prefers
+  project-scoped.
+
+Scope
+
+- Every tag is either **global** (`project_id` NULL) or **project-scoped**. Project entities may be
+  tagged with either their own project's tags or global tags.
+- Deleting a project soft-deletes (or cascades) its project-scoped tags and their assignments;
+  global tags are untouched.
+
+Assignment
+
+- Assignments are polymorphic via the registry; a controller turns a request's `entityType` string
+  into a `Class` and loads the entity (same trick `AnnotationCommandRegistrar.loadAnnotatable` uses).
+- Prefer **incremental add/remove** of individual assignments over quik's full delete-then-reinsert
+  "set the whole tag set" call, to avoid the race conditions quik had to guard against (CON-3330).
+  A "replace set" convenience command can exist on top.
+- Assignment carries audit (`created_by`, `created_on`).
+
+Categories / dimensions
+
+- v1: `category` is a free string; the set of categories is discovered from existing tags (for
+  autocomplete). No exclusivity enforcement yet.
+- v2 (optional): promote to a `tag_category` table to support **single-value dimensions**
+  (a goal has at most one `type`), **allowed entity types** per category (`projectKind` only on
+  Projects), controlled value lists, ordering, and color-at-the-category level. This is the
+  GitLab-scoped-label / Discourse-tag-group upgrade path; defer until a real need appears.
+
+Authorization
+
+- Route tag commands through the existing `AuthorizingCommandHandler` chain. Editing a
+  project-scoped tag requires project edit rights; managing global tags is an admin capability.
+  Define the requirements the same way other `AuthorizableCommand`s do (see `doc/AUTH_ARCH.md`).
+
+Import/export
+
+- Tags and assignments must round-trip through the JAXB project XML (`doc/samples/project.xsd`) if
+  they are considered part of a project's content. Add mappings + a round-trip regression test
+  alongside the existing `ProjectXmlStreamingRoundTripIT`. Global tags referenced by a project need
+  an export strategy (embed vs reference-by-key) — flag for decision.
+
+## 5. Module & wiring plan
+
+Follow the domain+jpa pair convention exactly as annotation does.
+
+1. **`tagging-domain`** — `Taggable` marker; `Tag` / `TagAssignment` interfaces (extend
+   `CreatedEntity` / `Describable`); `TagCommandFactory extends CommandFactory`; command interfaces
+   (`EditTagCommand`, `DeleteTagCommand`, `AssignTagCommand`, `UnassignTagCommand`); `spi/`
+   `TaggableTypeRegistry` + `DefaultTaggableTypeRegistry`. Depends only on `platform-core` /
+   `platform-identity`.
+2. **`tagging-jpa`** — `AbstractTag` / `TagImpl` `@Entity`; the `@ManyToAny` assignment mapping;
+   `TagMetadataContributor`; `JpaTagRepository extends AbstractJpaRepository`; command impls under
+   `.../impl/command/`; `TagCommandFactoryImpl extends AbstractCommandFactory`.
+3. **`project-jpa`** — `TaggableRegistryConfiguration` (`@Configuration`) declaring
+   `Goal→GoalImpl, Project→ProjectImpl, Actor→ActorImpl, Story→StoryImpl, Scenario→ScenarioImpl,
+   Stakeholder→…, UseCase→UseCaseImpl`; project impls implement `Taggable`.
+4. **`requel-app`** — add both modules to the reactor `<modules>` and as dependencies; append the
+   contributor to the `META-INF/services/...AdditionalMappingContributor` file; add
+   `V13__tagging.sql`. Component-scan + `@EntityScan("com.rreganjr.requel")` pick up the rest
+   automatically.
+5. **CQRS API** — a `TagCommandRegistrar` (`@Component` + `@PostConstruct`, copy
+   `AnnotationCommandRegistrar`) registering each command with its input DTO + result extractor;
+   DTOs (`TagDto`, `EditTagInput`, `AssignTagInput`) in `service-api`; a
+   `TagQueryController @RequestMapping("/api/tags")` resolving `entityType` via
+   `TaggableTypeRegistry` and exposing "tags on entity" / "entities with tag" / "tags in project".
+   No change to the generic `CommandController` is needed.
+6. **Angular** — a tag chip/selector component with category-aware autocomplete; a Goal-list filter
+   by `type`; reuse in the Project view for `projectKind`.
+
+Suggested phasing: (1) module skeleton + tables + `Taggable` on Goal + assign/unassign +
+`/api/tags` reads; (2) namespaced categories + Goal segmentation UI; (3) extend to Project/others +
+global tags admin; (4) JAXB round-trip + export decision; (5) optional `tag_category` promotion.
+
+## 6. Open questions
+
+- Do we need the `tag_category` table in v1, or is a free-string `category` enough to start?
+- Are global tags exported inside each project's XML, or referenced by key?
+- Should `type` (goal kind) be a *required* single-value dimension from day one, or stay optional?
+- Do we want per-user private tags eventually? (Deferred; the model leaves room via a nullable
+  `owner`/scope discriminator if we add it.)
+
+## 7. References in this codebase
+
+- Attachment pattern: `annotation-jpa/.../impl/AbstractAnnotation.java`,
+  `project-jpa/.../impl/config/ProjectAnnotatableMetadataContributor.java`,
+  `project-jpa/.../impl/config/ProjectAnnotatableRegistryConfiguration.java`,
+  `annotation-domain/.../spi/AnnotatableTypeRegistry.java`,
+  `requel-app/src/main/resources/META-INF/services/org.hibernate.boot.spi.AdditionalMappingContributor`.
+- CQRS: `service-impl/.../service/command/CommandController.java`,
+  `.../command/AnnotationCommandRegistrar.java`, `.../query/AnnotationQueryController.java`,
+  `service-api/.../service/api/CommandRegistration.java`.
+- Persistence: `platform-core/.../repository/jpa/AbstractJpaRepository.java`,
+  `platform-core/.../command/AbstractCommandFactory.java`.
+- Anti-pattern to avoid (coupled inline discriminators): `project-jpa/.../impl/GoalImpl.java`
+  `getReferers()`.
+- Migrations: `modules/requel-app/src/main/resources/db/migration/` (see `V1__init.sql` for the
+  `annotation_annotatable` DDL to mirror).

--- a/modules/gateway-api/src/main/java/com/rreganjr/requel/gateway/CommandInputSchema.java
+++ b/modules/gateway-api/src/main/java/com/rreganjr/requel/gateway/CommandInputSchema.java
@@ -1,0 +1,150 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway;
+
+import java.lang.reflect.RecordComponent;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Derives a JSON schema for a gateway command's input DTO, so every front-end generates its command
+ * surface from the same rules: MCP typed-tool schemas, the CLI's typed subcommands, and the
+ * descriptor endpoint ({@code /api/gateway/commands/descriptors}) all call this one generator and
+ * therefore cannot drift from one another (issues #103, #104).
+ *
+ * <p>Input DTOs are Java records, so each record component becomes a typed JSON property. A
+ * component is marked <em>required</em> when it (or its generated accessor) carries a
+ * {@code jakarta.validation} {@code @NotNull}/{@code @NotBlank} annotation — those annotations
+ * encode the fields the command's applicator dereferences unconditionally (issue #104). Annotations
+ * are matched by fully-qualified name so this module needs no compile-time dependency on the
+ * validation API. Unknown fields are rejected ({@code additionalProperties:false}) so typos surface
+ * early. A {@code null}/{@link Void} or non-record input type yields an empty object schema.
+ *
+ * <p>Pure JDK (reflection + collections); no Jackson or Spring, so it is safe to share from
+ * {@code gateway-api}.
+ */
+public final class CommandInputSchema {
+
+    private CommandInputSchema() {
+    }
+
+    /**
+     * Build the JSON schema (as a plain {@code Map}) for the given command input DTO type.
+     *
+     * @param inputType the command's input DTO record class, or {@code null}/{@link Void} for none
+     * @return an object-schema map: {@code {type, properties, required, additionalProperties:false}}
+     */
+    public static Map<String, Object> of(Class<?> inputType) {
+        if (inputType == null || inputType == Void.class || !inputType.isRecord()) {
+            return objectSchema(Map.of(), List.of());
+        }
+        Map<String, Object> properties = new LinkedHashMap<>();
+        List<String> required = new ArrayList<>();
+        for (RecordComponent component : inputType.getRecordComponents()) {
+            properties.put(component.getName(), jsonType(component.getType()));
+            if (isRequired(component)) {
+                required.add(component.getName());
+            }
+        }
+        return objectSchema(properties, required);
+    }
+
+    /** The input DTO's field names in declaration order (empty for {@code null}/{@link Void}/non-record). */
+    public static List<String> fieldNames(Class<?> inputType) {
+        if (inputType == null || inputType == Void.class || !inputType.isRecord()) {
+            return List.of();
+        }
+        List<String> names = new ArrayList<>();
+        for (RecordComponent component : inputType.getRecordComponents()) {
+            names.add(component.getName());
+        }
+        return names;
+    }
+
+    /** Assemble an object schema node with the given properties and required-field list. */
+    public static Map<String, Object> objectSchema(Map<String, Object> properties,
+            List<String> required) {
+        return Map.of("type", "object", "properties", properties, "required", required,
+                "additionalProperties", false);
+    }
+
+    /** A {@code {"type":"string"}} schema node. */
+    public static Map<String, Object> stringType() {
+        return Map.of("type", "string");
+    }
+
+    /** A {@code {"type":"integer"}} schema node. */
+    public static Map<String, Object> integerType() {
+        return Map.of("type", "integer");
+    }
+
+    /** A {@code {"type":"boolean"}} schema node. */
+    public static Map<String, Object> booleanType() {
+        return Map.of("type", "boolean");
+    }
+
+    /**
+     * A record component is required when it (or its generated accessor) carries a
+     * {@code jakarta.validation} {@code @NotNull} or {@code @NotBlank} annotation. Matched by fully
+     * qualified name so this module needs no compile-time dependency on the validation API.
+     */
+    private static boolean isRequired(RecordComponent component) {
+        return hasRequiredAnnotation(component.getAnnotations())
+                || hasRequiredAnnotation(component.getAccessor().getAnnotations());
+    }
+
+    private static boolean hasRequiredAnnotation(java.lang.annotation.Annotation[] annotations) {
+        for (java.lang.annotation.Annotation a : annotations) {
+            String name = a.annotationType().getName();
+            if (name.equals("jakarta.validation.constraints.NotNull")
+                    || name.equals("jakarta.validation.constraints.NotBlank")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Map a Java type to a JSON-schema type node. */
+    private static Map<String, Object> jsonType(Class<?> type) {
+        if (type == String.class || type == Character.class || type == char.class) {
+            return stringType();
+        }
+        if (type == Boolean.class || type == boolean.class) {
+            return booleanType();
+        }
+        if (type == Integer.class || type == int.class || type == Long.class || type == long.class
+                || type == Short.class || type == short.class || type == Byte.class
+                || type == byte.class) {
+            return integerType();
+        }
+        if (type == Double.class || type == double.class || type == Float.class
+                || type == float.class) {
+            return Map.of("type", "number");
+        }
+        if (Iterable.class.isAssignableFrom(type) || type.isArray()) {
+            return Map.of("type", "array");
+        }
+        // Enums serialize as their name; everything else is a nested object.
+        return type.isEnum() ? stringType() : Map.of("type", "object");
+    }
+}

--- a/modules/gateway-api/src/test/java/com/rreganjr/requel/gateway/CommandInputSchemaTest.java
+++ b/modules/gateway-api/src/test/java/com/rreganjr/requel/gateway/CommandInputSchemaTest.java
@@ -1,0 +1,128 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises {@link CommandInputSchema}: every Java-to-JSON type mapping, required-field derivation
+ * from {@code @NotNull}/{@code @NotBlank}, declaration-order preservation, the empty/{@link Void}/
+ * non-record cases, and the small schema-node builder helpers. This is the shared generator that
+ * MCP typed tools, the CLI's typed subcommands, and the descriptor endpoint all rely on (issues
+ * #103/#104), so pinning its behavior here guards every front-end at once.
+ */
+class CommandInputSchemaTest {
+
+	enum Color {
+		RED, GREEN
+	}
+
+	/** A record covering every jsonType branch, with a required String and a required Long. */
+	record RichInput(
+			@NotBlank String name,
+			@NotNull Long id,
+			int count,
+			boolean flag,
+			Double ratio,
+			Color color,
+			List<String> tags,
+			Object blob) {
+	}
+
+	/** Not a record — must be treated like Void (empty schema, no field names). */
+	static class NotARecord {
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void mapsEveryJavaTypeToItsJsonType() {
+		Map<String, Object> schema = CommandInputSchema.of(RichInput.class);
+		var props = (Map<String, Object>) schema.get("properties");
+
+		assertThat(props.get("name")).isEqualTo(Map.of("type", "string"));
+		assertThat(props.get("id")).isEqualTo(Map.of("type", "integer"));    // Long
+		assertThat(props.get("count")).isEqualTo(Map.of("type", "integer")); // primitive int
+		assertThat(props.get("flag")).isEqualTo(Map.of("type", "boolean"));  // primitive boolean
+		assertThat(props.get("ratio")).isEqualTo(Map.of("type", "number"));  // Double
+		assertThat(props.get("color")).isEqualTo(Map.of("type", "string"));  // enum → string
+		assertThat(props.get("tags")).isEqualTo(Map.of("type", "array"));    // List → array
+		assertThat(props.get("blob")).isEqualTo(Map.of("type", "object"));   // fallback object
+		assertThat(schema).containsEntry("type", "object");
+		assertThat(schema).containsEntry("additionalProperties", false);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void derivesRequiredOnlyFromValidationAnnotations() {
+		var required = (List<String>) CommandInputSchema.of(RichInput.class).get("required");
+		// Only the @NotBlank/@NotNull components; unannotated ones (incl. primitives) are optional.
+		assertThat(required).containsExactlyInAnyOrder("name", "id");
+		assertThat(required).doesNotContain("count", "flag", "ratio", "color", "tags", "blob");
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void propertiesPreserveDeclarationOrder() {
+		var props = (Map<String, Object>) CommandInputSchema.of(RichInput.class).get("properties");
+		assertThat(props.keySet())
+				.containsExactly("name", "id", "count", "flag", "ratio", "color", "tags", "blob");
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void voidNullAndNonRecordYieldEmptyObjectSchema() {
+		for (Class<?> type : new Class<?>[] {Void.class, null, NotARecord.class}) {
+			Map<String, Object> schema = CommandInputSchema.of(type);
+			assertThat((Map<String, Object>) schema.get("properties")).isEmpty();
+			assertThat((List<String>) schema.get("required")).isEmpty();
+			assertThat(schema).containsEntry("type", "object");
+			assertThat(schema).containsEntry("additionalProperties", false);
+		}
+	}
+
+	@Test
+	void fieldNamesReflectDeclarationOrderAndEmptyForNonRecords() {
+		assertThat(CommandInputSchema.fieldNames(RichInput.class))
+				.containsExactly("name", "id", "count", "flag", "ratio", "color", "tags", "blob");
+		assertThat(CommandInputSchema.fieldNames(Void.class)).isEmpty();
+		assertThat(CommandInputSchema.fieldNames(null)).isEmpty();
+		assertThat(CommandInputSchema.fieldNames(NotARecord.class)).isEmpty();
+	}
+
+	@Test
+	void builderHelpersProduceExpectedNodes() {
+		assertThat(CommandInputSchema.stringType()).isEqualTo(Map.of("type", "string"));
+		assertThat(CommandInputSchema.integerType()).isEqualTo(Map.of("type", "integer"));
+		assertThat(CommandInputSchema.booleanType()).isEqualTo(Map.of("type", "boolean"));
+		assertThat(CommandInputSchema.objectSchema(
+				Map.of("x", CommandInputSchema.stringType()), List.of("x")))
+				.isEqualTo(Map.of("type", "object",
+						"properties", Map.of("x", Map.of("type", "string")),
+						"required", List.of("x"),
+						"additionalProperties", false));
+	}
+}

--- a/modules/gateway-rest-client/src/main/java/com/rreganjr/requel/gateway/rest/CommandInfo.java
+++ b/modules/gateway-rest-client/src/main/java/com/rreganjr/requel/gateway/rest/CommandInfo.java
@@ -21,6 +21,7 @@
 package com.rreganjr.requel.gateway.rest;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Map;
 
 /**
  * Client-side view of a gateway command descriptor, as returned by
@@ -36,6 +37,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  * @param description       a longer description, or {@code null}
  * @param write             {@code true} for state-mutating commands
  * @param authorizationHint a human-readable permission hint, or {@code null}
+ * @param schema            JSON schema for the command's input DTO — an object node
+ *                          ({@code {type:object, properties, required, additionalProperties:false}})
+ *                          from which the CLI builds per-field typed subcommands (issue #103); may be
+ *                          {@code null} against an older server that predates the schema field
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record CommandInfo(
@@ -44,6 +49,7 @@ public record CommandInfo(
         String title,
         String description,
         boolean write,
-        String authorizationHint
+        String authorizationHint,
+        Map<String, Object> schema
 ) {
 }

--- a/modules/gateway-rest-client/src/test/java/com/rreganjr/requel/gateway/rest/RestGatewayCatalogTest.java
+++ b/modules/gateway-rest-client/src/test/java/com/rreganjr/requel/gateway/rest/RestGatewayCatalogTest.java
@@ -50,7 +50,10 @@ class RestGatewayCatalogTest {
                 .andExpect(method(HttpMethod.GET))
                 .andRespond(withSuccess("""
                         [{"commandType":"EditGoal","inputType":"EditGoalInput","title":"Edit Goal",
-                          "description":null,"write":true,"authorizationHint":null}]
+                          "description":null,"write":true,"authorizationHint":null,
+                          "schema":{"type":"object",
+                                    "properties":{"projectName":{"type":"string"}},
+                                    "required":["projectName"],"additionalProperties":false}}]
                         """, MediaType.APPLICATION_JSON));
 
         List<CommandInfo> commands = f.catalog().descriptors();
@@ -60,6 +63,10 @@ class RestGatewayCatalogTest {
             assertThat(c.inputType()).isEqualTo("EditGoalInput");
             assertThat(c.title()).isEqualTo("Edit Goal");
             assertThat(c.write()).isTrue();
+            // The input JSON schema round-trips into a plain map the CLI can drive subcommands from.
+            assertThat(c.schema()).containsEntry("type", "object")
+                    .containsEntry("additionalProperties", false);
+            assertThat(c.schema().get("required")).isEqualTo(List.of("projectName"));
         });
         f.server().verify();
     }

--- a/modules/mcp-server/src/main/java/com/rreganjr/requel/mcp/McpWriteService.java
+++ b/modules/mcp-server/src/main/java/com/rreganjr/requel/mcp/McpWriteService.java
@@ -20,7 +20,6 @@
  */
 package com.rreganjr.requel.mcp;
 
-import java.lang.reflect.RecordComponent;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -35,6 +34,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rreganjr.requel.gateway.CommandDescriptor;
 import com.rreganjr.requel.gateway.CommandGateway;
+import com.rreganjr.requel.gateway.CommandInputSchema;
 import com.rreganjr.requel.gateway.GatewayCommandCatalog;
 import com.rreganjr.requel.gateway.GatewayException;
 import com.rreganjr.requel.gateway.GatewayRequest;
@@ -132,7 +132,7 @@ public class McpWriteService {
 		// surface is exactly the gateway's exposed write surface (issue #104).
 		for (CommandDescriptor descriptor : catalog.descriptors()) {
 			tools.add(new McpToolDescriptor(descriptor.commandType(), describe(descriptor),
-					schemaFor(descriptor.inputType())));
+					CommandInputSchema.of(descriptor.inputType())));
 		}
 		// Composite convenience tools (orchestrations over several commands; issue #71).
 		tools.add(upsertGoalDescriptor());
@@ -228,14 +228,14 @@ public class McpWriteService {
 		String base = descriptor.description() != null && !descriptor.description().isBlank()
 				? descriptor.description()
 				: descriptor.title();
-		List<String> fields = fieldNames(descriptor.inputType());
+		List<String> fields = CommandInputSchema.fieldNames(descriptor.inputType());
 		String fieldHint = fields.isEmpty() ? "" : " Input fields: " + String.join(", ", fields) + ".";
 		return base + "." + fieldHint;
 	}
 
 	private Map<String, Object> runCommandSchema() {
-		return objectSchema(Map.of(
-				"commandType", stringType(),
+		return CommandInputSchema.objectSchema(Map.of(
+				"commandType", CommandInputSchema.stringType(),
 				"input", Map.of("type", "object")),
 				List.of("commandType"));
 	}
@@ -254,115 +254,18 @@ public class McpWriteService {
 
 	private static Map<String, Object> upsertGoalSchema() {
 		Map<String, Object> properties = new LinkedHashMap<>();
-		properties.put("projectName", stringType());
-		properties.put("criterionText", stringType());
-		properties.put("sourceSystem", stringType());
-		properties.put("sourceRef", stringType());
-		properties.put("name", stringType());
-		properties.put("text", stringType());
-		properties.put("sourceUrl", stringType());
-		properties.put("criterionRef", stringType());
-		properties.put("criterionHash", stringType());
+		properties.put("projectName", CommandInputSchema.stringType());
+		properties.put("criterionText", CommandInputSchema.stringType());
+		properties.put("sourceSystem", CommandInputSchema.stringType());
+		properties.put("sourceRef", CommandInputSchema.stringType());
+		properties.put("name", CommandInputSchema.stringType());
+		properties.put("text", CommandInputSchema.stringType());
+		properties.put("sourceUrl", CommandInputSchema.stringType());
+		properties.put("criterionRef", CommandInputSchema.stringType());
+		properties.put("criterionHash", CommandInputSchema.stringType());
 		// client is intentionally omitted: it is taken from the MCP client context, not arguments.
-		return objectSchema(properties,
+		return CommandInputSchema.objectSchema(properties,
 				List.of("projectName", "criterionText", "sourceSystem", "sourceRef"));
-	}
-
-	/**
-	 * Derive a JSON schema for a command's input DTO. Input DTOs are Java records, so each record
-	 * component becomes a typed property. A component is marked <em>required</em> when it carries a
-	 * {@code jakarta.validation} {@code @NotNull}/{@code @NotBlank} annotation — those annotations
-	 * encode the fields the command's applicator dereferences unconditionally (issue #104). Unknown
-	 * fields are rejected so typos surface early. A {@code null}/{@link Void} input type yields an
-	 * empty object schema.
-	 */
-	private static Map<String, Object> schemaFor(Class<?> inputType) {
-		if (inputType == null || inputType == Void.class || !inputType.isRecord()) {
-			return objectSchema(Map.of(), List.of());
-		}
-		Map<String, Object> properties = new LinkedHashMap<>();
-		List<String> required = new ArrayList<>();
-		for (RecordComponent component : inputType.getRecordComponents()) {
-			properties.put(component.getName(), jsonType(component.getType()));
-			if (isRequired(component)) {
-				required.add(component.getName());
-			}
-		}
-		return objectSchema(properties, required);
-	}
-
-	/**
-	 * A record component is required when it (or its generated accessor) carries a
-	 * {@code jakarta.validation} {@code @NotNull} or {@code @NotBlank} annotation. Matched by fully
-	 * qualified name so this module needs no compile-time dependency on the validation API.
-	 */
-	private static boolean isRequired(RecordComponent component) {
-		return hasRequiredAnnotation(component.getAnnotations())
-				|| hasRequiredAnnotation(component.getAccessor().getAnnotations());
-	}
-
-	private static boolean hasRequiredAnnotation(java.lang.annotation.Annotation[] annotations) {
-		for (java.lang.annotation.Annotation a : annotations) {
-			String name = a.annotationType().getName();
-			if (name.equals("jakarta.validation.constraints.NotNull")
-					|| name.equals("jakarta.validation.constraints.NotBlank")) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	private static List<String> fieldNames(Class<?> inputType) {
-		if (inputType == null || inputType == Void.class || !inputType.isRecord()) {
-			return List.of();
-		}
-		List<String> names = new ArrayList<>();
-		for (RecordComponent component : inputType.getRecordComponents()) {
-			names.add(component.getName());
-		}
-		return names;
-	}
-
-	/** Map a Java type to a JSON-schema type node. */
-	private static Map<String, Object> jsonType(Class<?> type) {
-		if (type == String.class || type == Character.class || type == char.class) {
-			return stringType();
-		}
-		if (type == Boolean.class || type == boolean.class) {
-			return booleanType();
-		}
-		if (type == Integer.class || type == int.class || type == Long.class || type == long.class
-				|| type == Short.class || type == short.class || type == Byte.class
-				|| type == byte.class) {
-			return integerType();
-		}
-		if (type == Double.class || type == double.class || type == Float.class
-				|| type == float.class) {
-			return Map.of("type", "number");
-		}
-		if (Iterable.class.isAssignableFrom(type) || type.isArray()) {
-			return Map.of("type", "array");
-		}
-		// Enums serialize as their name; everything else is a nested object.
-		return type.isEnum() ? stringType() : Map.of("type", "object");
-	}
-
-	private static Map<String, Object> objectSchema(Map<String, Object> properties,
-			List<String> required) {
-		return Map.of("type", "object", "properties", properties, "required", required,
-				"additionalProperties", false);
-	}
-
-	private static Map<String, Object> stringType() {
-		return Map.of("type", "string");
-	}
-
-	private static Map<String, Object> integerType() {
-		return Map.of("type", "integer");
-	}
-
-	private static Map<String, Object> booleanType() {
-		return Map.of("type", "boolean");
 	}
 
 	@SuppressWarnings("unchecked")

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/RequelCli.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/RequelCli.java
@@ -112,12 +112,16 @@ public class RequelCli implements Runnable {
     }
 
     public static void main(String[] args) {
-        int code = new CommandLine(new RequelCli())
+        RequelCli root = new RequelCli();
+        CommandLine commandLine = new CommandLine(root)
                 // Don't treat a leading '@' (e.g. --input-file @path) as a picocli argument file.
                 .setExpandAtFiles(false)
                 // Accept --output json/text as well as JSON/TEXT.
-                .setCaseInsensitiveEnumValuesAllowed(true)
-                .execute(args);
+                .setCaseInsensitiveEnumValuesAllowed(true);
+        // Runtime-discovered typed write subcommands (issue #103): best-effort, offline-tolerant —
+        // when unreachable or invoking a built-in, only the static subcommands are registered.
+        TypedCommands.registerFromServer(commandLine, root, args);
+        int code = commandLine.execute(args);
         System.exit(code);
     }
 }

--- a/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/TypedCommands.java
+++ b/modules/requel-cli/src/main/java/com/rreganjr/requel/cli/TypedCommands.java
@@ -1,0 +1,309 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rreganjr.requel.gateway.CommandGateway;
+import com.rreganjr.requel.gateway.GatewayException;
+import com.rreganjr.requel.gateway.GatewayRequest;
+import com.rreganjr.requel.gateway.GatewayResult;
+import com.rreganjr.requel.gateway.rest.BearerTokenSource;
+import com.rreganjr.requel.gateway.rest.CommandInfo;
+import com.rreganjr.requel.gateway.rest.RestCommandGateway;
+import com.rreganjr.requel.gateway.rest.RestGatewayCatalog;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.function.Function;
+import picocli.CommandLine;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Model.IGetter;
+import picocli.CommandLine.Model.ISetter;
+import picocli.CommandLine.Model.OptionSpec;
+import picocli.CommandLine.ParseResult;
+
+/**
+ * Registers a typed picocli subcommand per gateway <em>write</em> command, generated at runtime from
+ * the server's descriptor catalog ({@code /api/gateway/commands/descriptors}) so the CLI exposes
+ * exactly what the connected server permits and stays in lockstep with MCP and the gateway policy
+ * (issue #103). Each command's input JSON schema — the same schema MCP typed tools use — becomes a
+ * set of per-field {@code --flags}: scalar fields map to typed options (string/integer/number/
+ * boolean), and nested object/array fields take a raw-JSON string. Required fields (from the
+ * schema's {@code required} array) are required flags.
+ *
+ * <p>Discovery is best-effort and runtime-primary: the generic {@code requel run <Type> --input}
+ * stays the always-available fallback. When the invocation is a built-in subcommand, {@code --help}/
+ * {@code --version}, or the server is unreachable, no typed subcommands are registered and only the
+ * built-ins show — the offline story from the #70 plan.
+ */
+final class TypedCommands {
+
+    /** Default dispatch: a REST gateway built from the parent's URL + token source. */
+    static final Function<RequelCli, CommandGateway> REST_GATEWAY =
+            parent -> new RestCommandGateway(parent.url, parent.tokenSource());
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private TypedCommands() {
+    }
+
+    /**
+     * Best-effort: if this invocation looks like it wants a typed subcommand and a server is
+     * reachable, fetch the catalog and register the typed subcommands. Any failure (offline, auth,
+     * writes disabled → empty catalog) leaves only the built-ins, by design.
+     */
+    static void registerFromServer(CommandLine root, RequelCli parent, String[] args) {
+        ProbedInvocation probe = probe(args);
+        if (!probe.wantsTypedSubcommand()) {
+            return;
+        }
+        List<CommandInfo> descriptors;
+        try {
+            descriptors = new RestGatewayCatalog(probe.url(), probe.tokenSource()).descriptors();
+        } catch (RuntimeException e) {
+            // Offline / unauthorized / other transport failure: built-ins only.
+            return;
+        }
+        register(root, parent, descriptors, REST_GATEWAY);
+    }
+
+    /**
+     * Add a typed subcommand for each write descriptor. Pure and side-effect-free apart from
+     * mutating {@code root}'s subcommand set — the seam the tests drive with a stub gateway.
+     */
+    static void register(CommandLine root, RequelCli parent, List<CommandInfo> descriptors,
+            Function<RequelCli, CommandGateway> gatewayFactory) {
+        for (CommandInfo d : descriptors) {
+            if (!d.write()) {
+                continue; // the catalog is write-only, but never generate a mutating verb for a read
+            }
+            String name = kebab(d.commandType());
+            if (root.getSubcommands().containsKey(name)) {
+                continue; // never shadow a hand-written built-in (e.g. upsert-goal)
+            }
+            root.addSubcommand(name, buildSubcommand(d, parent, gatewayFactory));
+        }
+    }
+
+    private static CommandLine buildSubcommand(CommandInfo d, RequelCli parent,
+            Function<RequelCli, CommandGateway> gatewayFactory) {
+        Map<String, Object> values = new LinkedHashMap<>();
+        Set<String> rawJsonFields = new HashSet<>();
+
+        // The command's behavior is a Callable over the captured value map; wrapWithoutInspection
+        // makes it the spec's user object without scanning it for annotations, so picocli's default
+        // execution strategy invokes it when this subcommand is matched.
+        Callable<Integer> action = () ->
+                dispatch(parent, gatewayFactory, d.commandType(), values, rawJsonFields);
+        CommandSpec spec = CommandSpec.wrapWithoutInspection(action);
+        spec.name(kebab(d.commandType()));
+        spec.mixinStandardHelpOptions(true);
+        spec.usageMessage().description(describe(d));
+
+        Map<String, Object> properties = asMap(schema(d).get("properties"));
+        Set<String> required = Set.copyOf(asStringList(schema(d).get("required")));
+        for (Map.Entry<String, Object> property : properties.entrySet()) {
+            String field = property.getKey();
+            String jsonType = typeOf(property.getValue());
+            boolean rawJson = jsonType.equals("array") || jsonType.equals("object");
+            if (rawJson) {
+                rawJsonFields.add(field);
+            }
+            MapBinding binding = new MapBinding(values, field);
+            spec.addOption(OptionSpec.builder("--" + kebab(field))
+                    .type(rawJson ? String.class : javaType(jsonType))
+                    .required(required.contains(field))
+                    .paramLabel(field.toUpperCase(Locale.ROOT))
+                    .description(flagDescription(field, jsonType, rawJson, required.contains(field)))
+                    .getter(binding)
+                    .setter(binding)
+                    .build());
+        }
+
+        return new CommandLine(spec);
+    }
+
+    private static int dispatch(RequelCli parent, Function<RequelCli, CommandGateway> gatewayFactory,
+            String commandType, Map<String, Object> values, Set<String> rawJsonFields) {
+        Map<String, Object> input = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> e : values.entrySet()) {
+            Object value = e.getValue();
+            if (rawJsonFields.contains(e.getKey()) && value instanceof String raw) {
+                try {
+                    value = MAPPER.readValue(raw, Object.class);
+                } catch (JsonProcessingException ex) {
+                    System.err.println("Invalid JSON for --" + kebab(e.getKey()) + ": "
+                            + ex.getOriginalMessage());
+                    return ExitCode.USAGE;
+                }
+            }
+            input.put(e.getKey(), value);
+        }
+        CommandGateway gateway = gatewayFactory.apply(parent);
+        try {
+            GatewayResult result = gateway.execute(new GatewayRequest(commandType, input));
+            parent.printResult(result);
+            return ExitCode.SUCCESS;
+        } catch (GatewayException e) {
+            parent.printError(e);
+            return ExitCode.forKind(e.getKind());
+        }
+    }
+
+    // ---- invocation probing (decide whether to fetch, and resolve the connection) ---------------
+
+    /**
+     * Parse the args against a throwaway root (unmatched allowed, nothing executed) to decide whether
+     * this invocation wants a typed subcommand, and to resolve the URL/token the same way the real
+     * run will (picocli applies {@code --url}/{@code --token} flags and their env defaults).
+     */
+    /**
+     * Whether this invocation looks like it wants a runtime typed subcommand (i.e. not a built-in,
+     * {@code --help}/{@code --version}, or empty). Package-visible for tests of the fetch gating.
+     */
+    static boolean wantsTypedSubcommand(String[] args) {
+        return probe(args).wantsTypedSubcommand();
+    }
+
+    private static ProbedInvocation probe(String[] args) {
+        RequelCli probeRoot = new RequelCli();
+        CommandLine probe = new CommandLine(probeRoot)
+                .setUnmatchedArgumentsAllowed(true)
+                .setExpandAtFiles(false)
+                .setCaseInsensitiveEnumValuesAllowed(true);
+        boolean wants;
+        try {
+            ParseResult pr = probe.parseArgs(args);
+            // A recognized built-in subcommand → let it run offline; no fetch needed.
+            // Otherwise a non-option unmatched token is a candidate typed subcommand → fetch.
+            wants = !pr.hasSubcommand()
+                    && pr.unmatched().stream().anyMatch(t -> !t.startsWith("-"));
+        } catch (RuntimeException e) {
+            wants = false; // malformed → let the real parse report it; built-ins only
+        }
+        String url = probeRoot.url != null && !probeRoot.url.isBlank()
+                ? probeRoot.url : "http://localhost:8080";
+        return new ProbedInvocation(wants, url, probeRoot.tokenSource());
+    }
+
+    private record ProbedInvocation(boolean wantsTypedSubcommand, String url,
+            BearerTokenSource tokenSource) {
+    }
+
+    // ---- schema → picocli mapping helpers -------------------------------------------------------
+
+    /** picocli getter+setter backed by an entry in the per-subcommand values map. */
+    private static final class MapBinding implements IGetter, ISetter {
+        private final Map<String, Object> values;
+        private final String key;
+
+        MapBinding(Map<String, Object> values, String key) {
+            this.values = values;
+            this.key = key;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T get() {
+            return (T) values.get(key);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T set(T value) {
+            return (T) values.put(key, value);
+        }
+    }
+
+    private static Class<?> javaType(String jsonType) {
+        return switch (jsonType) {
+            case "integer" -> Long.class;   // headroom for ids; Jackson narrows to the DTO field
+            case "number" -> Double.class;
+            case "boolean" -> Boolean.class;
+            default -> String.class;        // string, and anything unrecognized
+        };
+    }
+
+    private static String flagDescription(String field, String jsonType, boolean rawJson,
+            boolean required) {
+        String prefix = required ? "(required) " : "";
+        String typeHint = rawJson ? " (" + jsonType + " as raw JSON)" : "";
+        return prefix + field + typeHint;
+    }
+
+    private static String[] describe(CommandInfo d) {
+        List<String> lines = new ArrayList<>();
+        lines.add(d.title() != null ? d.title() : d.commandType());
+        if (d.description() != null && !d.description().isBlank()) {
+            lines.add(d.description());
+        }
+        return lines.toArray(new String[0]);
+    }
+
+    private static Map<String, Object> schema(CommandInfo d) {
+        return d.schema() != null ? d.schema() : Map.of();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> asMap(Object node) {
+        return node instanceof Map ? (Map<String, Object>) node : Map.of();
+    }
+
+    private static List<String> asStringList(Object node) {
+        if (!(node instanceof List<?> list)) {
+            return List.of();
+        }
+        List<String> out = new ArrayList<>();
+        for (Object o : list) {
+            out.add(String.valueOf(o));
+        }
+        return out;
+    }
+
+    /** The {@code "type"} of a JSON-schema property node, defaulting to {@code "string"}. */
+    private static String typeOf(Object propertyNode) {
+        Object type = asMap(propertyNode).get("type");
+        return type instanceof String s ? s : "string";
+    }
+
+    /** {@code EditGoal} → {@code edit-goal}, {@code projectName} → {@code project-name}. */
+    static String kebab(String name) {
+        StringBuilder sb = new StringBuilder(name.length() + 4);
+        for (int i = 0; i < name.length(); i++) {
+            char c = name.charAt(i);
+            if (Character.isUpperCase(c)) {
+                if (i > 0) {
+                    sb.append('-');
+                }
+                sb.append(Character.toLowerCase(c));
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/CommandsCommandTest.java
+++ b/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/CommandsCommandTest.java
@@ -66,7 +66,7 @@ class CommandsCommandTest {
     @Test
     void listsCommandsAndReturnsSuccess() {
         RestGatewayCatalog catalog = catalogReturning(List.of(
-                new CommandInfo("EditGoal", "EditGoalInput", "Edit Goal", null, true, null)));
+                new CommandInfo("EditGoal", "EditGoalInput", "Edit Goal", null, true, null, null)));
         String out = captureStdout(() ->
                 assertThat(command(OutputFormat.TEXT, catalog).call()).isEqualTo(ExitCode.SUCCESS));
         assertThat(out).contains("EditGoal").contains("Edit Goal");
@@ -83,7 +83,7 @@ class CommandsCommandTest {
     @Test
     void jsonOutputEmitsArray() {
         RestGatewayCatalog catalog = catalogReturning(List.of(
-                new CommandInfo("EditGoal", "EditGoalInput", "Edit Goal", null, true, null)));
+                new CommandInfo("EditGoal", "EditGoalInput", "Edit Goal", null, true, null, null)));
         String out = captureStdout(() ->
                 assertThat(command(OutputFormat.JSON, catalog).call()).isEqualTo(ExitCode.SUCCESS));
         assertThat(out.trim()).startsWith("[").contains("\"commandType\" : \"EditGoal\"");

--- a/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/TypedCommandsTest.java
+++ b/modules/requel-cli/src/test/java/com/rreganjr/requel/cli/TypedCommandsTest.java
@@ -1,0 +1,192 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.rreganjr.requel.gateway.CommandGateway;
+import com.rreganjr.requel.gateway.GatewayRequest;
+import com.rreganjr.requel.gateway.GatewayResult;
+import com.rreganjr.requel.gateway.rest.CommandInfo;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+import picocli.CommandLine.Model.CommandSpec;
+
+/**
+ * Unit tests for {@link TypedCommands}: generating typed picocli subcommands from a command
+ * descriptor's input schema, dispatching the assembled input through the gateway, required-flag
+ * enforcement, raw-JSON handling for nested fields, built-in collision avoidance, and the
+ * fetch-gating that keeps built-in/offline invocations from hitting the network. No network: the
+ * gateway is stubbed via the injectable factory.
+ */
+class TypedCommandsTest {
+
+    private static Map<String, Object> schema(Map<String, Object> properties, List<String> required) {
+        return Map.of("type", "object", "properties", properties, "required", required,
+                "additionalProperties", false);
+    }
+
+    /** EditGoal with a required projectName (string) and optional name (string). */
+    private static CommandInfo editGoal() {
+        Map<String, Object> props = new LinkedHashMap<>();
+        props.put("projectName", Map.of("type", "string"));
+        props.put("name", Map.of("type", "string"));
+        return new CommandInfo("EditGoal", "EditGoalInput", "Edit Goal", null, true, "Goal[Edit]",
+                schema(props, List.of("projectName")));
+    }
+
+    private record Harness(CommandLine root, RequelCli parent,
+            AtomicReference<GatewayRequest> lastRequest) {
+    }
+
+    private static Harness harnessFor(CommandInfo... descriptors) {
+        RequelCli parent = new RequelCli();
+        parent.url = "http://localhost:8080";
+        CommandLine root = new CommandLine(parent);
+        AtomicReference<GatewayRequest> lastRequest = new AtomicReference<>();
+        CommandGateway stub = request -> {
+            lastRequest.set(request);
+            return new GatewayResult(request.commandType(), Map.of("id", 1));
+        };
+        Function<RequelCli, CommandGateway> factory = p -> stub;
+        TypedCommands.register(root, parent, List.of(descriptors), factory);
+        return new Harness(root, parent, lastRequest);
+    }
+
+    @Test
+    void generatesAKebabSubcommandWithTypedFlagsAndRequiredness() {
+        Harness h = harnessFor(editGoal());
+
+        CommandLine sub = h.root().getSubcommands().get("edit-goal");
+        assertThat(sub).isNotNull();
+        CommandSpec spec = sub.getCommandSpec();
+        assertThat(spec.findOption("--project-name")).isNotNull();
+        assertThat(spec.findOption("--project-name").required()).isTrue();
+        assertThat(spec.findOption("--name")).isNotNull();
+        assertThat(spec.findOption("--name").required()).isFalse();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void invokingATypedSubcommandDispatchesTheAssembledInput() {
+        Harness h = harnessFor(editGoal());
+
+        int code = h.root().execute("edit-goal", "--project-name", "Demo", "--name", "G");
+
+        assertThat(code).isEqualTo(ExitCode.SUCCESS);
+        GatewayRequest request = h.lastRequest().get();
+        assertThat(request).isNotNull();
+        assertThat(request.commandType()).isEqualTo("EditGoal");
+        // Flags map back to the ORIGINAL DTO field names, not the kebab flag names.
+        assertThat((Map<String, Object>) request.input())
+                .containsEntry("projectName", "Demo")
+                .containsEntry("name", "G");
+    }
+
+    @Test
+    void omittingARequiredFlagIsAUsageErrorAndNeverDispatches() {
+        Harness h = harnessFor(editGoal());
+
+        int code = h.root().execute("edit-goal", "--name", "G"); // missing required --project-name
+
+        assertThat(code).isEqualTo(ExitCode.USAGE);
+        assertThat(h.lastRequest().get()).isNull();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void nestedArrayFieldIsParsedFromRawJson() {
+        Map<String, Object> props = new LinkedHashMap<>();
+        props.put("name", Map.of("type", "string"));
+        props.put("tags", Map.of("type", "array"));
+        CommandInfo editThing = new CommandInfo("EditThing", "EditThingInput", "Edit Thing", null,
+                true, null, schema(props, List.of("name")));
+        Harness h = harnessFor(editThing);
+
+        int code = h.root().execute("edit-thing", "--name", "X", "--tags", "[\"a\",\"b\"]");
+
+        assertThat(code).isEqualTo(ExitCode.SUCCESS);
+        Map<String, Object> input = (Map<String, Object>) h.lastRequest().get().input();
+        assertThat(input).containsEntry("name", "X");
+        assertThat(input.get("tags")).isEqualTo(List.of("a", "b"));
+    }
+
+    @Test
+    void invalidJsonForANestedFieldIsAUsageError() {
+        Map<String, Object> props = new LinkedHashMap<>();
+        props.put("tags", Map.of("type", "array"));
+        CommandInfo editThing = new CommandInfo("EditThing", "EditThingInput", "Edit Thing", null,
+                true, null, schema(props, List.of()));
+        Harness h = harnessFor(editThing);
+
+        int code = h.root().execute("edit-thing", "--tags", "not json");
+
+        assertThat(code).isEqualTo(ExitCode.USAGE);
+        assertThat(h.lastRequest().get()).isNull();
+    }
+
+    @Test
+    void doesNotShadowABuiltInSubcommand() {
+        // UpsertGoal kebabs to "upsert-goal", which is a hand-written built-in — keep the built-in.
+        CommandInfo upsert = new CommandInfo("UpsertGoal", "UpsertGoalInput", "Upsert Goal", null,
+                true, null, schema(new LinkedHashMap<>(), List.of()));
+        Harness h = harnessFor(upsert);
+
+        Object builtIn = h.root().getSubcommands().get("upsert-goal").getCommand();
+        assertThat(builtIn).isInstanceOf(UpsertGoalCommand.class);
+    }
+
+    @Test
+    void readOnlyDescriptorsAreNeverGenerated() {
+        CommandInfo read = new CommandInfo("SomeQuery", "SomeQueryInput", "Some Query", null, false,
+                null, schema(new LinkedHashMap<>(), List.of()));
+        Harness h = harnessFor(read);
+
+        assertThat(h.root().getSubcommands()).doesNotContainKey("some-query");
+    }
+
+    @Test
+    void kebabConvertsPascalAndCamelCase() {
+        assertThat(TypedCommands.kebab("EditGoal")).isEqualTo("edit-goal");
+        assertThat(TypedCommands.kebab("AddGoalToGoalContainer"))
+                .isEqualTo("add-goal-to-goal-container");
+        assertThat(TypedCommands.kebab("projectName")).isEqualTo("project-name");
+    }
+
+    @Test
+    void fetchGatingSkipsBuiltInsHelpAndEmptyButFiresForTypedCandidates() {
+        // Candidate typed subcommand → fetch.
+        assertThat(TypedCommands.wantsTypedSubcommand(new String[] {"edit-goal", "--project", "D"}))
+                .isTrue();
+        assertThat(TypedCommands.wantsTypedSubcommand(
+                new String[] {"--url", "http://x", "edit-goal"})).isTrue();
+        // Built-ins / help / version / empty → no fetch (built-ins only).
+        assertThat(TypedCommands.wantsTypedSubcommand(new String[] {"run", "EditGoal"})).isFalse();
+        assertThat(TypedCommands.wantsTypedSubcommand(new String[] {"projects"})).isFalse();
+        assertThat(TypedCommands.wantsTypedSubcommand(new String[] {"--help"})).isFalse();
+        assertThat(TypedCommands.wantsTypedSubcommand(new String[] {})).isFalse();
+    }
+}

--- a/modules/service-impl/pom.xml
+++ b/modules/service-impl/pom.xml
@@ -111,5 +111,10 @@
             <version>0.12.6</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/gateway/GatewayCommandController.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/gateway/GatewayCommandController.java
@@ -22,6 +22,7 @@ package com.rreganjr.requel.service.gateway;
 
 import com.rreganjr.requel.gateway.CommandDescriptor;
 import com.rreganjr.requel.gateway.CommandGateway;
+import com.rreganjr.requel.gateway.CommandInputSchema;
 import com.rreganjr.requel.gateway.GatewayCommandCatalog;
 import com.rreganjr.requel.gateway.GatewayException;
 import com.rreganjr.requel.gateway.GatewayRequest;
@@ -109,14 +110,23 @@ public class GatewayCommandController {
     public record GatewayErrorBody(String kind, String message) {
     }
 
-    /** JSON view of a {@link CommandDescriptor} — the input type as a simple name, not a Class. */
+    /**
+     * JSON view of a {@link CommandDescriptor}: the input type as a simple name (not a Class), plus a
+     * JSON {@code schema} for that input DTO derived by {@link CommandInputSchema} — the same
+     * generator the MCP typed tools use — so the CLI can build per-field typed subcommands from it
+     * (issue #103) and stays in lockstep with MCP and the gateway policy. The schema is always an
+     * object node ({@code {type:object, properties, required, additionalProperties:false}}); commands
+     * with no input yield an empty-properties schema.
+     */
     public record DescriptorView(String commandType, String inputType, String title,
-            String description, boolean write, String authorizationHint) {
+            String description, boolean write, String authorizationHint,
+            Map<String, Object> schema) {
 
         static DescriptorView from(CommandDescriptor d) {
             return new DescriptorView(d.commandType(),
                     d.inputType() == null ? null : d.inputType().getSimpleName(),
-                    d.title(), d.description(), d.write(), d.authorizationHint());
+                    d.title(), d.description(), d.write(), d.authorizationHint(),
+                    CommandInputSchema.of(d.inputType()));
         }
     }
 }

--- a/modules/service-impl/src/test/java/com/rreganjr/requel/service/gateway/GatewayCommandControllerTest.java
+++ b/modules/service-impl/src/test/java/com/rreganjr/requel/service/gateway/GatewayCommandControllerTest.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.rreganjr.requel.gateway.CommandDescriptor;
+import com.rreganjr.requel.gateway.CommandGateway;
+import com.rreganjr.requel.gateway.GatewayCommandCatalog;
+import com.rreganjr.requel.gateway.GatewayResult;
+import com.rreganjr.requel.service.gateway.GatewayCommandController.DescriptorView;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the descriptor endpoint's {@link DescriptorView} projection (issue #103): it now
+ * carries a JSON {@code schema} for each command's input DTO (via {@link
+ * com.rreganjr.requel.gateway.CommandInputSchema}), which the CLI turns into per-field typed
+ * subcommands. Also pins the write-flag gating (empty list when writes are disabled). Constructs the
+ * controller directly with a stub catalog — no Spring context needed.
+ */
+class GatewayCommandControllerTest {
+
+	record EditThingInput(@NotBlank String name, @NotNull Long id, String note) {
+	}
+
+	private static final CommandGateway NOOP_GATEWAY =
+			request -> new GatewayResult(request.commandType(), null);
+
+	private static GatewayCommandCatalog catalogOf(CommandDescriptor... descriptors) {
+		return new GatewayCommandCatalog() {
+			@Override
+			public List<CommandDescriptor> descriptors() {
+				return List.of(descriptors);
+			}
+
+			@Override
+			public Optional<CommandDescriptor> find(String commandType) {
+				return List.of(descriptors).stream()
+						.filter(d -> d.commandType().equals(commandType)).findFirst();
+			}
+		};
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void descriptorViewCarriesInputSchemaWithRequiredFields() {
+		GatewayCommandCatalog catalog = catalogOf(
+				new CommandDescriptor("EditThing", EditThingInput.class, "Edit Thing",
+						"Edits a thing", true, "Thing[Edit]"));
+		GatewayCommandController controller =
+				new GatewayCommandController(NOOP_GATEWAY, catalog, true);
+
+		List<DescriptorView> views = controller.descriptors();
+
+		assertThat(views).singleElement().satisfies(v -> {
+			assertThat(v.commandType()).isEqualTo("EditThing");
+			assertThat(v.inputType()).isEqualTo("EditThingInput"); // simple name, not the Class
+			assertThat(v.write()).isTrue();
+			assertThat(v.schema()).containsEntry("type", "object")
+					.containsEntry("additionalProperties", false);
+			var props = (Map<String, Object>) v.schema().get("properties");
+			assertThat(props).containsOnlyKeys("name", "id", "note");
+			assertThat(props.get("name")).isEqualTo(Map.of("type", "string"));
+			assertThat(props.get("id")).isEqualTo(Map.of("type", "integer"));
+			// Only @NotBlank/@NotNull components are required; the unannotated one is optional.
+			assertThat((List<String>) v.schema().get("required"))
+					.containsExactlyInAnyOrder("name", "id");
+		});
+	}
+
+	@Test
+	void descriptorsAreEmptyWhenWritesDisabled() {
+		GatewayCommandCatalog catalog = catalogOf(
+				new CommandDescriptor("EditThing", EditThingInput.class, "Edit Thing", null, true,
+						null));
+		GatewayCommandController controller =
+				new GatewayCommandController(NOOP_GATEWAY, catalog, false);
+
+		assertThat(controller.descriptors()).isEmpty();
+	}
+}


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/103

requel-cli: dynamic typed write subcommands from command descriptors

Implements the "richer form" deferred from #70 Phase A (M4): the CLI now registers a typed picocli
subcommand per gateway write command, with per-field flags generated from each command's input DTO
JSON schema (e.g. `requel edit-goal --project-name Demo --name G`), alongside the existing generic
`requel run <Type> --input`. The input schema is derived by one shared generator that MCP, the
descriptor endpoint, and the CLI all use, so the three surfaces stay in lockstep with the gateway
allow/deny policy. Plan and milestones in doc/103-typed-subcommands-plan.md.

Closes #103

M1 — shared schema generator (gateway-api), MCP refactored onto it

modules/gateway-api/.../CommandInputSchema.java (new)
  The record-DTO -> JSON-schema generator, extracted from McpWriteService so it is no longer private
  to the MCP module. Pure JDK (reflection + collections): of(Class) maps each record component to a
  typed property; required is derived from jakarta.validation @NotNull/@NotBlank matched by
  fully-qualified name (no compile dependency on the validation API); also exposes fieldNames(Class)
  and the small schema-node builders (objectSchema/stringType/integerType/booleanType).
modules/gateway-api/src/test/.../CommandInputSchemaTest.java (new)
  Unit coverage for the generator: every Java->JSON type mapping, required-from-annotations,
  declaration-order preservation, Void/null/non-record -> empty object schema, and the builders.
modules/mcp-server/.../McpWriteService.java
  Deletes the nine private schema helpers and delegates to CommandInputSchema (toolDescriptors uses
  CommandInputSchema.of(...), describe uses fieldNames(...), the hand-built runCommand/upsertGoal
  schemas use the shared builders). Behavior is unchanged - the existing MCP schema/lockstep tests
  (McpWriteServiceSchemaTest, McpWriteCatalogLockstepTest, McpToolCatalogLockstepIT) still pass.

M2 — JSON schema on the descriptor endpoint and client DTO

modules/service-impl/.../GatewayCommandController.java
  DescriptorView gains a schema field, populated in from() via CommandInputSchema.of(inputType), so
  GET /api/gateway/commands/descriptors now carries each command's input schema (always an object
  node; empty properties when the command has no input).
modules/gateway-rest-client/.../CommandInfo.java
  Adds the matching nullable schema map (nullable so an older server without the field still
  deserializes; @JsonIgnoreProperties already tolerates extra fields).
modules/service-impl/.../GatewayCommandControllerTest.java (new)
  Constructs the controller directly with a stub catalog: asserts the view carries a schema with the
  correct required fields and that the list is empty when writes are disabled.
modules/service-impl/pom.xml
  Adds spring-boot-starter-test (test scope) - the module had no test tree.
modules/gateway-rest-client/src/test/.../RestGatewayCatalogTest.java
  Stub response now includes a schema; asserts it round-trips into the client CommandInfo.
modules/requel-cli/src/test/.../CommandsCommandTest.java
  Updates the two CommandInfo constructions for the new field (schema irrelevant to that listing).

M3 — runtime typed write subcommands in the CLI

modules/requel-cli/.../TypedCommands.java (new)
  At startup, probes the args to decide intent (built-in / --help / empty -> skip; a candidate typed
  token -> fetch), then fetches the catalog and registers one subcommand per write descriptor. Each is
  built programmatically (CommandSpec.wrapWithoutInspection + OptionSpecs backed by a value map):
  kebab name (EditGoal -> edit-goal), one --flag per schema property (kebab'd), typed as
  string/integer(Long)/number(Double)/boolean, required taken from the schema; nested object/array
  fields take a raw-JSON string parsed at dispatch. Flags map back to the original DTO field names and
  dispatch through RestCommandGateway, reusing the parent's URL/token and printResult/ExitCode. Any
  fetch failure (offline / unauthorized / writes disabled -> empty catalog) leaves only the built-ins,
  and it never shadows a hand-written built-in (e.g. upsert-goal).
modules/requel-cli/.../RequelCli.java
  main() holds the root + CommandLine and calls TypedCommands.registerFromServer(...) before execute.
modules/requel-cli/src/test/.../TypedCommandsTest.java (new)
  No-network unit tests (gateway stubbed via the injectable factory): flag generation + requiredness,
  dispatch payload mapping to original field names, missing-required -> usage error (no dispatch),
  raw-JSON array parsing, invalid-JSON -> usage error, built-in collision avoidance, read-only
  descriptors skipped, kebab conversion, and the fetch-gating.

M4 — docs

doc/103-typed-subcommands-plan.md (new) - plan, milestones, decisions, and status.
doc/70-requel-cli-plan.md - marks the deferred "richer form" item done (points to #103).
doc/70-requel-cli-verification.md - runbook now shows typed-subcommand usage (edit-goal, --help,
  raw-JSON nested fields) and the offline/built-ins-only fallback.
