### PR TITLE
Expose tag commands through the command gateway (MCP + CLI)

### DIFF
--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/gateway/GatewayPolicyConfig.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/gateway/GatewayPolicyConfig.java
@@ -75,7 +75,11 @@ public class GatewayPolicyConfig {
             "EditReportGenerator", "DeleteReportGenerator",
             // Annotations / IBIS
             "EditNote", "DeleteNote", "EditIssue", "DeleteIssue",
-            "EditPosition", "DeletePosition", "EditArgument", "DeleteArgument");
+            "EditPosition", "DeletePosition", "EditArgument", "DeleteArgument",
+            // Tagging / categorization (tags reuse the Annotation stakeholder permission:
+            // Edit to create/assign, Delete to delete; global/system tags require admin)
+            "EditTag", "DeleteTag", "AssignTag", "UnassignTag",
+            "EditTagCategory", "DeleteTagCategory");
 
     /**
      * Commands that must never be exposed, even if mistakenly added to the allowlist. Covers


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/116

Expose tag commands through the command gateway (MCP + CLI)

Adds the six tagging/categorization CQRS command types to the gateway
allowlist so they are exposed to the MCP server and the `requel` CLI, closing
the gap where tags were reachable only from the web UI / REST API. Implements
the missed Phase-2 step from doc/112-entity-categorization-plan.md:119.

modules/service-impl/.../gateway/GatewayPolicyConfig.java
- Add EditTag, DeleteTag, AssignTag, UnassignTag, EditTagCategory,
  DeleteTagCategory to ALLOWED (default-deny policy; these were never added
  when #112 landed after the MCP write tools (#107) and CLI typed
  subcommands (#103)).
- The gateway catalog (GatewayCommandCatalogImpl) derives each tool's input
  schema from the CommandRegistry, where TagCommandRegistrar already registers
  all six with typed input DTOs (EditTagInput, AssignTagInput, ...), so adding
  them to ALLOWED is sufficient to surface working MCP tools / CLI subcommands.

Authorization audit (per issue acceptance criteria):
- All six commands implement AuthorizableCommand and return a project-scoped
  RequiresStakeholderPermission(Annotation, Edit|Delete) for project tags
  (EditTag/AssignTag/UnassignTag -> Edit, DeleteTag -> Delete), or
  RequiresSystemRole(SystemAdminUserRole) for global/system tags.
- They also implement AuthorizationExemptable, but this is NOT a gateway
  bypass: AuthorizingCommandHandler skips the permission check only when
  isAuthorizationExempt() is true, which defaults to false and is set true
  only during internal delete cascades (TODO #75). Direct gateway invocations
  leave the flag false, and the flag is not part of any input DTO, so an
  external client cannot set it. The per-stakeholder check is enforced.
- Net effect matches intent: creating a tag requires Annotation[Edit] on the
  project; assigning/unassigning requires Annotation[Edit] on the target
  entity's project (you can only tag things you can edit); global tags are
  admin-only.

Closes #116
