### PR TITLE
Wire optimistic-lock version through all Edit* commands (#108)

### DIFF
--- a/doc/108-edit-optlock-plan.md
+++ b/doc/108-edit-optlock-plan.md
@@ -1,0 +1,33 @@
+Scope expansion for #108: wire the caller-supplied optimistic-lock `version` through **every** `Edit*` command whose input DTO already declares a `version` field, not just `EditGoal`.
+
+`EditGoal` is done and its tests pass. The pattern it establishes: on an update, reload the persisted entity, compare the caller's `version` to the persisted version, and throw `EntityLockException.staleEntity(...)` on a mismatch (a stale update fails cleanly instead of silently overwriting). Conflict surfacing needs no new code — `CommandController` already maps `EntityException` / `OptimisticLockException` to **HTTP 409**. `create` (no id / no existing entity) is never version-checked.
+
+## Commands to update (10 total)
+
+**Shared hierarchy** — interface `EditProjectOrDomainEntityCommand`, impl base `AbstractEditProjectOrDomainEntityCommand`. Add `setExpectedVersion(Integer)` to the interface once and a `checkExpectedVersion(entity)` helper to the base once; each command calls the helper in `execute()` and gets wired in the registrar.
+
+1. ✅ `EditGoal` — `EditGoalInput.goalId` (done; will be refactored onto the shared helper)
+2. `EditActor` — `EditActorInput.actorId`
+3. `EditStory` — `EditStoryInput.storyId`
+4. `EditUseCase` — `EditUseCaseInput.useCaseId`
+5. `EditScenario` — `EditScenarioInput.scenarioId` (lock check on the top-level scenario; nested step DTOs are out of scope)
+6. `EditNonUserStakeholder` — `EditNonUserStakeholderInput.stakeholderId`
+7. `EditUserStakeholder` — `EditUserStakeholderInput` (resolved by project + username; no id)
+
+**Separate hierarchies** — no shared base; add the setter to each interface and the field + check to each impl individually.
+
+8. `EditGoalRelation` — `EditGoalRelationInput` (from/to goal names; impl extends `AbstractProjectCommand`)
+9. `EditProject` — `EditProjectInput.projectName` (aggregate root; `EditProjectCommand` in project-domain / project-jpa)
+10. `EditUser` — `EditUserInput.username` (user-domain / user-jpa)
+
+## Approach
+
+- Interface: `setExpectedVersion(Integer)`; non-null on an update triggers the check, null (or create) skips it.
+- Impl: reload the entity, throw `EntityLockException.staleEntity(entityType, entity, Updating)` when `expectedVersion != persistedVersion`.
+- Registrar wiring: call `c.setExpectedVersion(i.version())` on the **edit** branch only, in `ProjectCommandRegistrar` and `UserCommandRegistrar`.
+- `EditUserStakeholder` and `EditGoalRelation` have no id field in their input; the registrar already uses `version != null` as the "this is an edit" signal to resolve the existing entity by natural key. Keep that gate (to preserve create-vs-edit semantics) and simply add the lock check inside it. (Considered fully decoupling `version` from the edit signal, but that would turn a create against an existing natural key from a uniqueness conflict into a silent upsert — out of scope for this ticket.)
+- Tests (mirror `GoalCommandTest`): per command — stale-version update rejected, matching-version update succeeds, create ignores `version`.
+
+## Known limitation
+
+The check compares the caller's `version` against the freshly-loaded persisted version at command time (a small lock window), matching the `EditGoal` v1 approach — not full end-to-end JPA `@Version` propagation into the persistence context. Acceptable for v1; noted for a future hardening ticket if needed.

--- a/modules/project-domain/src/main/java/com/rreganjr/requel/project/command/EditGoalCommand.java
+++ b/modules/project-domain/src/main/java/com/rreganjr/requel/project/command/EditGoalCommand.java
@@ -44,7 +44,7 @@ public interface EditGoalCommand extends EditTextEntityCommand {
 
 	/**
 	 * Set the container this goal is being added to.
-	 * 
+	 *
 	 * @param goalContainer
 	 */
 	public void setGoalContainer(GoalContainer goalContainer);

--- a/modules/project-domain/src/main/java/com/rreganjr/requel/project/command/EditGoalRelationCommand.java
+++ b/modules/project-domain/src/main/java/com/rreganjr/requel/project/command/EditGoalRelationCommand.java
@@ -66,4 +66,17 @@ public interface EditGoalRelationCommand extends AnalyzableEditCommand {
 	 *            the name of the type of relationship between the goals
 	 */
 	public void setRelationType(String relationTypeName);
+
+	/**
+	 * Set the caller-supplied optimistic-lock version expected for the goal relation
+	 * being edited. When non-null on an update, the command compares it against the
+	 * relation's currently persisted version and fails with an
+	 * {@link com.rreganjr.platform.exception.EntityLockException} if it has changed
+	 * since the caller loaded it. A {@code null} value (or a create) skips the check.
+	 * See issue #108.
+	 *
+	 * @param expectedVersion the version the caller believes is current, or
+	 *        {@code null} to skip the optimistic-lock check
+	 */
+	public void setExpectedVersion(Integer expectedVersion);
 }

--- a/modules/project-domain/src/main/java/com/rreganjr/requel/project/command/EditProjectCommand.java
+++ b/modules/project-domain/src/main/java/com/rreganjr/requel/project/command/EditProjectCommand.java
@@ -64,4 +64,17 @@ public interface EditProjectCommand extends AnalyzableEditCommand, ProjectScoped
 	 * @return
 	 */
 	public Project getProject();
+
+	/**
+	 * Set the caller-supplied optimistic-lock version expected for the project being
+	 * edited. When non-null on an update, the command compares it against the
+	 * project's currently persisted version and fails with an
+	 * {@link com.rreganjr.platform.exception.EntityLockException} if it has changed
+	 * since the caller loaded it. A {@code null} value (or a create) skips the check.
+	 * See issue #108.
+	 *
+	 * @param expectedVersion the version the caller believes is current, or
+	 *        {@code null} to skip the optimistic-lock check
+	 */
+	public void setExpectedVersion(Integer expectedVersion);
 }

--- a/modules/project-domain/src/main/java/com/rreganjr/requel/project/command/EditProjectOrDomainEntityCommand.java
+++ b/modules/project-domain/src/main/java/com/rreganjr/requel/project/command/EditProjectOrDomainEntityCommand.java
@@ -50,4 +50,18 @@ public interface EditProjectOrDomainEntityCommand extends AnalyzableEditCommand 
 	 * @param name
 	 */
 	public void setName(String name);
+
+	/**
+	 * Set the caller-supplied optimistic-lock version expected for the entity being
+	 * edited. When non-null on an update, the command compares it against the
+	 * entity's currently persisted version and fails with an
+	 * {@link com.rreganjr.platform.exception.EntityLockException} if the entity has
+	 * changed since the caller loaded it, rather than silently overwriting the
+	 * concurrent edit. A {@code null} value (or a create, where no entity is
+	 * resolved) skips the check. See issue #108.
+	 *
+	 * @param expectedVersion the version the caller believes is current, or
+	 *        {@code null} to skip the optimistic-lock check
+	 */
+	public void setExpectedVersion(Integer expectedVersion);
 }

--- a/modules/project-jpa/src/main/java/com/rreganjr/requel/project/impl/command/AbstractEditProjectOrDomainEntityCommand.java
+++ b/modules/project-jpa/src/main/java/com/rreganjr/requel/project/impl/command/AbstractEditProjectOrDomainEntityCommand.java
@@ -21,8 +21,11 @@
 package com.rreganjr.requel.project.impl.command;
 
 import com.rreganjr.command.CommandHandler;
+import com.rreganjr.platform.exception.EntityExceptionActionType;
+import com.rreganjr.platform.exception.EntityLockException;
 import com.rreganjr.requel.annotation.command.AnnotationCommandFactory;
 import com.rreganjr.requel.project.ProjectOrDomain;
+import com.rreganjr.requel.project.ProjectOrDomainEntity;
 import com.rreganjr.requel.project.ProjectRepository;
 import com.rreganjr.requel.project.command.EditProjectOrDomainEntityCommand;
 import com.rreganjr.requel.project.command.ProjectCommandFactory;
@@ -38,6 +41,7 @@ public abstract class AbstractEditProjectOrDomainEntityCommand extends AbstractE
 	private ProjectOrDomain projectOrDomain;
 	private boolean analysisEnabled = true;
 	private String name;
+	private Integer expectedVersion;
 
 	/**
 	 * @param assistantManager
@@ -84,5 +88,40 @@ public abstract class AbstractEditProjectOrDomainEntityCommand extends AbstractE
 
 	protected String getName() {
 		return name;
+	}
+
+	@Override
+	public void setExpectedVersion(Integer expectedVersion) {
+		this.expectedVersion = expectedVersion;
+	}
+
+	protected Integer getExpectedVersion() {
+		return expectedVersion;
+	}
+
+	/**
+	 * Reload {@code entity} to obtain its authoritative persisted version and enforce
+	 * the caller-supplied optimistic-lock version (issue #108). When the caller's
+	 * {@link #getExpectedVersion() expected version} is non-null and does not match the
+	 * persisted version, the entity changed since the caller loaded it, so this fails
+	 * with an {@link EntityLockException} instead of silently overwriting the concurrent
+	 * edit. A {@code null} expected version, or a {@code null} entity (a create), skips
+	 * the check.
+	 *
+	 * @param entity the entity being updated (typically just resolved by the registrar)
+	 * @return the reloaded, persistence-attached instance for the caller to mutate
+	 * @throws EntityLockException if the expected version does not match the persisted one
+	 */
+	protected <T extends ProjectOrDomainEntity> T checkExpectedVersion(T entity) {
+		if (entity == null) {
+			return entity;
+		}
+		T current = getProjectRepository().get(entity);
+		if (getExpectedVersion() != null && current != null
+				&& getExpectedVersion().intValue() != current.getVersion()) {
+			throw EntityLockException.staleEntity(current.getClass(), current,
+					EntityExceptionActionType.Updating);
+		}
+		return current;
 	}
 }

--- a/modules/project-jpa/src/main/java/com/rreganjr/requel/project/impl/command/EditActorCommandImpl.java
+++ b/modules/project-jpa/src/main/java/com/rreganjr/requel/project/impl/command/EditActorCommandImpl.java
@@ -169,6 +169,9 @@ public class EditActorCommandImpl extends AbstractEditProjectOrDomainEntityComma
 		} catch (NoSuchEntityException e) {
 		}
 
+		// Enforce the caller-supplied optimistic-lock version on update (issue #108).
+		actorImpl = checkExpectedVersion(actorImpl);
+
 		if (actorImpl == null) {
 			actorImpl = getProjectRepository().persist(
 					new ActorImpl(projectOrDomain, editedBy, getName(), ""));

--- a/modules/project-jpa/src/main/java/com/rreganjr/requel/project/impl/command/EditGoalCommandImpl.java
+++ b/modules/project-jpa/src/main/java/com/rreganjr/requel/project/impl/command/EditGoalCommandImpl.java
@@ -138,6 +138,9 @@ public class EditGoalCommandImpl extends AbstractEditProjectOrDomainEntityComman
 			goalImpl = getProjectRepository().persist(
 					new GoalImpl(projectOrDomain, editedBy, getName(), getText()));
 		} else {
+			// Enforce the caller-supplied optimistic-lock version (issue #108); reloads the
+			// goal and fails cleanly if it changed since the caller loaded it.
+			goalImpl = checkExpectedVersion(goalImpl);
 			goalImpl.setName(getName());
 			goalImpl.setText(getText());
 		}

--- a/modules/project-jpa/src/main/java/com/rreganjr/requel/project/impl/command/EditGoalRelationCommandImpl.java
+++ b/modules/project-jpa/src/main/java/com/rreganjr/requel/project/impl/command/EditGoalRelationCommandImpl.java
@@ -40,6 +40,8 @@ import com.rreganjr.platform.command.AuthorizationRequirement;
 import com.rreganjr.platform.command.AuthorizationRequirement.RequiresStakeholderPermission;
 import com.rreganjr.requel.project.command.EditGoalRelationCommand;
 import com.rreganjr.requel.project.command.ProjectCommandFactory;
+import com.rreganjr.platform.exception.EntityExceptionActionType;
+import com.rreganjr.platform.exception.EntityLockException;
 import com.rreganjr.requel.project.exception.GoalSelfRelationException;
 import com.rreganjr.requel.project.impl.GoalRelationImpl;
 import com.rreganjr.requel.project.impl.assistant.AssistantFacade;
@@ -66,6 +68,7 @@ public class EditGoalRelationCommandImpl extends AbstractProjectCommand implemen
 	private String relationTypeName;
 	private User editedBy;
 	private boolean analysisEnabled = true;
+	private Integer expectedVersion;
 
 	/**
 	 * @param assistantManager
@@ -155,6 +158,15 @@ public class EditGoalRelationCommandImpl extends AbstractProjectCommand implemen
 		return editedBy;
 	}
 
+	@Override
+	public void setExpectedVersion(Integer expectedVersion) {
+		this.expectedVersion = expectedVersion;
+	}
+
+	protected Integer getExpectedVersion() {
+		return expectedVersion;
+	}
+
 	/**
 	 * @see com.rreganjr.command.Command#execute()
 	 */
@@ -184,6 +196,12 @@ public class EditGoalRelationCommandImpl extends AbstractProjectCommand implemen
 					new GoalRelationImpl(fromGoal, toGoal, goalRelationType, editedBy));
 		} else {
 			goalRelationImpl = (GoalRelationImpl) getRepository().get(goalRelationImpl);
+			// Enforce the caller-supplied optimistic-lock version on update (issue #108).
+			if (getExpectedVersion() != null
+					&& getExpectedVersion().intValue() != goalRelationImpl.getVersion()) {
+				throw EntityLockException.staleEntity(GoalRelation.class, goalRelationImpl,
+						EntityExceptionActionType.Updating);
+			}
 			goalRelationImpl.setFromGoal(fromGoal);
 			goalRelationImpl.setToGoal(toGoal);
 			goalRelationImpl.setRelationType(goalRelationType);

--- a/modules/project-jpa/src/main/java/com/rreganjr/requel/project/impl/command/EditNonUserStakeholderCommandImpl.java
+++ b/modules/project-jpa/src/main/java/com/rreganjr/requel/project/impl/command/EditNonUserStakeholderCommandImpl.java
@@ -118,6 +118,8 @@ public class EditNonUserStakeholderCommandImpl extends AbstractEditProjectOrDoma
 		} catch (NoSuchEntityException e) {
 		}
 
+		// Enforce the caller-supplied optimistic-lock version on update (issue #108).
+		stakeholderImpl = checkExpectedVersion(stakeholderImpl);
 
 		if (stakeholderImpl == null) {
 			stakeholderImpl = getProjectRepository().persist(

--- a/modules/project-jpa/src/main/java/com/rreganjr/requel/project/impl/command/EditProjectCommandImpl.java
+++ b/modules/project-jpa/src/main/java/com/rreganjr/requel/project/impl/command/EditProjectCommandImpl.java
@@ -33,6 +33,7 @@ import com.rreganjr.platform.command.AuthorizationRequirement;
 import com.rreganjr.platform.command.AuthorizationRequirement.RequiresStakeholderPermission;
 import com.rreganjr.platform.exception.EntityException;
 import com.rreganjr.platform.exception.EntityExceptionActionType;
+import com.rreganjr.platform.exception.EntityLockException;
 import com.rreganjr.platform.exception.NoSuchEntityException;
 import com.rreganjr.requel.annotation.command.AnnotationCommandFactory;
 import com.rreganjr.requel.project.Project;
@@ -68,6 +69,7 @@ public class EditProjectCommandImpl extends AbstractEditProjectCommand implement
 	private String organizationName;
 	private Project project;
 	private boolean analysisEnabled = true;
+	private Integer expectedVersion;
 
 	/**
 	 * @param assistantManager
@@ -127,6 +129,15 @@ public class EditProjectCommandImpl extends AbstractEditProjectCommand implement
 	}
 
 	@Override
+	public void setExpectedVersion(Integer expectedVersion) {
+		this.expectedVersion = expectedVersion;
+	}
+
+	protected Integer getExpectedVersion() {
+		return expectedVersion;
+	}
+
+	@Override
 	public void execute() {
 		Organization organization = resolveOrganization();
 		User user = getUserRepository().get(getEditedBy());
@@ -148,6 +159,13 @@ public class EditProjectCommandImpl extends AbstractEditProjectCommand implement
 		if (projectImpl == null) {
 			projectImpl = createProject(organization, user);
 		} else {
+			// Enforce the caller-supplied optimistic-lock version on update (issue #108).
+			projectImpl = getRepository().get(projectImpl);
+			if (getExpectedVersion() != null
+					&& getExpectedVersion().intValue() != projectImpl.getVersion()) {
+				throw EntityLockException.staleEntity(Project.class, projectImpl,
+						EntityExceptionActionType.Updating);
+			}
 			projectImpl.setName(getName());
 			projectImpl.setOrganization(organization);
 		}

--- a/modules/project-jpa/src/main/java/com/rreganjr/requel/project/impl/command/EditScenarioCommandImpl.java
+++ b/modules/project-jpa/src/main/java/com/rreganjr/requel/project/impl/command/EditScenarioCommandImpl.java
@@ -118,6 +118,9 @@ public class EditScenarioCommandImpl extends EditScenarioStepCommandImpl impleme
 		} catch (NoSuchEntityException e) {
 		}
 
+		// Enforce the caller-supplied optimistic-lock version on update (issue #108).
+		scenarioImpl = checkExpectedVersion(scenarioImpl);
+
 		if (scenarioImpl == null) {
 			scenarioImpl = getProjectRepository().persist(
 					new ScenarioImpl(projectOrDomain, editedBy, getName(), getText(),

--- a/modules/project-jpa/src/main/java/com/rreganjr/requel/project/impl/command/EditStoryCommandImpl.java
+++ b/modules/project-jpa/src/main/java/com/rreganjr/requel/project/impl/command/EditStoryCommandImpl.java
@@ -164,6 +164,9 @@ public class EditStoryCommandImpl extends AbstractEditProjectOrDomainEntityComma
 		} catch (NoSuchEntityException e) {
 		}
 
+		// Enforce the caller-supplied optimistic-lock version on update (issue #108).
+		storyImpl = checkExpectedVersion(storyImpl);
+
 		// Resolve the primary actor before any persistence calls
 		Actor resolvedPrimaryActor = null;
 		if (getPrimaryActorName() != null && !getPrimaryActorName().trim().isEmpty()) {

--- a/modules/project-jpa/src/main/java/com/rreganjr/requel/project/impl/command/EditUseCaseCommandImpl.java
+++ b/modules/project-jpa/src/main/java/com/rreganjr/requel/project/impl/command/EditUseCaseCommandImpl.java
@@ -143,6 +143,9 @@ public class EditUseCaseCommandImpl extends AbstractEditProjectOrDomainEntityCom
 			}
 		}
 
+		// Enforce the caller-supplied optimistic-lock version on update (issue #108).
+		usecaseImpl = checkExpectedVersion(usecaseImpl);
+
 		Actor primaryActor = null;
 		if (getPrimaryActorName() != null && !getPrimaryActorName().trim().isEmpty()) {
 			try {

--- a/modules/project-jpa/src/main/java/com/rreganjr/requel/project/impl/command/EditUserStakeholderCommandImpl.java
+++ b/modules/project-jpa/src/main/java/com/rreganjr/requel/project/impl/command/EditUserStakeholderCommandImpl.java
@@ -138,6 +138,9 @@ public class EditUserStakeholderCommandImpl extends AbstractEditProjectOrDomainE
 		} catch (NoSuchEntityException e) {
 		}
 
+		// Enforce the caller-supplied optimistic-lock version on update (issue #108).
+		stakeholderImpl = checkExpectedVersion(stakeholderImpl);
+
 		ProjectTeam oldTeam = null;
 		ProjectTeam newTeam = null;
 		if (stakeholderImpl != null) {

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/project/impl/command/ActorCommandTest.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/project/impl/command/ActorCommandTest.java
@@ -22,6 +22,7 @@ package com.rreganjr.requel.project.impl.command;
 
 import com.rreganjr.AbstractIntegrationTestCase;
 import com.rreganjr.platform.exception.EntityException;
+import com.rreganjr.platform.exception.EntityLockException;
 import com.rreganjr.platform.exception.NoSuchEntityException;
 import com.rreganjr.requel.project.Actor;
 import com.rreganjr.requel.project.Project;
@@ -106,6 +107,64 @@ public class ActorCommandTest extends AbstractIntegrationTestCase {
 		assertEquals("Project User", updated.getName(), "name should be unchanged");
 		assertEquals("Creates requirements and participates in project discussions.",
 				updated.getText(), "text should have been updated");
+	}
+
+	@Test
+	public void editActorWithMatchingVersionSucceeds() throws Exception {
+		Project project = createProject("Actor-version-ok");
+		User admin = getUserRepository().findUserByUsername("admin");
+
+		EditActorCommand createCmd = getProjectCommandFactory().newEditActorCommand();
+		createCmd.setEditedBy(admin);
+		createCmd.setActorContainer(project);
+		createCmd.setName("Versioned actor");
+		createCmd.setText("Initial text.");
+		createCmd = getCommandHandler().execute(createCmd);
+		Actor original = createCmd.getActor();
+
+		EditActorCommand editCmd = getProjectCommandFactory().newEditActorCommand();
+		editCmd.setEditedBy(admin);
+		editCmd.setActor(original);
+		editCmd.setName("Versioned actor");
+		editCmd.setText("Updated with the current version.");
+		editCmd.setExpectedVersion(original.getVersion());
+		editCmd = getCommandHandler().execute(editCmd);
+
+		assertEquals("Updated with the current version.", editCmd.getActor().getText(),
+				"matching-version update should be applied");
+	}
+
+	@Test
+	public void editActorWithStaleVersionIsRejected() throws Exception {
+		Project project = createProject("Actor-version-stale");
+		User admin = getUserRepository().findUserByUsername("admin");
+
+		EditActorCommand createCmd = getProjectCommandFactory().newEditActorCommand();
+		createCmd.setEditedBy(admin);
+		createCmd.setActorContainer(project);
+		createCmd.setName("Contested actor");
+		createCmd.setText("Initial text.");
+		createCmd = getCommandHandler().execute(createCmd);
+		Actor original = createCmd.getActor();
+		int staleVersion = original.getVersion();
+
+		EditActorCommand firstEdit = getProjectCommandFactory().newEditActorCommand();
+		firstEdit.setEditedBy(admin);
+		firstEdit.setActor(original);
+		firstEdit.setName("Contested actor");
+		firstEdit.setText("First writer's change.");
+		firstEdit.setExpectedVersion(staleVersion);
+		getCommandHandler().execute(firstEdit);
+
+		assertThrows(EntityLockException.class, () -> {
+			EditActorCommand staleEdit = getProjectCommandFactory().newEditActorCommand();
+			staleEdit.setEditedBy(admin);
+			staleEdit.setActor(original);
+			staleEdit.setName("Contested actor");
+			staleEdit.setText("Second writer's stale change.");
+			staleEdit.setExpectedVersion(staleVersion);
+			getCommandHandler().execute(staleEdit);
+		}, "an update carrying a stale version should be rejected");
 	}
 
 	@Test

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/project/impl/command/EditProjectCommandImplTest.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/project/impl/command/EditProjectCommandImplTest.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import com.rreganjr.AbstractIntegrationTestCase;
 import com.rreganjr.platform.exception.EntityException;
+import com.rreganjr.platform.exception.EntityLockException;
 import com.rreganjr.requel.project.Project;
 import com.rreganjr.requel.project.ProjectUserRole;
 import com.rreganjr.requel.project.Stakeholder;
@@ -118,6 +119,55 @@ public class EditProjectCommandImplTest extends AbstractIntegrationTestCase {
 		assertEquals(updated.getId(),
 				getProjectRepository().findProjectByName(updated.getName()).getId(),
 				"updated project should be reloadable by its new name");
+	}
+
+	@Test
+	public void editProjectWithMatchingVersionSucceeds() throws Exception {
+		Project original = createProject("Version OK Project");
+		User admin = ensureProjectCapableAdmin();
+		String name = original.getName();
+		String org = original.getOrganization().getName();
+
+		EditProjectCommand command = getProjectCommandFactory().newEditProjectCommand();
+		command.setEditedBy(admin);
+		command.setProject(original);
+		command.setName(name);
+		command.setText("Updated with the current version");
+		command.setOrganizationName(org);
+		command.setExpectedVersion(original.getVersion());
+		command = getCommandHandler().execute(command);
+
+		assertEquals("Updated with the current version", command.getProject().getText(),
+				"matching-version update should be applied");
+	}
+
+	@Test
+	public void editProjectWithStaleVersionIsRejected() throws Exception {
+		Project original = createProject("Version Stale Project");
+		User admin = ensureProjectCapableAdmin();
+		String name = original.getName();
+		String org = original.getOrganization().getName();
+		int staleVersion = original.getVersion();
+
+		EditProjectCommand firstEdit = getProjectCommandFactory().newEditProjectCommand();
+		firstEdit.setEditedBy(admin);
+		firstEdit.setProject(original);
+		firstEdit.setName(name);
+		firstEdit.setText("First writer's change");
+		firstEdit.setOrganizationName(org);
+		firstEdit.setExpectedVersion(staleVersion);
+		getCommandHandler().execute(firstEdit);
+
+		assertThrows(EntityLockException.class, () -> {
+			EditProjectCommand staleEdit = getProjectCommandFactory().newEditProjectCommand();
+			staleEdit.setEditedBy(admin);
+			staleEdit.setProject(original);
+			staleEdit.setName(name);
+			staleEdit.setText("Second writer's stale change");
+			staleEdit.setOrganizationName(org);
+			staleEdit.setExpectedVersion(staleVersion);
+			getCommandHandler().execute(staleEdit);
+		}, "an update carrying a stale version should be rejected");
 	}
 
 	@Test

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/project/impl/command/GoalCommandTest.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/project/impl/command/GoalCommandTest.java
@@ -22,6 +22,7 @@ package com.rreganjr.requel.project.impl.command;
 
 import com.rreganjr.AbstractIntegrationTestCase;
 import com.rreganjr.platform.exception.EntityException;
+import com.rreganjr.platform.exception.EntityLockException;
 import com.rreganjr.platform.exception.NoSuchEntityException;
 import com.rreganjr.requel.project.Goal;
 import com.rreganjr.requel.project.Project;
@@ -128,6 +129,82 @@ public class GoalCommandTest extends AbstractIntegrationTestCase {
 			dup.setText("Duplicate definition.");
 			getCommandHandler().execute(dup);
 		}, "duplicate goal name on the same project should be rejected");
+	}
+
+	@Test
+	public void editGoalWithMatchingVersionSucceeds() throws Exception {
+		Project project = createProject("Goal-version-ok");
+		User admin = getUserRepository().findUserByUsername("admin");
+
+		EditGoalCommand createCmd = getProjectCommandFactory().newEditGoalCommand();
+		createCmd.setEditedBy(admin);
+		createCmd.setGoalContainer(project);
+		createCmd.setName("Versioned goal");
+		createCmd.setText("Initial text.");
+		createCmd = getCommandHandler().execute(createCmd);
+		Goal original = createCmd.getGoal();
+
+		EditGoalCommand editCmd = getProjectCommandFactory().newEditGoalCommand();
+		editCmd.setEditedBy(admin);
+		editCmd.setGoal(original);
+		editCmd.setName("Versioned goal");
+		editCmd.setText("Updated with the current version.");
+		editCmd.setExpectedVersion(original.getVersion());
+		editCmd = getCommandHandler().execute(editCmd);
+
+		assertEquals("Updated with the current version.", editCmd.getGoal().getText(),
+				"matching-version update should be applied");
+	}
+
+	@Test
+	public void editGoalWithStaleVersionIsRejected() throws Exception {
+		Project project = createProject("Goal-version-stale");
+		User admin = getUserRepository().findUserByUsername("admin");
+
+		EditGoalCommand createCmd = getProjectCommandFactory().newEditGoalCommand();
+		createCmd.setEditedBy(admin);
+		createCmd.setGoalContainer(project);
+		createCmd.setName("Contested goal");
+		createCmd.setText("Initial text.");
+		createCmd = getCommandHandler().execute(createCmd);
+		Goal original = createCmd.getGoal();
+		int staleVersion = original.getVersion();
+
+		// First writer wins — this bumps the persisted version past staleVersion.
+		EditGoalCommand firstEdit = getProjectCommandFactory().newEditGoalCommand();
+		firstEdit.setEditedBy(admin);
+		firstEdit.setGoal(original);
+		firstEdit.setName("Contested goal");
+		firstEdit.setText("First writer's change.");
+		firstEdit.setExpectedVersion(staleVersion);
+		getCommandHandler().execute(firstEdit);
+
+		// Second writer submits the now-stale version and must be rejected.
+		assertThrows(EntityLockException.class, () -> {
+			EditGoalCommand staleEdit = getProjectCommandFactory().newEditGoalCommand();
+			staleEdit.setEditedBy(admin);
+			staleEdit.setGoal(original);
+			staleEdit.setName("Contested goal");
+			staleEdit.setText("Second writer's stale change.");
+			staleEdit.setExpectedVersion(staleVersion);
+			getCommandHandler().execute(staleEdit);
+		}, "an update carrying a stale version should be rejected");
+	}
+
+	@Test
+	public void createGoalIgnoresExpectedVersion() throws Exception {
+		Project project = createProject("Goal-version-create");
+		User admin = getUserRepository().findUserByUsername("admin");
+
+		EditGoalCommand cmd = getProjectCommandFactory().newEditGoalCommand();
+		cmd.setEditedBy(admin);
+		cmd.setGoalContainer(project);
+		cmd.setName("Create ignores version");
+		cmd.setText("A create carries no goal id, so the version is not checked.");
+		cmd.setExpectedVersion(99);
+		cmd = getCommandHandler().execute(cmd);
+
+		assertNotNull(cmd.getGoal(), "create should succeed regardless of expectedVersion");
 	}
 
 	// -------------------------------------------------------------------------

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/project/impl/command/GoalRelationCommandTest.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/project/impl/command/GoalRelationCommandTest.java
@@ -21,6 +21,7 @@
 package com.rreganjr.requel.project.impl.command;
 
 import com.rreganjr.AbstractIntegrationTestCase;
+import com.rreganjr.platform.exception.EntityLockException;
 import com.rreganjr.requel.project.Goal;
 import com.rreganjr.requel.project.GoalRelation;
 import com.rreganjr.requel.project.GoalRelationType;
@@ -150,6 +151,76 @@ public class GoalRelationCommandTest extends AbstractIntegrationTestCase {
 		GoalRelation updated = editCmd.getGoalRelation();
 		assertEquals(GoalRelationType.Conflicts, updated.getRelationType(),
 				"relation type should have been changed to Conflicts");
+	}
+
+	@Test
+	public void editGoalRelationWithMatchingVersionSucceeds() throws Exception {
+		Project project = createProject("GoalRelation-version-ok");
+		User admin = getUserRepository().findUserByUsername("admin");
+		createGoal(project, "Version from goal");
+		createGoal(project, "Version to goal");
+
+		EditGoalRelationCommand createCmd = getProjectCommandFactory().newEditGoalRelationCommand();
+		createCmd.setEditedBy(admin);
+		createCmd.setProjectOrDomain(project);
+		createCmd.setFromGoal("Version from goal");
+		createCmd.setToGoal("Version to goal");
+		createCmd.setRelationType(GoalRelationType.Supports.name());
+		createCmd = getCommandHandler().execute(createCmd);
+		GoalRelation original = createCmd.getGoalRelation();
+
+		EditGoalRelationCommand editCmd = getProjectCommandFactory().newEditGoalRelationCommand();
+		editCmd.setEditedBy(admin);
+		editCmd.setProjectOrDomain(project);
+		editCmd.setGoalRelation(original);
+		editCmd.setFromGoal("Version from goal");
+		editCmd.setToGoal("Version to goal");
+		editCmd.setRelationType(GoalRelationType.Conflicts.name());
+		editCmd.setExpectedVersion(original.getVersion());
+		editCmd = getCommandHandler().execute(editCmd);
+
+		assertEquals(GoalRelationType.Conflicts, editCmd.getGoalRelation().getRelationType(),
+				"matching-version update should be applied");
+	}
+
+	@Test
+	public void editGoalRelationWithStaleVersionIsRejected() throws Exception {
+		Project project = createProject("GoalRelation-version-stale");
+		User admin = getUserRepository().findUserByUsername("admin");
+		createGoal(project, "Contested from goal");
+		createGoal(project, "Contested to goal");
+
+		EditGoalRelationCommand createCmd = getProjectCommandFactory().newEditGoalRelationCommand();
+		createCmd.setEditedBy(admin);
+		createCmd.setProjectOrDomain(project);
+		createCmd.setFromGoal("Contested from goal");
+		createCmd.setToGoal("Contested to goal");
+		createCmd.setRelationType(GoalRelationType.Supports.name());
+		createCmd = getCommandHandler().execute(createCmd);
+		GoalRelation original = createCmd.getGoalRelation();
+		int staleVersion = original.getVersion();
+
+		EditGoalRelationCommand firstEdit = getProjectCommandFactory().newEditGoalRelationCommand();
+		firstEdit.setEditedBy(admin);
+		firstEdit.setProjectOrDomain(project);
+		firstEdit.setGoalRelation(original);
+		firstEdit.setFromGoal("Contested from goal");
+		firstEdit.setToGoal("Contested to goal");
+		firstEdit.setRelationType(GoalRelationType.Conflicts.name());
+		firstEdit.setExpectedVersion(staleVersion);
+		getCommandHandler().execute(firstEdit);
+
+		assertThrows(EntityLockException.class, () -> {
+			EditGoalRelationCommand staleEdit = getProjectCommandFactory().newEditGoalRelationCommand();
+			staleEdit.setEditedBy(admin);
+			staleEdit.setProjectOrDomain(project);
+			staleEdit.setGoalRelation(original);
+			staleEdit.setFromGoal("Contested from goal");
+			staleEdit.setToGoal("Contested to goal");
+			staleEdit.setRelationType(GoalRelationType.Supports.name());
+			staleEdit.setExpectedVersion(staleVersion);
+			getCommandHandler().execute(staleEdit);
+		}, "an update carrying a stale version should be rejected");
 	}
 
 	@Test

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/project/impl/command/ScenarioCommandTest.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/project/impl/command/ScenarioCommandTest.java
@@ -22,6 +22,7 @@ package com.rreganjr.requel.project.impl.command;
 
 import com.rreganjr.AbstractIntegrationTestCase;
 import com.rreganjr.platform.exception.EntityException;
+import com.rreganjr.platform.exception.EntityLockException;
 import com.rreganjr.platform.exception.NoSuchEntityException;
 import com.rreganjr.requel.project.Project;
 import com.rreganjr.requel.project.Scenario;
@@ -150,6 +151,72 @@ public class ScenarioCommandTest extends AbstractIntegrationTestCase {
 		assertEquals("Create project scenario", updated.getName(), "name should be unchanged");
 		assertEquals("The user enters a name, customer, and optional description, then submits.",
 				updated.getText(), "text should have been updated");
+	}
+
+	@Test
+	public void editScenarioWithMatchingVersionSucceeds() throws Exception {
+		Project project = createProject("Scenario-version-ok");
+		User admin = getUserRepository().findUserByUsername("admin");
+
+		EditScenarioCommand createCmd = getProjectCommandFactory().newEditScenarioCommand();
+		createCmd.setEditedBy(admin);
+		createCmd.setProjectOrDomain(project);
+		createCmd.setName("Versioned scenario");
+		createCmd.setText("Initial text.");
+		createCmd.setScenarioTypeName(ScenarioType.Primary.name());
+		createCmd = getCommandHandler().execute(createCmd);
+		Scenario original = createCmd.getScenario();
+
+		EditScenarioCommand editCmd = getProjectCommandFactory().newEditScenarioCommand();
+		editCmd.setEditedBy(admin);
+		editCmd.setProjectOrDomain(project);
+		editCmd.setScenario(original);
+		editCmd.setName("Versioned scenario");
+		editCmd.setText("Updated with the current version.");
+		editCmd.setScenarioTypeName(ScenarioType.Primary.name());
+		editCmd.setExpectedVersion(original.getVersion());
+		editCmd = getCommandHandler().execute(editCmd);
+
+		assertEquals("Updated with the current version.", editCmd.getScenario().getText(),
+				"matching-version update should be applied");
+	}
+
+	@Test
+	public void editScenarioWithStaleVersionIsRejected() throws Exception {
+		Project project = createProject("Scenario-version-stale");
+		User admin = getUserRepository().findUserByUsername("admin");
+
+		EditScenarioCommand createCmd = getProjectCommandFactory().newEditScenarioCommand();
+		createCmd.setEditedBy(admin);
+		createCmd.setProjectOrDomain(project);
+		createCmd.setName("Contested scenario");
+		createCmd.setText("Initial text.");
+		createCmd.setScenarioTypeName(ScenarioType.Primary.name());
+		createCmd = getCommandHandler().execute(createCmd);
+		Scenario original = createCmd.getScenario();
+		int staleVersion = original.getVersion();
+
+		EditScenarioCommand firstEdit = getProjectCommandFactory().newEditScenarioCommand();
+		firstEdit.setEditedBy(admin);
+		firstEdit.setProjectOrDomain(project);
+		firstEdit.setScenario(original);
+		firstEdit.setName("Contested scenario");
+		firstEdit.setText("First writer's change.");
+		firstEdit.setScenarioTypeName(ScenarioType.Primary.name());
+		firstEdit.setExpectedVersion(staleVersion);
+		getCommandHandler().execute(firstEdit);
+
+		assertThrows(EntityLockException.class, () -> {
+			EditScenarioCommand staleEdit = getProjectCommandFactory().newEditScenarioCommand();
+			staleEdit.setEditedBy(admin);
+			staleEdit.setProjectOrDomain(project);
+			staleEdit.setScenario(original);
+			staleEdit.setName("Contested scenario");
+			staleEdit.setText("Second writer's stale change.");
+			staleEdit.setScenarioTypeName(ScenarioType.Primary.name());
+			staleEdit.setExpectedVersion(staleVersion);
+			getCommandHandler().execute(staleEdit);
+		}, "an update carrying a stale version should be rejected");
 	}
 
 	@Test

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/project/impl/command/StakeholderCommandTest.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/project/impl/command/StakeholderCommandTest.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 
 import com.rreganjr.AbstractIntegrationTestCase;
 import com.rreganjr.platform.exception.EntityException;
+import com.rreganjr.platform.exception.EntityLockException;
 import com.rreganjr.platform.exception.NoSuchEntityException;
 import com.rreganjr.requel.project.NonUserStakeholder;
 import com.rreganjr.requel.project.Project;
@@ -198,6 +199,105 @@ public class StakeholderCommandTest extends AbstractIntegrationTestCase {
 		NonUserStakeholder updated = editCmd.getStakeholder();
 		assertEquals("Updated ISO description", updated.getText(), "description should have been updated");
 		assertEquals("ISO", updated.getName(), "name should be unchanged");
+	}
+
+	@Test
+	public void editNonUserStakeholderWithMatchingVersionSucceeds() throws Exception {
+		Project project = createProject("NonUserStakeholder-version-ok");
+		User admin = getUserRepository().findUserByUsername("admin");
+
+		EditNonUserStakeholderCommand createCmd = getProjectCommandFactory().newEditNonUserStakeholderCommand();
+		createCmd.setEditedBy(admin);
+		createCmd.setProjectOrDomain(project);
+		createCmd.setName("Versioned authority");
+		createCmd.setText("Initial description.");
+		createCmd = getCommandHandler().execute(createCmd);
+		NonUserStakeholder original = createCmd.getStakeholder();
+
+		EditNonUserStakeholderCommand editCmd = getProjectCommandFactory().newEditNonUserStakeholderCommand();
+		editCmd.setEditedBy(admin);
+		editCmd.setProjectOrDomain(project);
+		editCmd.setStakeholder(original);
+		editCmd.setName("Versioned authority");
+		editCmd.setText("Updated with the current version.");
+		editCmd.setExpectedVersion(original.getVersion());
+		editCmd = getCommandHandler().execute(editCmd);
+
+		assertEquals("Updated with the current version.", editCmd.getStakeholder().getText(),
+				"matching-version update should be applied");
+	}
+
+	@Test
+	public void editNonUserStakeholderWithStaleVersionIsRejected() throws Exception {
+		Project project = createProject("NonUserStakeholder-version-stale");
+		User admin = getUserRepository().findUserByUsername("admin");
+
+		EditNonUserStakeholderCommand createCmd = getProjectCommandFactory().newEditNonUserStakeholderCommand();
+		createCmd.setEditedBy(admin);
+		createCmd.setProjectOrDomain(project);
+		createCmd.setName("Contested authority");
+		createCmd.setText("Initial description.");
+		createCmd = getCommandHandler().execute(createCmd);
+		NonUserStakeholder original = createCmd.getStakeholder();
+		int staleVersion = original.getVersion();
+
+		EditNonUserStakeholderCommand firstEdit = getProjectCommandFactory().newEditNonUserStakeholderCommand();
+		firstEdit.setEditedBy(admin);
+		firstEdit.setProjectOrDomain(project);
+		firstEdit.setStakeholder(original);
+		firstEdit.setName("Contested authority");
+		firstEdit.setText("First writer's change.");
+		firstEdit.setExpectedVersion(staleVersion);
+		getCommandHandler().execute(firstEdit);
+
+		assertThrows(EntityLockException.class, () -> {
+			EditNonUserStakeholderCommand staleEdit = getProjectCommandFactory().newEditNonUserStakeholderCommand();
+			staleEdit.setEditedBy(admin);
+			staleEdit.setProjectOrDomain(project);
+			staleEdit.setStakeholder(original);
+			staleEdit.setName("Contested authority");
+			staleEdit.setText("Second writer's stale change.");
+			staleEdit.setExpectedVersion(staleVersion);
+			getCommandHandler().execute(staleEdit);
+		}, "an update carrying a stale version should be rejected");
+	}
+
+	@Test
+	public void editUserStakeholderWithStaleVersionIsRejected() throws Exception {
+		Project project = createProject("UserStakeholder-version-stale");
+		User admin = getUserRepository().findUserByUsername("admin");
+		User projectUser = getUserRepository().findUserByUsername("project");
+
+		EditUserStakeholderCommand createCmd = getProjectCommandFactory().newEditUserStakeholderCommand();
+		createCmd.setEditedBy(admin);
+		createCmd.setProjectOrDomain(project);
+		createCmd.setUsername(projectUser.getUsername());
+		createCmd.setStakeholderPermissions(Collections.emptySet());
+		createCmd = getCommandHandler().execute(createCmd);
+		UserStakeholder original = createCmd.getStakeholder();
+		int staleVersion = original.getVersion();
+
+		EditUserStakeholderCommand firstEdit = getProjectCommandFactory().newEditUserStakeholderCommand();
+		firstEdit.setEditedBy(admin);
+		firstEdit.setProjectOrDomain(project);
+		firstEdit.setStakeholder(original);
+		firstEdit.setUsername(projectUser.getUsername());
+		firstEdit.setStakeholderPermissions(Collections.emptySet());
+		firstEdit.setTeamName("Dev");
+		firstEdit.setExpectedVersion(staleVersion);
+		getCommandHandler().execute(firstEdit);
+
+		assertThrows(EntityLockException.class, () -> {
+			EditUserStakeholderCommand staleEdit = getProjectCommandFactory().newEditUserStakeholderCommand();
+			staleEdit.setEditedBy(admin);
+			staleEdit.setProjectOrDomain(project);
+			staleEdit.setStakeholder(original);
+			staleEdit.setUsername(projectUser.getUsername());
+			staleEdit.setStakeholderPermissions(Collections.emptySet());
+			staleEdit.setTeamName("QA");
+			staleEdit.setExpectedVersion(staleVersion);
+			getCommandHandler().execute(staleEdit);
+		}, "an update carrying a stale version should be rejected");
 	}
 
 	@Test

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/project/impl/command/StoryCommandTest.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/project/impl/command/StoryCommandTest.java
@@ -22,6 +22,7 @@ package com.rreganjr.requel.project.impl.command;
 
 import com.rreganjr.AbstractIntegrationTestCase;
 import com.rreganjr.platform.exception.EntityException;
+import com.rreganjr.platform.exception.EntityLockException;
 import com.rreganjr.platform.exception.NoSuchEntityException;
 import com.rreganjr.requel.project.Actor;
 import com.rreganjr.requel.project.Project;
@@ -162,6 +163,69 @@ public class StoryCommandTest extends AbstractIntegrationTestCase {
 		assertEquals("Rich creates a project", updated.getName(), "name should be unchanged");
 		assertEquals("Rich logs in, chooses 'New Project', and enters a name and customer.",
 				updated.getText(), "text should have been updated");
+	}
+
+	@Test
+	public void editStoryWithMatchingVersionSucceeds() throws Exception {
+		Project project = createProject("Story-version-ok");
+		User admin = getUserRepository().findUserByUsername("admin");
+
+		EditStoryCommand createCmd = getProjectCommandFactory().newEditStoryCommand();
+		createCmd.setEditedBy(admin);
+		createCmd.setStoryContainer(project);
+		createCmd.setName("Versioned story");
+		createCmd.setText("Initial text.");
+		createCmd.setStoryTypeName(StoryType.Success.name());
+		createCmd = getCommandHandler().execute(createCmd);
+		Story original = createCmd.getStory();
+
+		EditStoryCommand editCmd = getProjectCommandFactory().newEditStoryCommand();
+		editCmd.setEditedBy(admin);
+		editCmd.setStory(original);
+		editCmd.setName("Versioned story");
+		editCmd.setText("Updated with the current version.");
+		editCmd.setStoryTypeName(StoryType.Success.name());
+		editCmd.setExpectedVersion(original.getVersion());
+		editCmd = getCommandHandler().execute(editCmd);
+
+		assertEquals("Updated with the current version.", editCmd.getStory().getText(),
+				"matching-version update should be applied");
+	}
+
+	@Test
+	public void editStoryWithStaleVersionIsRejected() throws Exception {
+		Project project = createProject("Story-version-stale");
+		User admin = getUserRepository().findUserByUsername("admin");
+
+		EditStoryCommand createCmd = getProjectCommandFactory().newEditStoryCommand();
+		createCmd.setEditedBy(admin);
+		createCmd.setStoryContainer(project);
+		createCmd.setName("Contested story");
+		createCmd.setText("Initial text.");
+		createCmd.setStoryTypeName(StoryType.Success.name());
+		createCmd = getCommandHandler().execute(createCmd);
+		Story original = createCmd.getStory();
+		int staleVersion = original.getVersion();
+
+		EditStoryCommand firstEdit = getProjectCommandFactory().newEditStoryCommand();
+		firstEdit.setEditedBy(admin);
+		firstEdit.setStory(original);
+		firstEdit.setName("Contested story");
+		firstEdit.setText("First writer's change.");
+		firstEdit.setStoryTypeName(StoryType.Success.name());
+		firstEdit.setExpectedVersion(staleVersion);
+		getCommandHandler().execute(firstEdit);
+
+		assertThrows(EntityLockException.class, () -> {
+			EditStoryCommand staleEdit = getProjectCommandFactory().newEditStoryCommand();
+			staleEdit.setEditedBy(admin);
+			staleEdit.setStory(original);
+			staleEdit.setName("Contested story");
+			staleEdit.setText("Second writer's stale change.");
+			staleEdit.setStoryTypeName(StoryType.Success.name());
+			staleEdit.setExpectedVersion(staleVersion);
+			getCommandHandler().execute(staleEdit);
+		}, "an update carrying a stale version should be rejected");
 	}
 
 	@Test

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/project/impl/command/UseCaseCommandTest.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/project/impl/command/UseCaseCommandTest.java
@@ -22,6 +22,7 @@ package com.rreganjr.requel.project.impl.command;
 
 import com.rreganjr.AbstractIntegrationTestCase;
 import com.rreganjr.platform.exception.EntityException;
+import com.rreganjr.platform.exception.EntityLockException;
 import com.rreganjr.platform.exception.NoSuchEntityException;
 import com.rreganjr.requel.project.Actor;
 import com.rreganjr.requel.project.Project;
@@ -156,6 +157,74 @@ public class UseCaseCommandTest extends AbstractIntegrationTestCase {
 		assertEquals("Create or edit a user account", updated.getName(), "name should be unchanged");
 		assertEquals("An administrator creates and manages user accounts, roles, and permissions.",
 				updated.getText(), "text should have been updated");
+	}
+
+	@Test
+	public void editUseCaseWithMatchingVersionSucceeds() throws Exception {
+		Project project = createProject("UseCase-version-ok");
+		User admin = getUserRepository().findUserByUsername("admin");
+		Actor actor = createActor(project, "Administrator");
+
+		EditUseCaseCommand createCmd = getProjectCommandFactory().newEditUseCaseCommand();
+		createCmd.setEditedBy(admin);
+		createCmd.setProjectOrDomain(project);
+		createCmd.setName("Versioned use case");
+		createCmd.setText("Initial text.");
+		createCmd.setPrimaryActorName(actor.getName());
+		createCmd = getCommandHandler().execute(createCmd);
+		UseCase original = createCmd.getUseCase();
+
+		EditUseCaseCommand editCmd = getProjectCommandFactory().newEditUseCaseCommand();
+		editCmd.setEditedBy(admin);
+		editCmd.setProjectOrDomain(project);
+		editCmd.setUseCase(original);
+		editCmd.setName("Versioned use case");
+		editCmd.setText("Updated with the current version.");
+		editCmd.setPrimaryActorName(actor.getName());
+		editCmd.setExpectedVersion(original.getVersion());
+		editCmd = getCommandHandler().execute(editCmd);
+
+		assertEquals("Updated with the current version.", editCmd.getUseCase().getText(),
+				"matching-version update should be applied");
+	}
+
+	@Test
+	public void editUseCaseWithStaleVersionIsRejected() throws Exception {
+		Project project = createProject("UseCase-version-stale");
+		User admin = getUserRepository().findUserByUsername("admin");
+		Actor actor = createActor(project, "Administrator");
+
+		EditUseCaseCommand createCmd = getProjectCommandFactory().newEditUseCaseCommand();
+		createCmd.setEditedBy(admin);
+		createCmd.setProjectOrDomain(project);
+		createCmd.setName("Contested use case");
+		createCmd.setText("Initial text.");
+		createCmd.setPrimaryActorName(actor.getName());
+		createCmd = getCommandHandler().execute(createCmd);
+		UseCase original = createCmd.getUseCase();
+		int staleVersion = original.getVersion();
+
+		EditUseCaseCommand firstEdit = getProjectCommandFactory().newEditUseCaseCommand();
+		firstEdit.setEditedBy(admin);
+		firstEdit.setProjectOrDomain(project);
+		firstEdit.setUseCase(original);
+		firstEdit.setName("Contested use case");
+		firstEdit.setText("First writer's change.");
+		firstEdit.setPrimaryActorName(actor.getName());
+		firstEdit.setExpectedVersion(staleVersion);
+		getCommandHandler().execute(firstEdit);
+
+		assertThrows(EntityLockException.class, () -> {
+			EditUseCaseCommand staleEdit = getProjectCommandFactory().newEditUseCaseCommand();
+			staleEdit.setEditedBy(admin);
+			staleEdit.setProjectOrDomain(project);
+			staleEdit.setUseCase(original);
+			staleEdit.setName("Contested use case");
+			staleEdit.setText("Second writer's stale change.");
+			staleEdit.setPrimaryActorName(actor.getName());
+			staleEdit.setExpectedVersion(staleVersion);
+			getCommandHandler().execute(staleEdit);
+		}, "an update carrying a stale version should be rejected");
 	}
 
 	@Test

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/service/AuthorizationIT.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/service/AuthorizationIT.java
@@ -740,12 +740,23 @@ public class AuthorizationIT extends AbstractIntegrationTestCase {
     }
 
     private String editUserStakeholderJson(String username) throws Exception {
-        // version=0 signals an edit (not create) so tests are idempotent across ordering
+        // A non-null version signals an edit (not create). Send the stakeholder's current
+        // persisted version so the optimistic-lock check passes (issue #108); fall back to 0
+        // when no stakeholder exists yet (create path, where the version is ignored).
+        Integer version = 0;
+        try {
+            Project project = getProjectRepository().findProjectByName(testProjectName);
+            User user = getUserRepository().findUserByUsername(username);
+            version = getProjectRepository()
+                    .findStakeholderByProjectOrDomainAndUser(project, user).getVersion();
+        } catch (Exception noExistingStakeholder) {
+            // no existing stakeholder for this user on the project — treat as a create
+        }
         return objectMapper.writeValueAsString(Map.of(
                 "projectName", testProjectName,
                 "username", username,
                 "permissionKeys", java.util.List.of(),
-                "version", 0));
+                "version", version));
     }
 
     private String editProjectJson() throws Exception {
@@ -756,11 +767,12 @@ public class AuthorizationIT extends AbstractIntegrationTestCase {
     }
 
     private String editUserJson(String username) throws Exception {
-        // Edit the named user — sets minimal fields to satisfy validation.
-        // version=0 works for an existing user loaded by username.
+        // Edit the named user — sets minimal fields to satisfy validation. Send the user's
+        // current persisted version so the optimistic-lock check passes (issue #108).
+        int version = getUserRepository().findUserByUsername(username).getVersion();
         return objectMapper.writeValueAsString(Map.of(
                 "username", username,
-                "version", 0,
+                "version", version,
                 "name", username,
                 "emailAddress", username + "@example.com",
                 "phoneNumber", "",

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/service/audit/AuditingCommandHandlerTest.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/service/audit/AuditingCommandHandlerTest.java
@@ -342,6 +342,7 @@ class AuditingCommandHandlerTest {
         @Override public void addUserRoleName(String s) {}
         @Override public void setUserRolePermissionNames(java.util.Map<String, java.util.Set<String>> m) {}
         @Override public void addUserRolePermissionName(String role, String perm) {}
+        @Override public void setExpectedVersion(Integer expectedVersion) {}
     }
 
     // -------------------------------------------------------------------------

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/user/impl/command/EditUserCommandTest.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/user/impl/command/EditUserCommandTest.java
@@ -22,6 +22,7 @@ package com.rreganjr.requel.user.impl.command;
 
 import com.rreganjr.AbstractIntegrationTestCase;
 import com.rreganjr.platform.command.AuthorizationException;
+import com.rreganjr.platform.exception.EntityLockException;
 import com.rreganjr.requel.project.ProjectUserRole;
 import com.rreganjr.requel.user.User;
 import com.rreganjr.requel.user.command.EditUserCommand;
@@ -145,6 +146,59 @@ public class EditUserCommandTest extends AbstractIntegrationTestCase {
         assertEquals("Updated Name", updated.getName(), "name should be updated");
         assertEquals("updated-" + ts + "@example.com", updated.getEmailAddress(),
                 "email should be updated");
+    }
+
+    @Test
+    public void editUserWithMatchingVersionSucceeds() throws Exception {
+        long ts = System.currentTimeMillis();
+        User admin = getUserRepository().findUserByUsername("admin");
+        User user = createUser("version-ok-" + ts, "pass123!", "Original Name");
+
+        EditUserCommand cmd = getUserCommandFactory().newEditUserCommand();
+        cmd.setEditedBy(admin);
+        cmd.setUser(user);
+        cmd.setUsername(user.getUsername());
+        cmd.setName("Updated With Current Version");
+        cmd.setEmailAddress(user.getEmailAddress());
+        cmd.setPhoneNumber("");
+        cmd.setOrganizationName("TestOrg");
+        cmd.setExpectedVersion(user.getVersion());
+        cmd = getCommandHandler().execute(cmd);
+
+        assertEquals("Updated With Current Version", cmd.getUser().getName(),
+                "matching-version update should be applied");
+    }
+
+    @Test
+    public void editUserWithStaleVersionIsRejected() throws Exception {
+        long ts = System.currentTimeMillis();
+        User admin = getUserRepository().findUserByUsername("admin");
+        User user = createUser("version-stale-" + ts, "pass123!", "Original Name");
+        int staleVersion = user.getVersion();
+
+        EditUserCommand firstEdit = getUserCommandFactory().newEditUserCommand();
+        firstEdit.setEditedBy(admin);
+        firstEdit.setUser(user);
+        firstEdit.setUsername(user.getUsername());
+        firstEdit.setName("First Writer Change");
+        firstEdit.setEmailAddress(user.getEmailAddress());
+        firstEdit.setPhoneNumber("");
+        firstEdit.setOrganizationName("TestOrg");
+        firstEdit.setExpectedVersion(staleVersion);
+        getCommandHandler().execute(firstEdit);
+
+        assertThrows(EntityLockException.class, () -> {
+            EditUserCommand staleEdit = getUserCommandFactory().newEditUserCommand();
+            staleEdit.setEditedBy(admin);
+            staleEdit.setUser(user);
+            staleEdit.setUsername(user.getUsername());
+            staleEdit.setName("Second Writer Stale Change");
+            staleEdit.setEmailAddress(user.getEmailAddress());
+            staleEdit.setPhoneNumber("");
+            staleEdit.setOrganizationName("TestOrg");
+            staleEdit.setExpectedVersion(staleVersion);
+            getCommandHandler().execute(staleEdit);
+        }, "an update carrying a stale version should be rejected");
     }
 
     // -------------------------------------------------------------------------

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/command/ProjectCommandRegistrar.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/command/ProjectCommandRegistrar.java
@@ -169,6 +169,8 @@ public class ProjectCommandRegistrar {
                             // New project — leave project null, command will create
                         }
                     }
+                    // Caller's version drives the optimistic-lock check on update (issue #108).
+                    c.setExpectedVersion(i.version());
 
                     if (i.name() != null) c.setName(i.name());
                     if (i.description() != null) c.setText(i.description());
@@ -208,10 +210,13 @@ public class ProjectCommandRegistrar {
                     c.setUsername(i.username());
                     if (i.teamName() != null) c.setTeamName(i.teamName());
                     if (i.permissionKeys() != null) c.setStakeholderPermissions(new HashSet<>(i.permissionKeys()));
-                    // For edit: find existing stakeholder by project + username
+                    // For edit (caller supplies a version): resolve the existing stakeholder by its
+                    // natural key (project + username) and apply the optimistic-lock check (issue
+                    // #108). Without a version this is treated as a create (unchanged behavior).
                     if (i.version() != null) {
                         UserStakeholder existing = findUserStakeholderByUsername(project, i.username());
                         if (existing != null) c.setStakeholder(existing);
+                        c.setExpectedVersion(i.version());
                     }
                 },
                 null, // no file
@@ -231,6 +236,7 @@ public class ProjectCommandRegistrar {
                     if (i.stakeholderId() != null) {
                         NonUserStakeholder existing = (NonUserStakeholder) findStakeholderById(project, i.stakeholderId());
                         c.setStakeholder(existing);
+                        c.setExpectedVersion(i.version());
                     }
                 },
                 null, // no file
@@ -256,6 +262,8 @@ public class ProjectCommandRegistrar {
                     Project project = projectRepository.findProjectByName(i.projectName());
                     if (i.goalId() != null) {
                         c.setGoal(findGoalById(project, i.goalId()));
+                        // Wire the caller-supplied optimistic-lock version (issue #108).
+                        c.setExpectedVersion(i.version());
                     } else {
                         c.setGoalContainer(project);
                     }
@@ -275,10 +283,13 @@ public class ProjectCommandRegistrar {
                     c.setFromGoal(i.fromGoalName());
                     c.setToGoal(i.toGoalName());
                     c.setRelationType(i.relationType());
+                    // For edit (caller supplies a version): resolve the existing relation by its
+                    // natural key (from/to goal) and apply the optimistic-lock check (issue #108).
+                    // Without a version this is treated as a create (unchanged behavior).
                     if (i.version() != null) {
-                        // Find existing relation for edit
                         GoalRelation existing = findGoalRelationById(project, i.fromGoalName(), i.toGoalName());
                         if (existing != null) c.setGoalRelation(existing);
+                        c.setExpectedVersion(i.version());
                     }
                 });
 
@@ -343,6 +354,7 @@ public class ProjectCommandRegistrar {
                     Project project = projectRepository.findProjectByName(i.projectName());
                     if (i.storyId() != null) {
                         c.setStory(findStoryById(project, i.storyId()));
+                        c.setExpectedVersion(i.version());
                     } else {
                         c.setStoryContainer(project);
                     }
@@ -404,6 +416,7 @@ public class ProjectCommandRegistrar {
                     Project project = projectRepository.findProjectByName(i.projectName());
                     if (i.actorId() != null) {
                         c.setActor(findActorById(project, i.actorId()));
+                        c.setExpectedVersion(i.version());
                     } else {
                         c.setActorContainer(project);
                     }
@@ -464,6 +477,7 @@ public class ProjectCommandRegistrar {
                     c.setProjectOrDomain(project);
                     if (i.useCaseId() != null) {
                         c.setUseCase(findUseCaseById(project, i.useCaseId()));
+                        c.setExpectedVersion(i.version());
                     }
                     c.setName(i.name());
                     if (i.text() != null) c.setText(i.text());
@@ -518,6 +532,7 @@ public class ProjectCommandRegistrar {
                     c.setProjectOrDomain(project);
                     if (i.scenarioId() != null) {
                         c.setScenario(findScenarioById(project, i.scenarioId()));
+                        c.setExpectedVersion(i.version());
                     }
                     if (i.name() != null) c.setName(i.name());
                     if (i.text() != null) c.setText(i.text());

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/command/UserCommandRegistrar.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/command/UserCommandRegistrar.java
@@ -72,6 +72,8 @@ public class UserCommandRegistrar {
                             // New user — leave user null, command will create
                         }
                     }
+                    // Caller's version drives the optimistic-lock check on update (issue #108).
+                    c.setExpectedVersion(i.version());
 
                     c.setUsername(i.username());
                     if (i.password() != null) {

--- a/modules/user-domain/src/main/java/com/rreganjr/requel/user/command/EditUserCommand.java
+++ b/modules/user-domain/src/main/java/com/rreganjr/requel/user/command/EditUserCommand.java
@@ -140,4 +140,17 @@ public interface EditUserCommand extends Command {
 	 *            the user invoking the command
 	 */
 	public void setEditedBy(User editedBy);
+
+	/**
+	 * Set the caller-supplied optimistic-lock version expected for the user being
+	 * edited. When non-null on an update, the command compares it against the user's
+	 * currently persisted version and fails with an
+	 * {@link com.rreganjr.platform.exception.EntityLockException} if it has changed
+	 * since the caller loaded it. A {@code null} value (or a create) skips the check.
+	 * See issue #108.
+	 *
+	 * @param expectedVersion the version the caller believes is current, or
+	 *        {@code null} to skip the optimistic-lock check
+	 */
+	public void setExpectedVersion(Integer expectedVersion);
 }

--- a/modules/user-jpa/src/main/java/com/rreganjr/requel/user/impl/command/EditUserCommandImpl.java
+++ b/modules/user-jpa/src/main/java/com/rreganjr/requel/user/impl/command/EditUserCommandImpl.java
@@ -34,6 +34,8 @@ import com.rreganjr.platform.command.AuthorizableCommand;
 import com.rreganjr.platform.command.AuthorizationException;
 import com.rreganjr.platform.command.AuthorizationRequirement;
 import com.rreganjr.platform.command.AuthorizationRequirement.RequiresSystemRole;
+import com.rreganjr.platform.exception.EntityExceptionActionType;
+import com.rreganjr.platform.exception.EntityLockException;
 import com.rreganjr.validator.EntityValidationException;
 import com.rreganjr.requel.user.impl.AbstractUserRole;
 import com.rreganjr.requel.user.Organization;
@@ -67,6 +69,7 @@ public class EditUserCommandImpl extends AbstractUserCommand implements EditUser
 	private boolean userRolesProvided = false;
 	private Map<String, Set<String>> userRolePermissionNames = new HashMap<String, Set<String>>();
 	private User editedBy;
+	private Integer expectedVersion;
 
 	/**
 	 * @param userRepository
@@ -93,6 +96,13 @@ public class EditUserCommandImpl extends AbstractUserCommand implements EditUser
 			// Non-admins can only edit their own account
 			if (!isAdmin && !userImpl.getUsername().equals(getEditedBy().getUsername())) {
 				throw new AuthorizationException("You can only edit your own account.");
+			}
+			// Enforce the caller-supplied optimistic-lock version on update (issue #108).
+			userImpl = getUserRepository().get(userImpl);
+			if (getExpectedVersion() != null
+					&& getExpectedVersion().intValue() != userImpl.getVersion()) {
+				throw EntityLockException.staleEntity(User.class, userImpl,
+						EntityExceptionActionType.Updating);
 			}
 			userImpl = updateUser(userImpl, isAdmin);
 		}
@@ -291,6 +301,15 @@ public class EditUserCommandImpl extends AbstractUserCommand implements EditUser
 
 	public User getEditedBy() {
 		return editedBy;
+	}
+
+	@Override
+	public void setExpectedVersion(Integer expectedVersion) {
+		this.expectedVersion = expectedVersion;
+	}
+
+	protected Integer getExpectedVersion() {
+		return expectedVersion;
 	}
 
 	@Override


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/108

Wire optimistic-lock version through all Edit* commands

Honor a caller-supplied `version` for optimistic locking on updates so a stale
edit fails cleanly with a 409 conflict instead of silently overwriting a
concurrent change. Extends the original EditGoal scope to every Edit* command
whose input DTO already declares a `version` field. The conflict surfaces via
the existing `EntityLockException` -> `CommandController` (HTTP 409) path; no new
error plumbing was needed.

Closes #108. Follow-up split from #71; depends on the command gateway series (#69).

## Summary

On an update the command reloads the target entity, compares its persisted
version to the caller-supplied expected version, and throws
`EntityLockException.staleEntity(...)` on a mismatch. A null version, or a create
(no entity resolved), skips the check. Ten commands are covered: EditGoal,
EditActor, EditStory, EditUseCase, EditScenario, EditNonUserStakeholder,
EditUserStakeholder (shared project-entity hierarchy) and EditGoalRelation,
EditProject, EditUser (separate hierarchies).

## Shared project-entity hierarchy

modules/project-domain/.../command/EditProjectOrDomainEntityCommand.java:
- Added `setExpectedVersion(Integer)` to the shared interface.

modules/project-domain/.../command/EditGoalCommand.java:
- Removed the `setExpectedVersion` that had been added here directly; it is now
  inherited from `EditProjectOrDomainEntityCommand`.

modules/project-jpa/.../impl/command/AbstractEditProjectOrDomainEntityCommand.java:
- Added the `expectedVersion` field/accessors and a generic
  `checkExpectedVersion(entity)` helper that reloads the entity, compares its
  persisted version to the expected version, throws `EntityLockException` on
  mismatch, and returns the reloaded persistence-attached instance to mutate.

modules/project-jpa/.../impl/command/*:
- EditGoalCommandImpl refactored off its earlier inline check onto the shared
  helper; EditActorCommandImpl, EditStoryCommandImpl, EditUseCaseCommandImpl,
  EditScenarioCommandImpl, EditNonUserStakeholderCommandImpl, and
  EditUserStakeholderCommandImpl now call `checkExpectedVersion(...)` in the
  update branch of `execute()`.

## Separate hierarchies

modules/project-domain/.../command/EditGoalRelationCommand.java,
modules/project-domain/.../command/EditProjectCommand.java,
modules/user-domain/.../command/EditUserCommand.java:
- Added `setExpectedVersion(Integer)` to each interface.

modules/project-jpa/.../impl/command/EditGoalRelationCommandImpl.java,
modules/project-jpa/.../impl/command/EditProjectCommandImpl.java,
modules/user-jpa/.../impl/command/EditUserCommandImpl.java:
- Added the `expectedVersion` field/accessors and an inline reload-and-compare
  check in the update branch, throwing `EntityLockException` on mismatch.

## Registrar wiring

modules/service-impl/.../command/ProjectCommandRegistrar.java:
- Pass `c.setExpectedVersion(i.version())` on the edit branch of EditGoal,
  EditActor, EditStory, EditUseCase, EditScenario, EditNonUserStakeholder, and
  EditProject. EditUserStakeholder and EditGoalRelation have no id field in their
  input, so the registrar already uses `version != null` as the edit-vs-create
  signal; the expected-version check is applied inside that existing gate to
  preserve create semantics (a create against an existing natural key still
  returns a uniqueness conflict rather than becoming a silent upsert).

modules/service-impl/.../command/UserCommandRegistrar.java:
- Pass `c.setExpectedVersion(i.version())` for EditUser.

## Tests

modules/requel-app/src/test/.../project/impl/command/*:
- Added stale-version-rejected and matching-version-succeeds cases (mirroring the
  existing GoalCommandTest cases) to ActorCommandTest, StoryCommandTest,
  UseCaseCommandTest, ScenarioCommandTest, StakeholderCommandTest,
  GoalRelationCommandTest, and EditProjectCommandImplTest.
- EditUserCommandTest: same two cases for EditUser.

modules/requel-app/src/test/.../service/audit/AuditingCommandHandlerTest.java:
- Added a no-op `setExpectedVersion` to the hand-written `ApiEditUserCommand`
  test double so it still satisfies the `EditUserCommand` interface.

modules/requel-app/src/test/.../service/AuthorizationIT.java:
- `editUserJson` and `editUserStakeholderJson` previously sent a hardcoded
  `version: 0` as a legacy edit sentinel. With the lock now enforced, `0` is
  stale for entities whose version advances during `@BeforeEach` setup, so those
  edits correctly returned 409. Both helpers now send the entity's current
  persisted version loaded from the repository (the stakeholder helper falls back
  to 0 when no stakeholder exists yet, i.e. the create path). This matches how
  the goal/actor/story auth helpers already pass captured versions. The
  forbidden-case tests are unaffected because authorization is checked before the
  version check runs.

## Docs

doc/108-edit-optlock-plan.md (new):
- Scope/plan for widening #108 from EditGoal to all Edit* commands, the
  reload-and-compare approach, the command inventory, and the known limitation
  (the check compares against the freshly-loaded persisted version at command
  time rather than propagating the caller version into the JPA persistence
  context).
