### PR TITLE
4.1 Skip navigation and heading structure (#135)

### DIFF
--- a/requel-angular/src/app/features/actors/actor-editor.ts
+++ b/requel-angular/src/app/features/actors/actor-editor.ts
@@ -19,6 +19,7 @@
  *
  */
 import { Component, computed, OnDestroy, OnInit, signal } from '@angular/core';
+import { PageHeaderComponent } from '../../shared/page-header';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
@@ -43,14 +44,14 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
 @Component({
   selector: 'app-actor-editor',
   standalone: true,
-  imports: [FormsModule, ButtonModule, InputText, TextareaModule, TableModule,
+  imports: [PageHeaderComponent, FormsModule, ButtonModule, InputText, TextareaModule, TableModule,
             MessageModule, ConfirmDialogModule, EntitySelectorDialogComponent,
             AnnotationsSectionComponent],
   providers: [ConfirmationService],
   template: `
     <div class="actor-editor" data-testid="actor-editor">
       <div class="page-header">
-        <h2>{{ isNew() ? 'New Actor' : actorName() }}</h2>
+        <app-page-header [title]="isNew() ? 'New Actor' : actorName()" />
         <div class="page-actions">
           <p-button label="Back" icon="pi pi-arrow-left" severity="secondary" data-testid="actor-back"
                     [outlined]="true" (onClick)="onBack()" />

--- a/requel-angular/src/app/features/admin/global-tags.ts
+++ b/requel-angular/src/app/features/admin/global-tags.ts
@@ -19,6 +19,7 @@
  *
  */
 import { Component, OnInit, signal } from '@angular/core';
+import { PageHeaderComponent } from '../../shared/page-header';
 import { FormsModule } from '@angular/forms';
 import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
@@ -36,10 +37,10 @@ import { TagService } from '../../core/tag.service';
 @Component({
   selector: 'app-global-tags',
   standalone: true,
-  imports: [FormsModule, TableModule, ButtonModule, InputText, MessageModule],
+  imports: [PageHeaderComponent, FormsModule, TableModule, ButtonModule, InputText, MessageModule],
   template: `
     <div class="global-tags" data-testid="global-tags">
-      <div class="page-header"><h2>Global Tags</h2></div>
+      <div class="page-header"><app-page-header title="Global Tags" /></div>
 
       @if (errorMessage()) {
         <p-message severity="error" [text]="errorMessage()!" />
@@ -84,7 +85,6 @@ import { TagService } from '../../core/tag.service';
   styles: [`
     .global-tags { max-width: 800px; }
     .page-header { margin-bottom: 1rem; }
-    .page-header h2 { margin: 0; }
     .add-row { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 1rem; flex-wrap: wrap; }
     .cat-input, .val-input { max-width: 220px; }
     .text-center { text-align: center; }

--- a/requel-angular/src/app/features/admin/tag-categories.ts
+++ b/requel-angular/src/app/features/admin/tag-categories.ts
@@ -19,6 +19,7 @@
  *
  */
 import { Component, OnInit, signal } from '@angular/core';
+import { PageHeaderComponent } from '../../shared/page-header';
 import { FormsModule } from '@angular/forms';
 import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
@@ -37,10 +38,10 @@ import { TagService } from '../../core/tag.service';
 @Component({
   selector: 'app-tag-categories',
   standalone: true,
-  imports: [FormsModule, TableModule, ButtonModule, InputText, CheckboxModule, MessageModule],
+  imports: [PageHeaderComponent, FormsModule, TableModule, ButtonModule, InputText, CheckboxModule, MessageModule],
   template: `
     <div class="tag-categories" data-testid="tag-categories">
-      <div class="page-header"><h2>Global Tag Categories</h2></div>
+      <div class="page-header"><app-page-header title="Global Tag Categories" /></div>
 
       @if (errorMessage()) {
         <p-message severity="error" [text]="errorMessage()!" />
@@ -92,7 +93,6 @@ import { TagService } from '../../core/tag.service';
   styles: [`
     .tag-categories { max-width: 960px; }
     .page-header { margin-bottom: 1rem; }
-    .page-header h2 { margin: 0; }
     .add-row { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 1rem; flex-wrap: wrap; }
     .excl { display: inline-flex; align-items: center; gap: 0.35rem; }
     .name-input, .color-input { max-width: 160px; }

--- a/requel-angular/src/app/features/auth/dashboard.spec.ts
+++ b/requel-angular/src/app/features/auth/dashboard.spec.ts
@@ -1,0 +1,22 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { DashboardComponent } from './dashboard';
+import { AuthService } from '../../core/auth.service';
+
+describe('DashboardComponent (issue #135)', () => {
+  it('renders exactly one <h1> page title and no <h2>', () => {
+    TestBed.configureTestingModule({
+      imports: [DashboardComponent],
+      providers: [
+        { provide: AuthService, useValue: { user: signal({ username: 'admin', name: 'Admin' }) } }
+      ]
+    });
+    const fixture = TestBed.createComponent(DashboardComponent);
+    fixture.detectChanges();
+
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelectorAll('h1').length).toBe(1);
+    expect(el.querySelectorAll('h2').length).toBe(0);
+    expect(el.querySelector('h1')?.textContent).toContain('Welcome, Admin');
+  });
+});

--- a/requel-angular/src/app/features/auth/layout.spec.ts
+++ b/requel-angular/src/app/features/auth/layout.spec.ts
@@ -1,0 +1,56 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+import { LayoutComponent } from './layout';
+import { AuthService } from '../../core/auth.service';
+import { EventStreamService } from '../../core/event-stream.service';
+import { SidebarNavComponent } from '../../shared/sidebar-nav';
+
+// Lightweight stand-in for the sidebar so the layout can render without the
+// sidebar's data services / SSE subscriptions.
+@Component({ selector: 'app-sidebar-nav', standalone: true, template: '' })
+class SidebarNavStubComponent {}
+
+describe('LayoutComponent accessibility (issue #135)', () => {
+  function createFixture() {
+    TestBed.configureTestingModule({
+      imports: [LayoutComponent],
+      providers: [
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: AuthService, useValue: { user: signal(null), logout: vi.fn() } },
+        { provide: EventStreamService, useValue: { connect: vi.fn() } }
+      ]
+    });
+    TestBed.overrideComponent(LayoutComponent, {
+      remove: { imports: [SidebarNavComponent] },
+      add: { imports: [SidebarNavStubComponent] }
+    });
+    const fixture = TestBed.createComponent(LayoutComponent);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('renders a skip link as the first focusable element, targeting #main-content', () => {
+    const el: HTMLElement = createFixture().nativeElement;
+
+    const skip = el.querySelector<HTMLAnchorElement>('a.skip-link');
+    expect(skip).toBeTruthy();
+    expect(skip!.getAttribute('href')).toBe('#main-content');
+
+    const focusable = el.querySelectorAll<HTMLElement>(
+      'a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    expect(focusable.length).toBeGreaterThan(0);
+    expect(focusable[0]).toBe(skip);
+  });
+
+  it('exposes <main> as a focus target with id="main-content" and tabindex="-1"', () => {
+    const el: HTMLElement = createFixture().nativeElement;
+
+    const main = el.querySelector<HTMLElement>('main#main-content');
+    expect(main).toBeTruthy();
+    expect(main!.getAttribute('tabindex')).toBe('-1');
+  });
+});

--- a/requel-angular/src/app/features/auth/layout.ts
+++ b/requel-angular/src/app/features/auth/layout.ts
@@ -39,6 +39,7 @@ import { MenuItem, MessageService } from 'primeng/api';
   providers: [MessageService],
   template: `
     <p-toast />
+    <a class="skip-link" href="#main-content">Skip to content</a>
     <div class="layout">
       <header class="app-header">
         <a routerLink="/" class="header-brand" data-testid="header-brand">
@@ -57,13 +58,29 @@ import { MenuItem, MessageService } from 'primeng/api';
         <aside class="sidebar">
           <app-sidebar-nav />
         </aside>
-        <main class="main-content">
+        <main id="main-content" class="main-content" tabindex="-1">
           <router-outlet />
         </main>
       </div>
     </div>
   `,
   styles: [`
+    .skip-link {
+      position: absolute;
+      left: 0.5rem;
+      top: -3rem;
+      z-index: 1100;
+      padding: 0.5rem 1rem;
+      background: #1a1a7e;
+      color: #ffffff;
+      border-radius: 0 0 4px 4px;
+      text-decoration: none;
+      transition: top 0.15s ease-in-out;
+    }
+    .skip-link:focus {
+      top: 0;
+    }
+
     .layout {
       display: flex;
       flex-direction: column;

--- a/requel-angular/src/app/features/auth/login.spec.ts
+++ b/requel-angular/src/app/features/auth/login.spec.ts
@@ -25,6 +25,15 @@ describe('LoginComponent', () => {
     comp = fixture.componentInstance;
   });
 
+  it('renders exactly one <h1> page title and no <h2> (issue #135)', () => {
+    const fixture = TestBed.createComponent(LoginComponent);
+    fixture.detectChanges();
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelectorAll('h1').length).toBe(1);
+    expect(el.querySelectorAll('h2').length).toBe(0);
+    expect(el.querySelector('h1')?.textContent?.trim()).toBe('Requel');
+  });
+
   it('onLogin() calls authService.login with the entered credentials', async () => {
     comp.username.set('admin');
     comp.password.set('secret');

--- a/requel-angular/src/app/features/auth/login.ts
+++ b/requel-angular/src/app/features/auth/login.ts
@@ -34,7 +34,7 @@ import { AuthService } from '../../core/auth.service';
   template: `
     <div class="login-container">
       <div class="login-card">
-        <h2>Requel</h2>
+        <h1>Requel</h1>
         <p class="subtitle">Requirements Elicitation System</p>
 
         @if (errorMessage()) {
@@ -77,7 +77,7 @@ import { AuthService } from '../../core/auth.service';
       width: 100%;
       max-width: 400px;
     }
-    h2 { margin: 0 0 0.25rem; text-align: center; }
+    h1 { margin: 0 0 0.25rem; text-align: center; font-size: 1.5rem; }
     .subtitle { text-align: center; color: var(--p-text-muted-color); margin: 0 0 1.5rem; }
     .field { margin-bottom: 1rem; }
     .field label { display: block; margin-bottom: 0.5rem; font-weight: 500; }

--- a/requel-angular/src/app/features/goals/goal-editor.ts
+++ b/requel-angular/src/app/features/goals/goal-editor.ts
@@ -19,6 +19,7 @@
  *
  */
 import { Component, OnDestroy, OnInit, signal } from '@angular/core';
+import { PageHeaderComponent } from '../../shared/page-header';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
@@ -45,14 +46,14 @@ import { TagSelectorComponent } from '../../shared/tag-selector';
 @Component({
   selector: 'app-goal-editor',
   standalone: true,
-  imports: [FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
+  imports: [PageHeaderComponent, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
             TableModule, MessageModule, ConfirmDialogModule, EntitySelectorDialogComponent,
             AnnotationsSectionComponent, TagSelectorComponent],
   providers: [ConfirmationService],
   template: `
     <div class="goal-editor" data-testid="goal-editor">
       <div class="page-header">
-        <h2>{{ isNew() ? 'New Goal' : goalName() }}</h2>
+        <app-page-header [title]="isNew() ? 'New Goal' : goalName()" />
         <div class="page-actions">
           <p-button label="Back" icon="pi pi-arrow-left" severity="secondary" data-testid="goal-back"
                     [outlined]="true" (onClick)="onBack()" />

--- a/requel-angular/src/app/features/projects/project-editor.ts
+++ b/requel-angular/src/app/features/projects/project-editor.ts
@@ -19,6 +19,7 @@
  *
  */
 import { Component, OnInit, OnDestroy, signal, computed, ViewChild } from '@angular/core';
+import { PageHeaderComponent } from '../../shared/page-header';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormsModule, NgForm } from '@angular/forms';
 import { InputText } from 'primeng/inputtext';
@@ -41,12 +42,12 @@ import { TagSelectorComponent } from '../../shared/tag-selector';
 @Component({
   selector: 'app-project-editor',
   standalone: true,
-  imports: [FormsModule, InputText, TextareaModule, ButtonModule, SelectModule, MessageModule, ConfirmDialogModule, TagSelectorComponent],
+  imports: [PageHeaderComponent, FormsModule, InputText, TextareaModule, ButtonModule, SelectModule, MessageModule, ConfirmDialogModule, TagSelectorComponent],
   providers: [ConfirmationService],
   template: `
     <div class="project-editor" data-testid="project-editor">
       <div class="page-header">
-        <h2>{{ isNew() ? 'New Project' : 'Project: ' + originalName() }}</h2>
+        <app-page-header [title]="isNew() ? 'New Project' : 'Project: ' + originalName()" />
         <div class="page-actions">
           @if (!isNew()) {
             <p-button icon="pi pi-download" label="Export" [outlined]="true"
@@ -106,7 +107,6 @@ import { TagSelectorComponent } from '../../shared/tag-selector';
   styles: [`
     .project-editor { max-width: 800px; }
     .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
-    .page-header h2 { margin: 0; }
     .form-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1.5rem; }
     .field { display: flex; flex-direction: column; gap: 0.5rem; }
     .field label { font-weight: 500; }

--- a/requel-angular/src/app/features/reports/report-editor.ts
+++ b/requel-angular/src/app/features/reports/report-editor.ts
@@ -19,6 +19,7 @@
  *
  */
 import { Component, OnDestroy, OnInit, signal } from '@angular/core';
+import { PageHeaderComponent } from '../../shared/page-header';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
@@ -37,13 +38,13 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
 @Component({
   selector: 'app-report-editor',
   standalone: true,
-  imports: [FormsModule, ButtonModule, InputText, TextareaModule, MessageModule,
+  imports: [PageHeaderComponent, FormsModule, ButtonModule, InputText, TextareaModule, MessageModule,
             ConfirmDialogModule, AnnotationsSectionComponent],
   providers: [ConfirmationService],
   template: `
     <div class="report-editor" data-testid="report-editor">
       <div class="page-header">
-        <h2>{{ isNew() ? 'New Document' : reportName() }}</h2>
+        <app-page-header [title]="isNew() ? 'New Document' : reportName()" />
         <div class="page-actions">
           <p-button label="Back" icon="pi pi-arrow-left" severity="secondary" data-testid="report-back"
                     [outlined]="true" (onClick)="onBack()" />

--- a/requel-angular/src/app/features/scenarios/scenario-editor.ts
+++ b/requel-angular/src/app/features/scenarios/scenario-editor.ts
@@ -19,6 +19,7 @@
  *
  */
 import { Component, OnDestroy, OnInit, signal } from '@angular/core';
+import { PageHeaderComponent } from '../../shared/page-header';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Location } from '@angular/common';
 import { Subscription } from 'rxjs';
@@ -62,14 +63,14 @@ interface StepNodeData {
 @Component({
   selector: 'app-scenario-editor',
   standalone: true,
-  imports: [FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
+  imports: [PageHeaderComponent, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
             MessageModule, ConfirmDialogModule, TooltipModule, DragDropModule,
             ScenarioSelectorDialogComponent, AnnotationsSectionComponent],
   providers: [ConfirmationService],
   template: `
     <div class="scenario-editor" data-testid="scenario-editor">
       <div class="page-header">
-        <h2>{{ isNew() ? 'New Scenario' : scenarioName() }}</h2>
+        <app-page-header [title]="isNew() ? 'New Scenario' : scenarioName()" />
         <div class="page-actions">
           <p-button label="Back" icon="pi pi-arrow-left" severity="secondary" data-testid="scenario-back"
                     [outlined]="true" (onClick)="onBack()" />

--- a/requel-angular/src/app/features/stakeholders/stakeholder-editor.ts
+++ b/requel-angular/src/app/features/stakeholders/stakeholder-editor.ts
@@ -19,6 +19,7 @@
  *
  */
 import { Component, computed, OnDestroy, OnInit, signal } from '@angular/core';
+import { PageHeaderComponent } from '../../shared/page-header';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
@@ -50,14 +51,14 @@ interface PermissionGroup {
 @Component({
   selector: 'app-stakeholder-editor',
   standalone: true,
-  imports: [FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
+  imports: [PageHeaderComponent, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
             CheckboxModule, MessageModule, ConfirmDialogModule, TableModule,
             EntitySelectorDialogComponent],
   providers: [ConfirmationService],
   template: `
     <div class="stakeholder-editor">
       <div class="page-header">
-        <h2>{{ isNew() ? (isUserType() ? 'Add User Stakeholder' : 'Add Non-User Stakeholder') : stakeholderName() }}</h2>
+        <app-page-header [title]="isNew() ? (isUserType() ? 'Add User Stakeholder' : 'Add Non-User Stakeholder') : stakeholderName()" />
         <div class="page-actions">
           <p-button label="Back" icon="pi pi-arrow-left" severity="secondary"
                     [outlined]="true" (onClick)="onBack()" />

--- a/requel-angular/src/app/features/stories/story-editor.ts
+++ b/requel-angular/src/app/features/stories/story-editor.ts
@@ -19,6 +19,7 @@
  *
  */
 import { Component, OnDestroy, OnInit, signal } from '@angular/core';
+import { PageHeaderComponent } from '../../shared/page-header';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
@@ -45,14 +46,14 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
 @Component({
   selector: 'app-story-editor',
   standalone: true,
-  imports: [FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
+  imports: [PageHeaderComponent, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
             TableModule, MessageModule, ConfirmDialogModule, EntitySelectorDialogComponent,
             AnnotationsSectionComponent],
   providers: [ConfirmationService],
   template: `
     <div class="story-editor" data-testid="story-editor">
       <div class="page-header">
-        <h2>{{ isNew() ? 'New Story' : storyName() }}</h2>
+        <app-page-header [title]="isNew() ? 'New Story' : storyName()" />
         <div class="page-actions">
           <p-button label="Back" icon="pi pi-arrow-left" severity="secondary"
                     data-testid="story-back"

--- a/requel-angular/src/app/features/terms/term-editor.ts
+++ b/requel-angular/src/app/features/terms/term-editor.ts
@@ -19,6 +19,7 @@
  *
  */
 import { Component, OnDestroy, OnInit, signal } from '@angular/core';
+import { PageHeaderComponent } from '../../shared/page-header';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
@@ -40,13 +41,13 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
 @Component({
   selector: 'app-term-editor',
   standalone: true,
-  imports: [FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
+  imports: [PageHeaderComponent, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
             TableModule, MessageModule, ConfirmDialogModule, AnnotationsSectionComponent],
   providers: [ConfirmationService],
   template: `
     <div class="term-editor" data-testid="term-editor">
       <div class="page-header">
-        <h2>{{ isNew() ? 'New Glossary Term' : termName() }}</h2>
+        <app-page-header [title]="isNew() ? 'New Glossary Term' : termName()" />
         <div class="page-actions">
           <p-button label="Back" icon="pi pi-arrow-left" severity="secondary" data-testid="term-back"
                     [outlined]="true" (onClick)="onBack()" />

--- a/requel-angular/src/app/features/use-cases/use-case-editor.ts
+++ b/requel-angular/src/app/features/use-cases/use-case-editor.ts
@@ -19,6 +19,7 @@
  *
  */
 import { Component, computed, OnDestroy, OnInit, signal } from '@angular/core';
+import { PageHeaderComponent } from '../../shared/page-header';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Location } from '@angular/common';
 import { Subscription } from 'rxjs';
@@ -52,14 +53,14 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
 @Component({
   selector: 'app-use-case-editor',
   standalone: true,
-  imports: [FormsModule, ButtonModule, InputText, TextareaModule, MessageModule,
+  imports: [PageHeaderComponent, FormsModule, ButtonModule, InputText, TextareaModule, MessageModule,
             ConfirmDialogModule, TableModule, TooltipModule, SelectModule,
             EntitySelectorDialogComponent, AnnotationsSectionComponent],
   providers: [ConfirmationService],
   template: `
     <div class="use-case-editor" data-testid="use-case-editor">
       <div class="page-header">
-        <h2>{{ isNew() ? 'New Use Case' : useCaseName() }}</h2>
+        <app-page-header [title]="isNew() ? 'New Use Case' : useCaseName()" />
         <div class="page-actions">
           <p-button label="Back" icon="pi pi-arrow-left" severity="secondary"
                     [outlined]="true" (onClick)="onBack()" />

--- a/requel-angular/src/app/features/users/edit-account.ts
+++ b/requel-angular/src/app/features/users/edit-account.ts
@@ -19,6 +19,7 @@
  *
  */
 import { Component, OnInit, signal, computed, ViewChild } from '@angular/core';
+import { PageHeaderComponent } from '../../shared/page-header';
 import { FormsModule, NgForm } from '@angular/forms';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
 import { InputText } from 'primeng/inputtext';
@@ -38,10 +39,10 @@ import { UserService } from '../../core/user.service';
 @Component({
   selector: 'app-edit-account',
   standalone: true,
-  imports: [FormsModule, InputText, Password, SelectModule, ButtonModule, MessageModule],
+  imports: [PageHeaderComponent, FormsModule, InputText, Password, SelectModule, ButtonModule, MessageModule],
   template: `
     <div class="edit-account" data-testid="account-editor">
-      <h2>Edit Account</h2>
+      <app-page-header title="Edit Account" />
 
       @if (errorMessage()) {
         <p-message severity="error" [text]="errorMessage()!" />

--- a/requel-angular/src/app/features/users/settings.ts
+++ b/requel-angular/src/app/features/users/settings.ts
@@ -19,6 +19,7 @@
  *
  */
 import { ChangeDetectorRef, Component, OnInit, signal } from '@angular/core';
+import { PageHeaderComponent } from '../../shared/page-header';
 import { FormsModule } from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
 import { InputNumberModule } from 'primeng/inputnumber';
@@ -32,12 +33,12 @@ import { ApiTokensComponent } from './api-tokens';
 @Component({
   selector: 'app-settings',
   standalone: true,
-  imports: [FormsModule, ButtonModule, InputNumberModule, SelectModule, MessageModule,
+  imports: [PageHeaderComponent, FormsModule, ButtonModule, InputNumberModule, SelectModule, MessageModule,
     ApiTokensComponent],
   template: `
     <div class="settings" data-testid="settings-page">
       <div class="page-header">
-        <h2>Settings</h2>
+        <app-page-header title="Settings" />
       </div>
 
       @if (successMessage()) {
@@ -82,7 +83,6 @@ import { ApiTokensComponent } from './api-tokens';
   styles: [`
     .settings { max-width: 600px; }
     .page-header { margin-bottom: 1.5rem; }
-    .page-header h2 { margin: 0; }
     .settings-form { display: flex; flex-direction: column; gap: 1.5rem; }
     .field { display: flex; flex-direction: column; gap: 0.25rem; }
     .field label { font-weight: 600; }

--- a/requel-angular/src/app/features/users/user-editor.ts
+++ b/requel-angular/src/app/features/users/user-editor.ts
@@ -19,6 +19,7 @@
  *
  */
 import { ChangeDetectorRef, Component, OnDestroy, OnInit, signal, computed, ViewChild } from '@angular/core';
+import { PageHeaderComponent } from '../../shared/page-header';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { FormsModule, NgForm } from '@angular/forms';
@@ -37,10 +38,10 @@ import { CommandService } from '../../core/command.service';
 @Component({
   selector: 'app-user-editor',
   standalone: true,
-  imports: [FormsModule, InputText, Password, ButtonModule, CheckboxModule, SelectModule, MessageModule],
+  imports: [PageHeaderComponent, FormsModule, InputText, Password, ButtonModule, CheckboxModule, SelectModule, MessageModule],
   template: `
     <div class="user-editor" data-testid="user-editor">
-      <h2>{{ isNew() ? 'New User' : 'Edit User: ' + username }}</h2>
+      <app-page-header [title]="isNew() ? 'New User' : 'Edit User: ' + username" />
 
       @if (errorMessage()) {
         <p-message severity="error" [text]="errorMessage()!" />

--- a/requel-angular/src/app/shared/list-page.ts
+++ b/requel-angular/src/app/shared/list-page.ts
@@ -20,15 +20,16 @@
  */
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { InputText } from 'primeng/inputtext';
+import { PageHeaderComponent } from './page-header';
 
 @Component({
   selector: 'app-list-page',
   standalone: true,
-  imports: [InputText],
+  imports: [PageHeaderComponent, InputText],
   template: `
     <div class="list-page-wrap">
       <div class="page-header">
-        <h2>{{ title }}</h2>
+        <app-page-header [title]="title" />
         <div class="page-actions">
           <ng-content select="[actions]" />
         </div>
@@ -48,7 +49,6 @@ import { InputText } from 'primeng/inputtext';
   `,
   styles: [`
     .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
-    .page-header h2 { margin: 0; }
     .page-actions { display: flex; gap: 0.5rem; }
     .search-bar { margin-bottom: 1rem; }
   `]

--- a/requel-angular/src/app/shared/page-header.spec.ts
+++ b/requel-angular/src/app/shared/page-header.spec.ts
@@ -1,0 +1,26 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { PageHeaderComponent } from './page-header';
+
+@Component({
+  standalone: true,
+  imports: [PageHeaderComponent],
+  template: `<app-page-header [title]="title" />`
+})
+class HostComponent {
+  title = 'My Page';
+}
+
+describe('PageHeaderComponent (issue #135)', () => {
+  it('renders exactly one <h1> containing the title and no <h2>', () => {
+    TestBed.configureTestingModule({ imports: [HostComponent] });
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+
+    const el: HTMLElement = fixture.nativeElement;
+    const h1s = el.querySelectorAll('h1');
+    expect(h1s.length).toBe(1);
+    expect(h1s[0].textContent?.trim()).toBe('My Page');
+    expect(el.querySelectorAll('h2').length).toBe(0);
+  });
+});

--- a/requel-angular/src/app/shared/page-header.ts
+++ b/requel-angular/src/app/shared/page-header.ts
@@ -18,28 +18,30 @@
  * along with Requel. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import { Component, computed } from '@angular/core';
-import { AuthService } from '../../core/auth.service';
-import { PageHeaderComponent } from '../../shared/page-header';
+import { Component, Input } from '@angular/core';
 
 /**
- * Placeholder dashboard shown after login. Will be replaced with
- * the project list / workspace view in Phase 1.
+ * Shared page title. Renders the single <h1> for a route so every page has a
+ * consistent, unique top-level heading (WCAG 2.4.6, 1.3.1 - see issue #135).
+ *
+ * The host uses `display: contents` so the <h1> participates directly in the
+ * parent layout (e.g. an existing `.page-header` flex row), preserving the
+ * previous <h2>-based markup and spacing. The h1 is pinned to the former h2
+ * size so converting the tag does not change the visual size.
  */
 @Component({
-  selector: 'app-dashboard',
+  selector: 'app-page-header',
   standalone: true,
-  imports: [PageHeaderComponent],
-  template: `
-    <app-page-header [title]="'Welcome, ' + displayName()" />
-    <p>Select a project from the sidebar to begin working on requirements.</p>
-  `
+  template: `<h1 class="page-title">{{ title }}</h1>`,
+  styles: [`
+    :host { display: contents; }
+    .page-title {
+      margin: 0;
+      font-size: 1.5rem;
+      font-weight: 700;
+    }
+  `]
 })
-export class DashboardComponent {
-  readonly displayName = computed(() => {
-    const user = this.authService.user();
-    return user?.name ?? user?.username ?? 'User';
-  });
-
-  constructor(private authService: AuthService) {}
+export class PageHeaderComponent {
+  @Input() title = '';
 }


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/135

Add skip navigation and standardize one h1 per route (Finding 4.1)

Addresses the UI/UX review Finding 4.1 (WCAG 2.4.1 Bypass Blocks, 2.4.6
Headings and Labels, 1.3.1 Info and Relationships): the shell had no skip
link and page titles were rendered as h2 with no consistent h1 per route.

Changes:

- requel-angular/src/app/shared/page-header.ts (new): shared PageHeaderComponent
  that renders the single <h1> page title for a route. Host uses
  `display: contents` so the h1 slots directly into existing `.page-header`
  flex rows, and the h1 is pinned to 1.5rem/700 to preserve the previous h2
  visual size (no size change, just the correct heading level).

- requel-angular/src/app/features/auth/layout.ts: add a skip link
  (`<a class="skip-link" href="#main-content">`) as the first focusable
  element, visually hidden until focused. Give <main> `id="main-content"` and
  `tabindex="-1"` so the skip target can receive focus.

- Converted every page-title h2 to a single h1 per route: list-page.ts (covers
  all list routes) and the goal, project, term, stakeholder, use-case, story,
  actor, scenario, report, user, settings and edit-account editors plus the
  admin global-tags/tag-categories pages now use <app-page-header>. dashboard.ts
  uses it too; login.ts converts its branding heading to an h1 (size preserved).
  Removed the now-dead `.page-header h2` CSS rules.

- Tests (Vitest): page-header.spec.ts asserts exactly one h1 with the title;
  layout.spec.ts asserts the skip link is the first focusable element and
  targets #main-content, and that <main> exposes id/tabindex; dashboard.spec.ts
  and an added login.spec.ts case assert one h1 / no h2 per route.

Full suite green: 56 files, 345 tests passing.

Closes #135
