### PR TITLE
Replace PAT role-gate with per-user ManageApiTokens permission (#85)

### DIFF
--- a/doc/pat_ui_plan.md
+++ b/doc/pat_ui_plan.md
@@ -80,6 +80,29 @@ So `ManageApiTokens` is a rollout, not a one-liner:
 date" stale-state errors across test contexts). Adding a permission must be done carefully and
 re-tested across the full suite.
 
+### Implemented (#85) — decisions
+
+The fast-follow was implemented in #85 with these decisions (supersede the open questions above):
+
+- **Opt-in, admin-granted.** `manageApiTokens` is declared on `ProjectUserRole` only and is **not**
+  auto-granted — neither to existing users nor on new-user creation. An admin grants it per user.
+- **No backfill.** Step 2's one-time grant to existing `ProjectUserRole` instances was dropped;
+  existing project users have no PAT access until an admin grants it (the seeded `project`/`admin`
+  users included). `UserRolePermissionsInitializer` still persists/caches the new *available*
+  permission so it can be granted.
+- **Admin toggle is already generic.** The user create/edit UI (`UserEditorComponent`) renders
+  per-role permission checkboxes from `GET /api/users/roles` (`availablePermissions`) and submits
+  `userRolePermissionNames`; `EditUserCommandImpl.updateRoles()` grants/revokes them. So declaring
+  the permission surfaces the toggle automatically — no bespoke UI.
+- **`UserDto.permissions` already existed** (added since this plan was written), so step 4 reduced
+  to the Angular gate: `SettingsComponent.canManageTokens()` now checks
+  `permissions.includes('manageApiTokens')` instead of the role.
+- **Enforcement** lives in `ApiTokenController` (`getPermissionStrings(user).contains(...)` → 403);
+  the `.hasRole("ProjectUserRole")` matcher on `/api/auth/tokens` in `ApiSecurityConfig` was relaxed
+  to `.authenticated()`.
+- **Admins** get PAT access only when they also hold `ProjectUserRole` and are granted the
+  permission — there is no `manageApiTokens` on `SystemAdminUserRole`.
+
 ## Angular pieces
 
 - `models/api-token.ts` — `ApiTokenDto`, `CreateApiTokenRequest`, `CreateApiTokenResponse`.

--- a/modules/project-jpa/src/main/java/com/rreganjr/requel/project/ProjectUserRole.java
+++ b/modules/project-jpa/src/main/java/com/rreganjr/requel/project/ProjectUserRole.java
@@ -58,12 +58,16 @@ public class ProjectUserRole extends AbstractUserRole {
 	@Transient
 	public static final UserRolePermission inviteUsers = new JpaUserRolePermission(
 			ProjectUserRole.class, "inviteUsers");
+	@Transient
+	public static final UserRolePermission manageApiTokens = new JpaUserRolePermission(
+			ProjectUserRole.class, "manageApiTokens");
 
 	static {
 		AbstractUserRole.userRoleTypes.add(ProjectUserRole.class);
 		AbstractUserRole.userRoleTypePermissions.put(ProjectUserRole.class,
 				new HashSet<UserRolePermission>());
 		AbstractUserRole.userRoleTypePermissions.get(ProjectUserRole.class).add(createProjects);
+		AbstractUserRole.userRoleTypePermissions.get(ProjectUserRole.class).add(manageApiTokens);
 		// AbstractUserRole.userRoleTypePermissions.get(ProjectUserRole.class).add(inviteUsers);
 	}
 
@@ -128,6 +132,15 @@ public class ProjectUserRole extends AbstractUserRole {
 	 */
 	public boolean canInviteUsers() {
 		return hasUserRolePermission(inviteUsers);
+	}
+
+	/**
+	 * @return true if this user is authorized to manage (create, list, revoke,
+	 *         and delete) their own personal access tokens. Granted per-user
+	 *         (issue #85); holding the role alone does not confer it.
+	 */
+	public boolean canManageApiTokens() {
+		return hasUserRolePermission(manageApiTokens);
 	}
 
 	@Override

--- a/modules/requel-app/src/test/java/com/rreganjr/AbstractIntegrationTestCase.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/AbstractIntegrationTestCase.java
@@ -225,6 +225,15 @@ public abstract class AbstractIntegrationTestCase {
         testRoleGrantHelper.grantProjectRoleIfMissing(username);
     }
 
+    /**
+     * Grant the per-user {@code manageApiTokens} permission (issue #85) on the user's
+     * ProjectUserRole. Not granted by default (opt-in), so tests that exercise token management
+     * must call this explicitly for the users that should be able to manage tokens.
+     */
+    protected void grantManageApiTokens(String username) {
+        testRoleGrantHelper.grantManageApiTokensIfMissing(username);
+    }
+
 	@Autowired
 	protected void setNlpProcessorFactory(NLPProcessorFactory nlpProcessorFactory) {
 		this.nlpProcessorFactory = nlpProcessorFactory;

--- a/modules/requel-app/src/test/java/com/rreganjr/TestRoleGrantHelper.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/TestRoleGrantHelper.java
@@ -21,6 +21,8 @@
 package com.rreganjr;
 
 import com.rreganjr.requel.project.ProjectUserRole;
+import com.rreganjr.requel.user.impl.AbstractUserRole;
+import com.rreganjr.requel.user.impl.JpaUserRolePermission;
 import com.rreganjr.requel.user.impl.UserImpl;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -60,5 +62,36 @@ public class TestRoleGrantHelper {
         if (!hasRole) {
             user.grantRole(ProjectUserRole.class);
         }
+    }
+
+    /**
+     * Grants the {@code manageApiTokens} permission (issue #85) on the user's
+     * {@link ProjectUserRole} instance, if not already present. The user must already hold
+     * ProjectUserRole. Grants the persisted permission row (looked up by name + role type) so no
+     * duplicate permission is inserted — mirrors how an admin would grant it via the user editor.
+     */
+    @Transactional
+    public void grantManageApiTokensIfMissing(String username) {
+        List<UserImpl> results = entityManager
+                .createQuery("SELECT u FROM UserImpl u WHERE u.username = :username", UserImpl.class)
+                .setParameter("username", username)
+                .getResultList();
+        if (results.isEmpty()) return;
+        UserImpl user = results.get(0);
+        AbstractUserRole projectRole = user.getUserRoles().stream()
+                .filter(r -> r instanceof ProjectUserRole)
+                .map(r -> (AbstractUserRole) r)
+                .findFirst()
+                .orElse(null);
+        if (projectRole == null) return;
+        if (projectRole.hasUserRolePermission(ProjectUserRole.manageApiTokens)) return;
+        JpaUserRolePermission managed = entityManager
+                .createQuery("SELECT p FROM UserRolePermission p "
+                        + "WHERE p.name = :name AND p.userRoleType = :type",
+                        JpaUserRolePermission.class)
+                .setParameter("name", ProjectUserRole.manageApiTokens.getName())
+                .setParameter("type", ProjectUserRole.class.getName())
+                .getSingleResult();
+        projectRole.grantUserRolePermission(managed);
     }
 }

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/service/ApiTokenIT.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/service/ApiTokenIT.java
@@ -60,16 +60,29 @@ public class ApiTokenIT extends AbstractIntegrationTestCase {
 	private String adminJwt;
 	private String otherUsername;
 	private String otherJwt;
+	private String noPermUsername;
+	private String noPermJwt;
 
 	@BeforeAll
 	void setUp() throws Exception {
 		initializeBaselineData();
-		adminJwt = login("admin", "admin");
 
 		long ts = System.currentTimeMillis();
 		otherUsername = "tok-other-" + ts;
 		createUser(otherUsername, "secret");
+		// A project user with NO manageApiTokens permission (opt-in default, #85).
+		noPermUsername = "tok-noperm-" + ts;
+		createUser(noPermUsername, "secret");
+
+		// manageApiTokens is per-user and not granted by default (#85). Grant it to the users that
+		// manage tokens in these tests (admin + otherUser); noPermUser is deliberately left without.
+		grantManageApiTokens("admin");
+		grantManageApiTokens(otherUsername);
+
+		// Log in AFTER granting so the JWTs carry the up-to-date permission claims.
+		adminJwt = login("admin", "admin");
 		otherJwt = login(otherUsername, "secret");
+		noPermJwt = login(noPermUsername, "secret");
 	}
 
 	@Test
@@ -188,6 +201,33 @@ public class ApiTokenIT extends AbstractIntegrationTestCase {
 						.contentType(MediaType.APPLICATION_JSON)
 						.content("{\"name\":\"  \"}"))
 				.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	void projectUserWithoutManagePermissionCannotCreate() throws Exception {
+		// noPermUser holds ProjectUserRole but was not granted manageApiTokens (#85): 403, not 201.
+		mockMvc.perform(post("/api/auth/tokens")
+						.header("Authorization", "Bearer " + noPermJwt)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(Map.of("name", "nope"))))
+				.andExpect(status().isForbidden());
+	}
+
+	@Test
+	void projectUserWithoutManagePermissionCannotList() throws Exception {
+		mockMvc.perform(get("/api/auth/tokens").header("Authorization", "Bearer " + noPermJwt))
+				.andExpect(status().isForbidden());
+	}
+
+	@Test
+	void projectUserWithManagePermissionCanListAndCreate() throws Exception {
+		// otherUser holds ProjectUserRole and WAS granted manageApiTokens: management succeeds.
+		mockMvc.perform(get("/api/auth/tokens").header("Authorization", "Bearer " + otherJwt))
+				.andExpect(status().isOk());
+		String[] minted = mintToken(otherJwt, "other-ok");
+		mockMvc.perform(get("/api/auth/me").header("Authorization", "Bearer " + minted[0]))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.username").value(otherUsername));
 	}
 
 	// ---- helpers ------------------------------------------------------------------------------

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/ApiTokenController.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/auth/ApiTokenController.java
@@ -21,8 +21,8 @@
 package com.rreganjr.requel.service.auth;
 
 import com.rreganjr.requel.service.api.dto.ErrorResponse;
+import com.rreganjr.requel.user.User;
 import java.time.Instant;
-import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -44,12 +44,41 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/auth/tokens")
 public class ApiTokenController {
 
+	/**
+	 * The per-user UserRolePermission (on ProjectUserRole) that authorizes token management (#85).
+	 * Referenced by name to avoid a service->project-jpa dependency; matches
+	 * {@code ProjectUserRole.manageApiTokens}.
+	 */
+	private static final String MANAGE_API_TOKENS = "manageApiTokens";
+
 	private final ApiTokenService tokenService;
 	private final CurrentUserResolver currentUserResolver;
+	private final UserDtoMapper userDtoMapper;
 
-	public ApiTokenController(ApiTokenService tokenService, CurrentUserResolver currentUserResolver) {
+	public ApiTokenController(ApiTokenService tokenService, CurrentUserResolver currentUserResolver,
+			UserDtoMapper userDtoMapper) {
 		this.tokenService = tokenService;
 		this.currentUserResolver = currentUserResolver;
+		this.userDtoMapper = userDtoMapper;
+	}
+
+	/**
+	 * Resolve the current caller, requiring the {@code manageApiTokens} permission. Works for both
+	 * JWT and PAT callers (both load the user live). Returns the {@link User} when permitted, or a
+	 * 403 {@link ResponseEntity} otherwise — callers must return the entity as-is when present.
+	 */
+	private ManageAuth requireManageApiTokens() {
+		User user = currentUserResolver.resolve();
+		if (!userDtoMapper.getPermissionStrings(user).contains(MANAGE_API_TOKENS)) {
+			return new ManageAuth(null, ResponseEntity.status(HttpStatus.FORBIDDEN)
+					.body(ErrorResponse.of("FORBIDDEN",
+							"You do not have permission to manage API tokens")));
+		}
+		return new ManageAuth(user, null);
+	}
+
+	/** Either a permitted {@code user} or a {@code forbidden} 403 response (never both null). */
+	private record ManageAuth(User user, ResponseEntity<?> forbidden) {
 	}
 
 	/** Create request: a display name and optional expiry in days (null/0 = never expires). */
@@ -67,11 +96,15 @@ public class ApiTokenController {
 
 	@PostMapping
 	public ResponseEntity<?> create(@RequestBody(required = false) CreateApiTokenRequest request) {
+		ManageAuth auth = requireManageApiTokens();
+		if (auth.forbidden() != null) {
+			return auth.forbidden();
+		}
 		if (request == null || request.name() == null || request.name().isBlank()) {
 			return ResponseEntity.badRequest()
 					.body(ErrorResponse.of("BAD_REQUEST", "Token name is required"));
 		}
-		Long ownerId = currentUserResolver.resolve().getId();
+		Long ownerId = auth.user().getId();
 		ApiTokenService.IssuedToken issued = tokenService.create(ownerId, request.name().trim(),
 				request.expiresInDays());
 		return ResponseEntity.status(HttpStatus.CREATED)
@@ -79,14 +112,22 @@ public class ApiTokenController {
 	}
 
 	@GetMapping
-	public List<ApiTokenDto> list() {
-		Long ownerId = currentUserResolver.resolve().getId();
-		return tokenService.list(ownerId).stream().map(this::toDto).toList();
+	public ResponseEntity<?> list() {
+		ManageAuth auth = requireManageApiTokens();
+		if (auth.forbidden() != null) {
+			return auth.forbidden();
+		}
+		Long ownerId = auth.user().getId();
+		return ResponseEntity.ok(tokenService.list(ownerId).stream().map(this::toDto).toList());
 	}
 
 	@DeleteMapping("/{id}")
 	public ResponseEntity<?> revoke(@PathVariable("id") Long id) {
-		Long ownerId = currentUserResolver.resolve().getId();
+		ManageAuth auth = requireManageApiTokens();
+		if (auth.forbidden() != null) {
+			return auth.forbidden();
+		}
+		Long ownerId = auth.user().getId();
 		if (tokenService.revoke(ownerId, id)) {
 			return ResponseEntity.noContent().build();
 		}
@@ -101,7 +142,11 @@ public class ApiTokenController {
 	 */
 	@DeleteMapping("/{id}/permanent")
 	public ResponseEntity<?> delete(@PathVariable("id") Long id) {
-		Long ownerId = currentUserResolver.resolve().getId();
+		ManageAuth auth = requireManageApiTokens();
+		if (auth.forbidden() != null) {
+			return auth.forbidden();
+		}
+		Long ownerId = auth.user().getId();
 		switch (tokenService.delete(ownerId, id)) {
 			case DELETED:
 				return ResponseEntity.noContent().build();

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/config/ApiSecurityConfig.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/config/ApiSecurityConfig.java
@@ -88,11 +88,12 @@ public class ApiSecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/auth/login").permitAll()
                 .requestMatchers("/api/dev/**").permitAll()
-                // Personal access token management (#73): project users only. PATs act against
-                // project data, so a pure system admin (no project role) has no use for one; an
-                // admin who also holds ProjectUserRole still qualifies through that role.
+                // Personal access token management (#73, #85): authentication is enforced here;
+                // the finer-grained ManageApiTokens permission is checked in ApiTokenController
+                // (via getPermissionStrings), which resolves the live user for both JWT and PAT
+                // callers and returns 403 when the permission is absent.
                 .requestMatchers("/api/auth/tokens", "/api/auth/tokens/**")
-                    .hasRole("ProjectUserRole")
+                    .authenticated()
                 .requestMatchers("/api/users/organizations").authenticated()
                 .requestMatchers("/api/users/**").hasRole("SystemAdminUserRole")
                 .requestMatchers("/api/commands/NewUser").hasRole("SystemAdminUserRole")

--- a/requel-angular/src/app/features/users/settings.ts
+++ b/requel-angular/src/app/features/users/settings.ts
@@ -107,11 +107,11 @@ export class SettingsComponent implements OnInit {
   ) {}
 
   /**
-   * PATs act against project data, so only project users see the section. A pure system admin has
-   * no use for one; an admin who also holds ProjectUserRole still qualifies through that role.
+   * The PAT section is gated on the per-user manageApiTokens permission (#85), not the role.
+   * An admin who is granted the permission (via their ProjectUserRole) qualifies too.
    */
   canManageTokens(): boolean {
-    return this.authService.user()?.roles?.includes('ProjectUserRole') ?? false;
+    return this.authService.user()?.permissions?.includes('manageApiTokens') ?? false;
   }
 
   async ngOnInit(): Promise<void> {


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/85

Replace the PAT role-gate with a per-user ManageApiTokens permission

Fast-follow to #73. Slice 6 gated personal-access-token management on the
ProjectUserRole role; this replaces that coarse gate with a finer-grained,
per-user `manageApiTokens` UserRolePermission so token issuance can be
granted/revoked per user without changing their role.

Decisions (see doc/pat_ui_plan.md "Implemented (#85) — decisions"):
- Opt-in, admin-granted. Not auto-granted to existing users or on new-user
  creation. No backfill migration. manageApiTokens lives on ProjectUserRole
  only; an admin gets PAT access only if they also hold that role and are
  granted the permission.

Changes:

- modules/project-jpa/.../project/ProjectUserRole.java — declare the static
  `manageApiTokens` UserRolePermission constant, add it to the available set in
  the static block, and add `canManageApiTokens()`. This makes the permission
  available (persisted/cached by UserRolePermissionsInitializer) and grantable,
  but grants it to no one by default.

- modules/service-impl/.../service/config/ApiSecurityConfig.java — relax the
  `/api/auth/tokens` matcher from `.hasRole("ProjectUserRole")` to
  `.authenticated()`; the fine-grained permission check now lives in the
  controller (works for both JWT and PAT callers, which load the user live).

- modules/service-impl/.../service/auth/ApiTokenController.java — enforce the
  permission on all four endpoints (create/list/revoke/delete): resolve the
  current user and check `getPermissionStrings(user).contains("manageApiTokens")`,
  returning 403 otherwise. `list()` now returns ResponseEntity for uniform
  guarding.

- requel-angular/src/app/features/users/settings.ts — gate the PAT section on
  `permissions.includes('manageApiTokens')` instead of
  `roles.includes('ProjectUserRole')`. (UserDto already carries `permissions`;
  the user create/edit UI already renders the grant toggle generically from
  GET /api/users/roles, so no bespoke admin-UI change is needed.)

- modules/requel-app/src/test/.../TestRoleGrantHelper.java +
  AbstractIntegrationTestCase.java — add a transactional helper to grant the
  persisted `manageApiTokens` permission on a user's ProjectUserRole instance
  (grants the managed row, so no duplicate permission is inserted), exposed via
  a protected `grantManageApiTokens(username)`.

- modules/requel-app/src/test/.../service/ApiTokenIT.java — grant manageApiTokens
  to the token-managing users (admin, otherUser) so existing scenarios still
  pass; add a project user without the permission and assert 403 on create/list,
  and assert a granted project user can list and mint.

- doc/pat_ui_plan.md — record the #85 decisions and that the fast-follow shipped.

Closes #85
