### PR TITLE
Persistent OAuth AS signing key loaded from a configured keystore

### DIFF
--- a/doc/105-keystore-credentials.md
+++ b/doc/105-keystore-credentials.md
@@ -1,18 +1,59 @@
 https://github.com/rreganjr/Requel/issues/105
 
-# Keystore & credential handling
+# OAuth signing key: keystore & credential handling
 
 ## Summary
 
-The signing/TLS keystore is a permission-locked **PKCS12 file on disk** (configurable via
-`requel.keystore.location`, accepting both `file:` and `classpath:` resources — use `file:` for real
-keys, `classpath:` only for throwaway dev keys). The keystore **password is never committed or
-hardcoded**; it is supplied at runtime from an environment variable that developers and operators
-populate from the environment's native secret store.
+The embedded OAuth 2.1 authorization server signs issued JWTs with an RSA key. By default that key is
+generated fresh at every startup (ephemeral), so it changes on each restart and previously-issued
+tokens stop validating — fine for dev/test/CI, but a blocker for the remote MCP connector (#100),
+which needs tokens that survive a restart.
 
-Spring relaxed binding maps the env var `REQUEL_KEYSTORE_PASSWORD` onto the config property
-automatically, so the same launch configuration works unchanged across macOS, Linux, Windows, and
-Docker — only the source of the password value differs.
+When a keystore is configured, `AuthorizationServerConfig.jwkSource()` loads a **persistent** RSA key
+from it and uses the key alias as a stable JWK `kid`, so tokens issued before a restart keep
+validating afterwards and JWKS consumers can cache the key. When no keystore is configured, the
+ephemeral behavior (with its startup warning) is unchanged.
+
+The signing key lives in a permission-locked **PKCS12 (or JKS) keystore file on disk**. The keystore
+and key passwords are **never committed or hardcoded**; they are supplied at runtime from environment
+variables that developers and operators populate from the environment's native secret store.
+
+## Configuration
+
+Read via `Environment`, following the existing `requel.oauth.*` convention (e.g.
+`requel.oauth.dcr.registrar-client-secret`):
+
+| Property | Env var | Meaning |
+| --- | --- | --- |
+| `requel.oauth.jwk.keystore.location` | `REQUEL_OAUTH_JWK_KEYSTORE_LOCATION` | Spring resource: `file:` (real keys) or `classpath:` (throwaway dev keys). Blank = ephemeral key. |
+| `requel.oauth.jwk.keystore.type` | `REQUEL_OAUTH_JWK_KEYSTORE_TYPE` | `PKCS12` (default) or `JKS`. |
+| `requel.oauth.jwk.keystore.password` | `REQUEL_OAUTH_JWK_KEYSTORE_PASSWORD` | Keystore password. Never commit. |
+| `requel.oauth.jwk.key-alias` | `REQUEL_OAUTH_JWK_KEY_ALIAS` | Alias of the signing entry; also the stable JWK `kid`. Required when a location is set. |
+| `requel.oauth.jwk.key-password` | `REQUEL_OAUTH_JWK_KEY_PASSWORD` | Key password; defaults to the keystore password when unset (typical for PKCS12). |
+
+Spring relaxed binding maps the env vars above onto the properties automatically, so the same launch
+configuration works across macOS, Linux, Windows, and Docker — only the source of the password value
+differs.
+
+## Generating the keystore (keytool)
+
+A single self-signed RSA key in a PKCS12 keystore is all the AS needs — the key is used only to sign
+and verify Requel's own JWTs, so the certificate is never presented to a third party:
+
+```bash
+keytool -genkeypair \
+  -alias requel-oauth-signing \
+  -keyalg RSA -keysize 2048 \
+  -dname "CN=Requel OAuth Signing" \
+  -validity 3650 \
+  -keystore requel-oauth-signing.p12 \
+  -storetype PKCS12 \
+  -storepass "$REQUEL_OAUTH_JWK_KEYSTORE_PASSWORD"
+```
+
+Keep `requel-oauth-signing.p12` out of source control. Mount it into the deployed instance / Docker
+image at a permission-locked path (e.g. `chmod 600`, owned by the app's service user) and point
+`requel.oauth.jwk.keystore.location` at it with a `file:` URL.
 
 ## Why not put the private key in the OS keychain directly?
 
@@ -21,37 +62,29 @@ Certificate Store (`Windows-MY`), but their support for *app-managed private key
 historically buggy, and neither exists on Linux/Docker. To keep dev/prod parity, the **private key
 lives in a portable PKCS12 file** and only the **password** is sourced from the OS secret store.
 
-## Acceptance criteria
-
-- No keystore password in source, `application.properties`, or the built artifact.
-- Password sourced from the `REQUEL_KEYSTORE_PASSWORD` env var at launch.
-- Documentation covers macOS, Linux, and Windows.
-- Headless/Docker fallback: env var injected by the orchestrator (Vault / Docker secret /
-  `systemd` credential).
-
-## Populating the password per OS
+## Sourcing the password per OS
 
 ### macOS — Keychain
 
 ```bash
 # store once
-security add-generic-password -a requel -s requel-keystore -w 'PASSWORD'
+security add-generic-password -a requel -s requel-oauth-jwk -w 'PASSWORD'
 # fetch at launch
-export REQUEL_KEYSTORE_PASSWORD="$(security find-generic-password -s requel-keystore -w)"
+export REQUEL_OAUTH_JWK_KEYSTORE_PASSWORD="$(security find-generic-password -s requel-oauth-jwk -w)"
 ```
 
 ### Linux — Secret Service (libsecret)
 
 ```bash
 # store once (prompts for the value)
-secret-tool store --label='Requel keystore' service requel-keystore
+secret-tool store --label='Requel OAuth JWK keystore' service requel-oauth-jwk
 # fetch at launch
-export REQUEL_KEYSTORE_PASSWORD="$(secret-tool lookup service requel-keystore)"
+export REQUEL_OAUTH_JWK_KEYSTORE_PASSWORD="$(secret-tool lookup service requel-oauth-jwk)"
 ```
 
 Requires a running Secret Service (GNOME Keyring / KWallet). On headless servers and containers there
-usually isn't one — inject `REQUEL_KEYSTORE_PASSWORD` via the orchestrator, Vault, or a `systemd`
-credential instead.
+usually isn't one — inject `REQUEL_OAUTH_JWK_KEYSTORE_PASSWORD` via the orchestrator, Vault, a Docker
+secret, or a `systemd` credential instead.
 
 ### Windows — Credential Manager (PowerShell SecretManagement)
 
@@ -59,18 +92,22 @@ credential instead.
 # one-time setup
 Install-Module Microsoft.PowerShell.SecretManagement, Microsoft.PowerShell.SecretStore -Scope CurrentUser
 Register-SecretVault -Name Requel -ModuleName Microsoft.PowerShell.SecretStore -DefaultVault
-Set-Secret -Name requel-keystore -Secret 'PASSWORD'
+Set-Secret -Name requel-oauth-jwk -Secret 'PASSWORD'
 # at launch
-$env:REQUEL_KEYSTORE_PASSWORD = Get-Secret -Name requel-keystore -AsPlainText
+$env:REQUEL_OAUTH_JWK_KEYSTORE_PASSWORD = Get-Secret -Name requel-oauth-jwk -AsPlainText
 ```
 
 ## Launch example
 
-Once `REQUEL_KEYSTORE_PASSWORD` is set in the environment:
+Once the password is in the environment (from any of the sources above):
 
 ```bash
-java -jar modules/requel-app/target/requel-app-1.2.0.jar \
-  --server.ssl.key-store=file:/path/to/keystore.p12 \
-  --server.ssl.key-store-type=PKCS12 \
-  --server.ssl.key-store-password=${REQUEL_KEYSTORE_PASSWORD}
+export REQUEL_OAUTH_JWK_KEYSTORE_LOCATION=file:/etc/requel/requel-oauth-signing.p12
+export REQUEL_OAUTH_JWK_KEY_ALIAS=requel-oauth-signing
+# REQUEL_OAUTH_JWK_KEYSTORE_PASSWORD already exported by the OS-specific step above
+
+java -jar modules/requel-app/target/requel-app-1.2.0.jar
 ```
+
+With no `REQUEL_OAUTH_JWK_KEYSTORE_LOCATION` set, the AS falls back to an ephemeral key and logs the
+existing "tokens will not survive a restart" warning — so dev, tests, and CI need no keystore.

--- a/doc/105-keystore-credentials.md
+++ b/doc/105-keystore-credentials.md
@@ -1,0 +1,76 @@
+https://github.com/rreganjr/Requel/issues/105
+
+# Keystore & credential handling
+
+## Summary
+
+The signing/TLS keystore is a permission-locked **PKCS12 file on disk** (configurable via
+`requel.keystore.location`, accepting both `file:` and `classpath:` resources — use `file:` for real
+keys, `classpath:` only for throwaway dev keys). The keystore **password is never committed or
+hardcoded**; it is supplied at runtime from an environment variable that developers and operators
+populate from the environment's native secret store.
+
+Spring relaxed binding maps the env var `REQUEL_KEYSTORE_PASSWORD` onto the config property
+automatically, so the same launch configuration works unchanged across macOS, Linux, Windows, and
+Docker — only the source of the password value differs.
+
+## Why not put the private key in the OS keychain directly?
+
+Java can address the macOS Keychain (`KeyStore.getInstance("KeychainStore")`) and the Windows
+Certificate Store (`Windows-MY`), but their support for *app-managed private keys* is limited and
+historically buggy, and neither exists on Linux/Docker. To keep dev/prod parity, the **private key
+lives in a portable PKCS12 file** and only the **password** is sourced from the OS secret store.
+
+## Acceptance criteria
+
+- No keystore password in source, `application.properties`, or the built artifact.
+- Password sourced from the `REQUEL_KEYSTORE_PASSWORD` env var at launch.
+- Documentation covers macOS, Linux, and Windows.
+- Headless/Docker fallback: env var injected by the orchestrator (Vault / Docker secret /
+  `systemd` credential).
+
+## Populating the password per OS
+
+### macOS — Keychain
+
+```bash
+# store once
+security add-generic-password -a requel -s requel-keystore -w 'PASSWORD'
+# fetch at launch
+export REQUEL_KEYSTORE_PASSWORD="$(security find-generic-password -s requel-keystore -w)"
+```
+
+### Linux — Secret Service (libsecret)
+
+```bash
+# store once (prompts for the value)
+secret-tool store --label='Requel keystore' service requel-keystore
+# fetch at launch
+export REQUEL_KEYSTORE_PASSWORD="$(secret-tool lookup service requel-keystore)"
+```
+
+Requires a running Secret Service (GNOME Keyring / KWallet). On headless servers and containers there
+usually isn't one — inject `REQUEL_KEYSTORE_PASSWORD` via the orchestrator, Vault, or a `systemd`
+credential instead.
+
+### Windows — Credential Manager (PowerShell SecretManagement)
+
+```powershell
+# one-time setup
+Install-Module Microsoft.PowerShell.SecretManagement, Microsoft.PowerShell.SecretStore -Scope CurrentUser
+Register-SecretVault -Name Requel -ModuleName Microsoft.PowerShell.SecretStore -DefaultVault
+Set-Secret -Name requel-keystore -Secret 'PASSWORD'
+# at launch
+$env:REQUEL_KEYSTORE_PASSWORD = Get-Secret -Name requel-keystore -AsPlainText
+```
+
+## Launch example
+
+Once `REQUEL_KEYSTORE_PASSWORD` is set in the environment:
+
+```bash
+java -jar modules/requel-app/target/requel-app-1.2.0.jar \
+  --server.ssl.key-store=file:/path/to/keystore.p12 \
+  --server.ssl.key-store-type=PKCS12 \
+  --server.ssl.key-store-password=${REQUEL_KEYSTORE_PASSWORD}
+```

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/service/config/OAuthSigningKeyTest.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/service/config/OAuthSigningKeyTest.java
@@ -1,0 +1,191 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.nimbusds.jose.jwk.RSAKey;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.ResourceLoader;
+
+/**
+ * Unit test for the OAuth AS signing-key resolution (issue #105):
+ * {@link AuthorizationServerConfig#buildSigningKey}.
+ *
+ * <p>Covers both paths without booting the authorization server:
+ * <ul>
+ *   <li><b>Keystore configured</b> — the key loads, the JWK {@code kid} is the alias, and the key is
+ *       stable across two loads (simulating an app restart), which is what lets tokens survive a
+ *       restart.</li>
+ *   <li><b>No keystore</b> — an ephemeral key is generated with a random {@code kid} that differs on
+ *       each call (the pre-#105 dev/test/CI behavior).</li>
+ * </ul>
+ *
+ * <p>The test keystore is generated at runtime with {@code keytool} into a {@link TempDir}, so no
+ * keystore is committed to source control (consistent with the credential guidance in
+ * {@code doc/105-keystore-credentials.md}). The test is skipped if {@code keytool} is not present in
+ * the running JDK.
+ */
+class OAuthSigningKeyTest {
+
+    private static final String ALIAS = "requel-oauth-signing";
+    private static final String STORE_PASS = "changeit";
+
+    private final ResourceLoader resourceLoader = new DefaultResourceLoader();
+
+    // ---- keystore-configured path ---------------------------------------------------------------
+
+    @Test
+    void loadsKeyFromKeystoreWithAliasAsStableKid(@TempDir Path dir) throws Exception {
+        String location = generatePkcs12(dir).toUri().toString(); // file: resource
+
+        RSAKey key = AuthorizationServerConfig.buildSigningKey(
+                location, "PKCS12", STORE_PASS, ALIAS, STORE_PASS, resourceLoader);
+
+        assertThat(key.getKeyID()).isEqualTo(ALIAS);
+        assertThat(key.toRSAPrivateKey()).isNotNull();
+        assertThat(key.toRSAPublicKey().getModulus().bitLength()).isGreaterThanOrEqualTo(2048);
+    }
+
+    @Test
+    void keystoreKeyIsStableAcrossReloads(@TempDir Path dir) throws Exception {
+        String location = generatePkcs12(dir).toUri().toString();
+
+        RSAKey first = AuthorizationServerConfig.buildSigningKey(
+                location, "PKCS12", STORE_PASS, ALIAS, STORE_PASS, resourceLoader);
+        RSAKey second = AuthorizationServerConfig.buildSigningKey(
+                location, "PKCS12", STORE_PASS, ALIAS, STORE_PASS, resourceLoader);
+
+        // Two app starts against the same keystore: identical kid + public key, so a token signed
+        // before a restart still validates after it (issue #105 acceptance criterion).
+        assertThat(second.getKeyID()).isEqualTo(first.getKeyID());
+        assertThat(second.toRSAPublicKey().getModulus()).isEqualTo(first.toRSAPublicKey().getModulus());
+    }
+
+    @Test
+    void defaultsKeystoreTypeToPkcs12AndKeyPasswordToStorePassword(@TempDir Path dir) throws Exception {
+        String location = generatePkcs12(dir).toUri().toString();
+
+        // Blank storeType -> PKCS12; blank keyPassword -> falls back to the store password.
+        RSAKey key = AuthorizationServerConfig.buildSigningKey(
+                location, "", STORE_PASS, ALIAS, "", resourceLoader);
+
+        assertThat(key.getKeyID()).isEqualTo(ALIAS);
+        assertThat(key.toRSAPrivateKey()).isNotNull();
+    }
+
+    @Test
+    void keystoreLocationWithoutAliasFails(@TempDir Path dir) throws Exception {
+        String location = generatePkcs12(dir).toUri().toString();
+
+        assertThatThrownBy(() -> AuthorizationServerConfig.buildSigningKey(
+                location, "PKCS12", STORE_PASS, "", STORE_PASS, resourceLoader))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("key-alias");
+    }
+
+    @Test
+    void unknownAliasFails(@TempDir Path dir) throws Exception {
+        String location = generatePkcs12(dir).toUri().toString();
+
+        assertThatThrownBy(() -> AuthorizationServerConfig.buildSigningKey(
+                location, "PKCS12", STORE_PASS, "no-such-alias", STORE_PASS, resourceLoader))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void missingKeystoreFileFails() {
+        assertThatThrownBy(() -> AuthorizationServerConfig.buildSigningKey(
+                "file:/does/not/exist.p12", "PKCS12", STORE_PASS, ALIAS, STORE_PASS, resourceLoader))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Unable to load OAuth signing key");
+    }
+
+    // ---- ephemeral fallback path ----------------------------------------------------------------
+
+    @Test
+    void generatesEphemeralKeyWhenNoLocation() throws Exception {
+        RSAKey key = AuthorizationServerConfig.buildSigningKey(
+                "", "PKCS12", "", "", "", resourceLoader);
+
+        assertThat(key.toRSAPrivateKey()).isNotNull();
+        assertThat(key.toRSAPublicKey().getModulus().bitLength()).isGreaterThanOrEqualTo(2048);
+        assertThat(key.getKeyID()).isNotBlank();
+    }
+
+    @Test
+    void ephemeralKeysDifferBetweenCalls() {
+        RSAKey first = AuthorizationServerConfig.buildSigningKey(
+                null, null, null, null, null, resourceLoader);
+        RSAKey second = AuthorizationServerConfig.buildSigningKey(
+                null, null, null, null, null, resourceLoader);
+
+        // Each "restart" mints a new key -> different kid. This is exactly the caveat #105 removes.
+        assertThat(second.getKeyID()).isNotEqualTo(first.getKeyID());
+    }
+
+    // ---- helper: throwaway PKCS12 via keytool (nothing committed to source control) --------------
+
+    private static Path generatePkcs12(Path dir) throws Exception {
+        Path keytool = Paths.get(System.getProperty("java.home"), "bin",
+                isWindows() ? "keytool.exe" : "keytool");
+        assumeTrue(Files.isExecutable(keytool), "keytool not available in this JDK; skipping");
+
+        Path keystore = dir.resolve("oauth-signing.p12");
+        Process process = new ProcessBuilder(
+                keytool.toString(),
+                "-genkeypair",
+                "-alias", ALIAS,
+                "-keyalg", "RSA",
+                "-keysize", "2048",
+                "-dname", "CN=Requel OAuth Signing (test)",
+                "-validity", "3650",
+                "-keystore", keystore.toString(),
+                "-storetype", "PKCS12",
+                "-storepass", STORE_PASS,
+                "-keypass", STORE_PASS)
+                .redirectErrorStream(true)
+                .start();
+
+        boolean finished = process.waitFor(60, TimeUnit.SECONDS);
+        if (!finished) {
+            process.destroyForcibly();
+            throw new IllegalStateException("keytool timed out generating the test keystore");
+        }
+        if (process.exitValue() != 0 || !Files.exists(keystore)) {
+            String output = new String(process.getInputStream().readAllBytes());
+            throw new IllegalStateException("keytool failed to generate the test keystore:\n" + output);
+        }
+        return keystore;
+    }
+
+    private static boolean isWindows() {
+        return System.getProperty("os.name", "").toLowerCase().contains("win");
+    }
+}

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/config/AuthorizationServerConfig.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/config/AuthorizationServerConfig.java
@@ -31,6 +31,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.core.env.Environment;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -65,8 +68,14 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.GeneralSecurityException;
+import java.security.Key;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.net.URI;
@@ -247,23 +256,86 @@ public class AuthorizationServerConfig {
     /**
      * RSA signing key for issued JWTs.
      *
-     * <p><b>Slice 1 caveat:</b> this key is generated at startup, so it changes on every restart and
-     * previously-issued tokens stop validating after a restart. Fine for dev; the hardening
-     * follow-up (see plan "Out of scope / follow-ups") loads a persistent key from a configured
-     * keystore so tokens survive restarts.
+     * <p>When {@code requel.oauth.jwk.keystore.location} is set, the key pair is loaded from that
+     * keystore and the JWK {@code kid} is the (stable) key alias, so tokens issued before a restart
+     * keep validating afterwards and JWKS consumers can cache the key (issue #105). When the location
+     * is blank, the previous behavior is kept: a fresh key is generated at startup (ephemeral,
+     * dev/test/CI default) with a one-time warning. See {@code doc/105-keystore-credentials.md}.
+     *
+     * @see #buildSigningKey(String, String, String, String, String, ResourceLoader)
      */
     @Bean
     public JWKSource<SecurityContext> jwkSource() {
-        KeyPair keyPair = generateRsaKey();
-        RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
-        RSAPrivateKey privateKey = (RSAPrivateKey) keyPair.getPrivate();
-        RSAKey rsaKey = new RSAKey.Builder(publicKey)
-                .privateKey(privateKey)
-                .keyID(UUID.randomUUID().toString())
-                .build();
-        log.warn("OAuth AS signing key generated at startup (ephemeral). Tokens will not survive a "
-                + "restart; configure a persistent keystore before production (issue #83 hardening).");
+        RSAKey rsaKey = buildSigningKey(
+                environment.getProperty("requel.oauth.jwk.keystore.location", ""),
+                environment.getProperty("requel.oauth.jwk.keystore.type", "PKCS12"),
+                environment.getProperty("requel.oauth.jwk.keystore.password", ""),
+                environment.getProperty("requel.oauth.jwk.key-alias", ""),
+                environment.getProperty("requel.oauth.jwk.key-password", ""),
+                new DefaultResourceLoader());
         return new ImmutableJWKSet<>(new JWKSet(rsaKey));
+    }
+
+    /**
+     * Builds the RSA signing {@link RSAKey}. If {@code location} is blank, generates an ephemeral key
+     * (random {@code kid}) and logs the not-production warning. Otherwise loads the key pair from the
+     * keystore at {@code location} (a Spring {@code file:}/{@code classpath:} resource) and uses the
+     * key alias as a stable {@code kid}. The key password falls back to the store password when unset
+     * (common for PKCS12). Package-visible and parameterized so both paths can be unit-tested without
+     * booting the authorization server.
+     *
+     * @throws IllegalStateException if a location is set but the alias is missing, the keystore cannot
+     *         be read, or the aliased entry is not an RSA private key with a certificate.
+     */
+    static RSAKey buildSigningKey(String location, String storeType, String storePassword,
+            String keyAlias, String keyPassword, ResourceLoader resourceLoader) {
+        if (location == null || location.isBlank()) {
+            KeyPair keyPair = generateRsaKey();
+            RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
+            RSAPrivateKey privateKey = (RSAPrivateKey) keyPair.getPrivate();
+            log.warn("OAuth AS signing key generated at startup (ephemeral). Tokens will not survive a "
+                    + "restart; set requel.oauth.jwk.keystore.location to a persistent keystore before "
+                    + "production (issue #105).");
+            return new RSAKey.Builder(publicKey)
+                    .privateKey(privateKey)
+                    .keyID(UUID.randomUUID().toString())
+                    .build();
+        }
+        if (keyAlias == null || keyAlias.isBlank()) {
+            throw new IllegalStateException("requel.oauth.jwk.key-alias is required when "
+                    + "requel.oauth.jwk.keystore.location is set");
+        }
+        String type = (storeType == null || storeType.isBlank()) ? "PKCS12" : storeType;
+        char[] storePw = storePassword == null ? new char[0] : storePassword.toCharArray();
+        // The key password defaults to the store password when unset (PKCS12 typically shares them).
+        char[] keyPw = (keyPassword == null || keyPassword.isEmpty()) ? storePw : keyPassword.toCharArray();
+        Resource resource = resourceLoader.getResource(location);
+        try (InputStream in = resource.getInputStream()) {
+            KeyStore keyStore = KeyStore.getInstance(type);
+            keyStore.load(in, storePw);
+            Key key = keyStore.getKey(keyAlias, keyPw);
+            if (!(key instanceof RSAPrivateKey privateKey)) {
+                throw new IllegalStateException("Alias '" + keyAlias + "' in keystore '" + location
+                        + "' is not an RSA private key");
+            }
+            Certificate certificate = keyStore.getCertificate(keyAlias);
+            if (certificate == null) {
+                throw new IllegalStateException("No certificate for alias '" + keyAlias
+                        + "' in keystore '" + location + "'");
+            }
+            RSAPublicKey publicKey = (RSAPublicKey) certificate.getPublicKey();
+            // Stable kid == alias, so JWKS consumers can cache the key across restarts (issue #105).
+            RSAKey rsaKey = new RSAKey.Builder(publicKey)
+                    .privateKey(privateKey)
+                    .keyID(keyAlias)
+                    .build();
+            log.info("OAuth AS signing key loaded from keystore '{}' (type {}, alias '{}'); stable "
+                    + "kid, tokens survive restarts.", location, type, keyAlias);
+            return rsaKey;
+        } catch (IOException | GeneralSecurityException e) {
+            throw new IllegalStateException("Unable to load OAuth signing key from keystore '"
+                    + location + "' (alias '" + keyAlias + "')", e);
+        }
     }
 
     private static KeyPair generateRsaKey() {


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/105

Persistent OAuth AS signing key loaded from a configured keystore

The embedded OAuth 2.1 authorization server generated its RSA signing key fresh at every startup, so
the key was ephemeral: it changed on every restart and previously-issued access/refresh tokens
stopped validating. That is a hard blocker for the remote MCP connector (#100). This change loads a
persistent signing key from a configured keystore when one is provided, with the previous
generate-at-startup behavior kept as the fallback so dev/test/CI are unchanged and need no keystore.

modules/service-impl/.../config/AuthorizationServerConfig.java:
- jwkSource() now delegates to a new package-visible static buildSigningKey(location, storeType,
  storePassword, keyAlias, keyPassword, ResourceLoader). When requel.oauth.jwk.keystore.location is
  set it loads the RSA key pair from the keystore (PKCS12 default, JKS supported) via a Spring
  Resource (file:/classpath:) and builds the RSAKey with a STABLE kid equal to the key alias — so
  JWKS consumers can cache it and tokens survive restarts. When the location is blank it keeps the
  ephemeral generate-at-startup key (random kid) and the existing not-production warning.
- New config read via Environment, matching the existing requel.oauth.* convention:
  requel.oauth.jwk.keystore.location / .type / .password, requel.oauth.jwk.key-alias, and
  requel.oauth.jwk.key-password (key password defaults to the store password when unset). Password
  env var is REQUEL_OAUTH_JWK_KEYSTORE_PASSWORD via relaxed binding.
- Fails fast with IllegalStateException when a location is set without an alias, the keystore cannot
  be read, or the aliased entry is not an RSA private key with a certificate.

modules/requel-app/src/test/.../config/OAuthSigningKeyTest.java (new):
- Covers the keystore path (key loads, kid == alias, key stable across two loads simulating a
  restart, type/key-password defaulting) and the fallback path (ephemeral key present, random kid,
  differs between calls), plus error cases (missing alias, unknown alias, missing file). The test
  keystore is generated at runtime with keytool into a @TempDir, so nothing is committed to source
  control; the test is skipped when keytool is absent.

doc/105-keystore-credentials.md (new):
- Documents the requel.oauth.jwk.* configuration, the keytool generation command, deployment/Docker
  wiring, why the private key is not stored directly in the OS keychain, and per-OS instructions for
  sourcing REQUEL_OAUTH_JWK_KEYSTORE_PASSWORD from the macOS Keychain, Linux Secret Service, and
  Windows Credential Manager, plus the headless/Docker fallback.

Closes #105
