### PR TITLE
Make interactive elements keyboard-operable, named, and focus-visible (#136, #137)

### DIFF
--- a/doc/136-a11y-interactive-elements-plan.md
+++ b/doc/136-a11y-interactive-elements-plan.md
@@ -1,0 +1,121 @@
+# Issue #136 — Interactive elements: keyboard, roles, focus (folds in Finding 4.3)
+
+Source: `doc/UI_UX_REVIEW.md` Findings 4.2 and 4.3.
+Issue: https://github.com/rreganjr/Requel/issues/136 (Finding 4.2, High, 3–5 days).
+Folded in: Finding 4.3 (icon-only button accessible names, High, 1–2 days) — same files/lines, done in one pass to avoid double edits and merge conflicts.
+
+WCAG addressed: 2.1.1 Keyboard, 2.1.3 Keyboard (No Exception), 2.4.7 Focus Visible, 4.1.2 Name/Role/Value, 2.5.3 Label in Name.
+
+## Summary
+
+Make every navigation and action affordance a real, keyboard-operable element with an accessible name and a visible keyboard focus ring:
+
+1. Convert click-only `<a class="entity-link">` anchors to real `[routerLink]` anchors.
+2. Convert clickable `<div class="add-step-row">` controls to real `<button type="button">`.
+3. Normalize the tag-remove control and mark its glyph decorative.
+4. Add a global `:focus-visible` outline (Aura-matched) so custom controls show a keyboard focus ring.
+5. (4.3) Add `ariaLabel` to every icon-only `p-button`, with row context where possible; mark decorative icons `aria-hidden`.
+
+All navigation targets are already clean routes of the form `['/projects', projectName, <segment>, id]`, so the anchor conversions carry no behavior change.
+
+## Focus-visible spec (locked)
+
+Add one global rule to `requel-angular/src/styles.scss`. Rationale: the app has no existing focus styling, and PrimeNG's Aura preset applies its own focus ring via **`outline`** (primitive `focusRing: { width: 1px, style: solid, color: {primary.color}, offset: 2px, shadow: none }`). Using `outline` for our custom controls therefore matches native PrimeNG controls exactly — no box-shadow mismatch.
+
+```scss
+:focus-visible {
+  outline: var(--p-focus-ring-width, 1px) var(--p-focus-ring-style, solid)
+           var(--p-focus-ring-color, var(--p-primary-color));
+  outline-offset: var(--p-focus-ring-offset, 2px);
+}
+```
+
+- `:focus-visible` (not `:focus`) → ring on keyboard focus only, hidden on mouse click.
+- Aura tokens with literal fallbacks that mirror the Aura primitive → tracks theme changes, matches PrimeNG.
+- Global scope is intentional so future interactive elements are covered automatically; PrimeNG components keep their own ring (this only complements them).
+
+## Change inventory
+
+### 4.2a — Anchor → `[routerLink]`
+
+Each `<a class="entity-link" (click)="navigateX(...)">` becomes `<a class="entity-link" [routerLink]="['/projects', projectName, '<segment>', id]">`. The `(click)` handler and its `navigateX` method are removed once no longer referenced. `RouterLink` must be added to each component's standalone `imports` (none import it today).
+
+| File | Lines (current) | Route segment |
+|------|-----------------|---------------|
+| `features/goals/goal-editor.ts` | 112, 138 | `goals` |
+| `features/stories/story-editor.ts` | 138, 172 | `goals`, `actors` |
+| `features/actors/actor-editor.ts` | 117, 157, 170 | `goals`, `use-cases`, `stories` |
+| `features/use-cases/use-case-editor.ts` | 136, 184, 244, 282, 321 | `scenarios`, `goals`, `stories`, `actors` |
+| `features/scenarios/scenario-editor.ts` | 152 | `scenarios` |
+| `features/open-issues/open-issues.ts` | 91 | see special case below |
+
+**Special case — `open-issues.ts`.** `navigateTo` maps `entityType → segment` via `ENTITY_ROUTES` and no-ops when unmapped. This is not a literal `[routerLink]`. Replace with an anchor bound to a computed route, e.g. a `routeFor(issue)` helper returning `['/projects', projectName, ENTITY_ROUTES[issue.entityType], issue.entityId]` or `null`; render a plain `[routerLink]` anchor when a route exists and non-link text when it does not (preserves the current "unmapped = not clickable" behavior).
+
+### 4.2b — Clickable `div` → `<button>`
+
+`features/scenarios/scenario-editor.ts` lines 135 (`scenario-add-step-top`) and 188 (`scenario-add-step-bottom`):
+
+```html
+<button type="button" class="add-step-row" data-testid="scenario-add-step-top" (click)="addStepAt(0)">
+  <i class="pi pi-plus" aria-hidden="true"></i>
+  <span>Add step</span>
+</button>
+```
+
+Update the `.add-step-row` styles (lines ~274–282) so the `<button>` matches the previous full-width look: reset `button` UA styling (`border`, `background`, `width: 100%`, `text-align: left`, `font: inherit`, `cursor: pointer`), keep the existing hover rule. Keep the `data-testid`s so specs still resolve. (Do not remove the drag-and-drop wiring on the step rows.)
+
+### 4.2c — Tag remove control
+
+`shared/tag-selector.ts` (lines ~50–52 markup, ~94–95 `.chip-x` styles): already a `<button type="button">` with `aria-label="Remove tag"`. Make the `×` glyph decorative and give clearer context:
+
+```html
+<button type="button" class="chip-x" data-testid="tag-remove"
+        [attr.aria-label]="'Remove tag ' + label(t)" (click)="removeTag(t)">
+  <span aria-hidden="true">×</span>
+</button>
+```
+
+Focus ring is covered by the global `:focus-visible` rule (the `.chip-x` reset currently strips any default outline).
+
+### 4.3 — Accessible names on icon-only `p-button`s
+
+Add `[ariaLabel]` (with row context where a name is in scope) to each icon-only button. Tooltips are not a substitute. Mark purely decorative standalone icons `aria-hidden="true"`.
+
+| File | Lines (current) | Note |
+|------|-----------------|------|
+| `shared/annotations-section.ts` | 95, 118, 147, 163 | trash/remove buttons |
+| `features/stories/story-editor.ts` | 140, 174 | remove relation |
+| `features/use-cases/use-case-editor.ts` | 189, 249, 288, 326 | remove relation (also has tooltips) |
+| `features/actors/actor-editor.ts` | 122 | remove relation |
+| `features/admin/global-tags.ts` | 74 | delete row |
+| `features/admin/tag-categories.ts` | 82 | delete row |
+| `features/scenarios/scenario-editor.ts` | 155, 169, 173, 177 | remove/edit/add-below/remove step |
+
+Example: `[ariaLabel]="'Remove goal ' + goal.name"`.
+
+## Testing
+
+Add/extend the `.spec.ts` for each touched component, using existing `data-testid` hooks:
+
+- Entity links: assert the element is an `<a>` exposing the expected `routerLink` (via `RouterLinkWithHref` / `By.directive(RouterLink)` or the rendered `href`), and that the old click-navigation method is gone.
+- Add-step controls: assert the `scenario-add-step-*` elements are `<button>` and invoke `addStepAt(0)` / `addStep()` on click.
+- Tag remove: assert `tag-remove` is a `<button>` with a contextful `aria-label`.
+- Icon-only buttons (4.3): assert each target `p-button` renders a non-empty `aria-label` on its host button.
+- `open-issues`: assert a mapped entity type renders a `routerLink` anchor and an unmapped type renders non-link text.
+
+Keep `RouterTestingModule` / `provideRouter([])` in the relevant specs so `routerLink` resolves.
+
+## Verification / acceptance criteria
+
+- `cd requel-angular && ng test --watch=false` is green (includes the new assertions).
+- `mvn clean verify` is green.
+- Manual keyboard pass: every entity link, add-step button, tag-remove, and icon-only action is reachable by Tab, activates with Enter/Space, and shows a visible focus outline; screen reader announces a meaningful name for each (no bare "button").
+- No behavior regressions in navigation or drag-and-drop step reordering.
+
+## Workflow (per CLAUDE.md — actions only when told)
+
+1. Branch from `release/2.0`: `136-a11y-interactive-elements`.
+2. Implement 4.2 + 4.3 + focus rule; run `ng test` and `mvn verify`.
+3. Write `commit.md` with `Closes #136` (and reference Finding 4.3 / its issue if one exists).
+4. Commit + push on the ticket branch; open PR `--base release/2.0`.
+5. After squash-merge, close #136 (and the 4.3 issue) explicitly — `release/2.0` is not the default branch, so auto-close will not fire.

--- a/requel-angular/src/app/features/actors/actor-editor.spec.ts
+++ b/requel-angular/src/app/features/actors/actor-editor.spec.ts
@@ -291,18 +291,25 @@ describe('ActorEditorComponent', () => {
     expect(comp.errorMessage()).toBe('Not allowed');
   });
 
-  it('onGoalClick navigates to the goal editor', () => {
-    comp.projectName = 'proj1';
-    comp.onGoalClick(42);
-    expect(router.navigate).toHaveBeenCalledWith(['/projects', 'proj1', 'goals', 42]);
+  it('renders the goal link as a routerLink anchor', async () => {
+    paramMap$.next(convertToParamMap({ name: 'proj1', actorId: '5' }));
+    fixture.detectChanges();
+    await flush();
+    fixture.detectChanges();
+    const a = fixture.nativeElement.querySelector('[data-testid="actor-goal-link"]');
+    expect(a.tagName).toBe('A');
+    expect(a.getAttribute('href')).toBe('/projects/proj1/goals/1');
   });
 
-  it('navigate(type, id) navigates to that entity editor', () => {
-    comp.projectName = 'proj1';
-    comp.navigate('use-cases', 30);
-    expect(router.navigate).toHaveBeenCalledWith(['/projects', 'proj1', 'use-cases', 30]);
-    comp.navigate('stories', 40);
-    expect(router.navigate).toHaveBeenCalledWith(['/projects', 'proj1', 'stories', 40]);
+  it('renders referenced-by links as routerLink anchors', async () => {
+    paramMap$.next(convertToParamMap({ name: 'proj1', actorId: '5' }));
+    fixture.detectChanges();
+    await flush();
+    fixture.detectChanges();
+    const uc = fixture.nativeElement.querySelector('[data-testid="actor-refby-usecase-link"]');
+    const st = fixture.nativeElement.querySelector('[data-testid="actor-refby-story-link"]');
+    expect(uc.getAttribute('href')).toBe('/projects/proj1/use-cases/30');
+    expect(st.getAttribute('href')).toBe('/projects/proj1/stories/40');
   });
 
   it('onBack navigates back to actor list', () => {

--- a/requel-angular/src/app/features/actors/actor-editor.ts
+++ b/requel-angular/src/app/features/actors/actor-editor.ts
@@ -20,7 +20,7 @@
  */
 import { Component, computed, OnDestroy, OnInit, signal } from '@angular/core';
 import { PageHeaderComponent } from '../../shared/page-header';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
 import { FormsModule } from '@angular/forms';
@@ -44,7 +44,7 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
 @Component({
   selector: 'app-actor-editor',
   standalone: true,
-  imports: [PageHeaderComponent, FormsModule, ButtonModule, InputText, TextareaModule, TableModule,
+  imports: [PageHeaderComponent, RouterLink, FormsModule, ButtonModule, InputText, TextareaModule, TableModule,
             MessageModule, ConfirmDialogModule, EntitySelectorDialogComponent,
             AnnotationsSectionComponent],
   providers: [ConfirmationService],
@@ -115,12 +115,12 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
               <tr data-testid="actor-goal-row">
                 <td>
                   <a class="entity-link" data-testid="actor-goal-link"
-                     (click)="onGoalClick(g.id)">{{ g.name }}</a>
+                     [routerLink]="['/projects', projectName, 'goals', g.id]">{{ g.name }}</a>
                 </td>
                 @if (canEdit()) {
                   <td>
                     <p-button icon="pi pi-times" severity="danger" [text]="true"
-                              data-testid="actor-remove-goal"
+                              data-testid="actor-remove-goal" [ariaLabel]="'Remove goal ' + g.name"
                               [rounded]="true" (onClick)="onRemoveGoal(g)" />
                   </td>
                 }
@@ -155,7 +155,7 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
                 <tr data-testid="actor-refby-usecase-row">
                   <td>
                     <a class="entity-link" data-testid="actor-refby-usecase-link"
-                       (click)="navigate('use-cases', ref.id)">{{ ref.name }}</a>
+                       [routerLink]="['/projects', projectName, 'use-cases', ref.id]">{{ ref.name }}</a>
                   </td>
                 </tr>
               </ng-template>
@@ -168,7 +168,7 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
                 <tr data-testid="actor-refby-story-row">
                   <td>
                     <a class="entity-link" data-testid="actor-refby-story-link"
-                       (click)="navigate('stories', ref.id)">{{ ref.name }}</a>
+                       [routerLink]="['/projects', projectName, 'stories', ref.id]">{{ ref.name }}</a>
                   </td>
                 </tr>
               </ng-template>
@@ -420,14 +420,6 @@ export class ActorEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
     } catch {
       this.errorMessage.set('Failed to remove goal.');
     }
-  }
-
-  onGoalClick(goalId: number): void {
-    this.router.navigate(['/projects', this.projectName, 'goals', goalId]);
-  }
-
-  navigate(type: string, id: number): void {
-    this.router.navigate(['/projects', this.projectName, type, id]);
   }
 
   onBack(): void {

--- a/requel-angular/src/app/features/admin/global-tags.ts
+++ b/requel-angular/src/app/features/admin/global-tags.ts
@@ -72,7 +72,8 @@ import { TagService } from '../../core/tag.service';
             <td>{{ t.createdBy }}</td>
             <td>
               <p-button icon="pi pi-trash" severity="danger" [text]="true" size="small"
-                        data-testid="global-tag-delete" (onClick)="deleteTag(t)" />
+                        data-testid="global-tag-delete" [ariaLabel]="'Delete tag ' + t.value"
+                        (onClick)="deleteTag(t)" />
             </td>
           </tr>
         </ng-template>

--- a/requel-angular/src/app/features/admin/tag-categories.ts
+++ b/requel-angular/src/app/features/admin/tag-categories.ts
@@ -80,7 +80,8 @@ import { TagService } from '../../core/tag.service';
             <td>{{ c.color ?? '—' }}</td>
             <td>
               <p-button icon="pi pi-trash" severity="danger" [text]="true" size="small"
-                        data-testid="tag-category-delete" (onClick)="deleteCategory(c)" />
+                        data-testid="tag-category-delete" [ariaLabel]="'Delete category ' + c.name"
+                        (onClick)="deleteCategory(c)" />
             </td>
           </tr>
         </ng-template>

--- a/requel-angular/src/app/features/goals/goal-editor.ts
+++ b/requel-angular/src/app/features/goals/goal-editor.ts
@@ -20,7 +20,7 @@
  */
 import { Component, OnDestroy, OnInit, signal } from '@angular/core';
 import { PageHeaderComponent } from '../../shared/page-header';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
 import { FormsModule } from '@angular/forms';
@@ -46,7 +46,7 @@ import { TagSelectorComponent } from '../../shared/tag-selector';
 @Component({
   selector: 'app-goal-editor',
   standalone: true,
-  imports: [PageHeaderComponent, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
+  imports: [PageHeaderComponent, RouterLink, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
             TableModule, MessageModule, ConfirmDialogModule, EntitySelectorDialogComponent,
             AnnotationsSectionComponent, TagSelectorComponent],
   providers: [ConfirmationService],
@@ -109,11 +109,11 @@ import { TagSelectorComponent } from '../../shared/tag-selector';
               </ng-template>
               <ng-template #body let-r>
                 <tr data-testid="goal-relation-row">
-                  <td><a class="entity-link" (click)="navigateToGoal(r.goalId)">{{ r.goalName }}</a></td>
+                  <td><a class="entity-link" [routerLink]="['/projects', projectName, 'goals', r.goalId]">{{ r.goalName }}</a></td>
                   <td>{{ r.relationType }}</td>
                   @if (canEdit()) {
                     <td><p-button icon="pi pi-trash" severity="danger" [text]="true" size="small"
-                                  data-testid="goal-remove-relation"
+                                  data-testid="goal-remove-relation" [ariaLabel]="'Remove relation to ' + r.goalName"
                                   (onClick)="onDeleteRelation(r)" /></td>
                   }
                 </tr>
@@ -135,7 +135,7 @@ import { TagSelectorComponent } from '../../shared/tag-selector';
               </ng-template>
               <ng-template #body let-r>
                 <tr>
-                  <td><a class="entity-link" (click)="navigateToGoal(r.goalId)">{{ r.goalName }}</a></td>
+                  <td><a class="entity-link" [routerLink]="['/projects', projectName, 'goals', r.goalId]">{{ r.goalName }}</a></td>
                   <td>{{ r.relationType }}</td>
                 </tr>
               </ng-template>
@@ -456,10 +456,6 @@ export class GoalEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
     } else {
       this.errorMessage.set(result.error ?? 'Failed to delete relation.');
     }
-  }
-
-  navigateToGoal(goalId: number): void {
-    this.router.navigate(['/projects', this.projectName, 'goals', goalId]);
   }
 
   onBack(): void {

--- a/requel-angular/src/app/features/open-issues/open-issues.spec.ts
+++ b/requel-angular/src/app/features/open-issues/open-issues.spec.ts
@@ -73,12 +73,28 @@ describe('OpenIssuesComponent', () => {
     expect(comp.mustResolveCount()).toBe(1);
   });
 
-  it('navigateTo routes to correct entity path for known type', async () => {
+  it('routeFor returns the entity route for a known type', async () => {
     fixture.detectChanges();
     httpTesting.expectOne(r => r.url.includes('open-issues')).flush([]);
     await flush();
-    comp.navigateTo(MOCK_ISSUES[0]);
-    expect(router.navigate).toHaveBeenCalledWith(['/projects', 'proj1', 'goals', 10]);
+    expect(comp.routeFor(MOCK_ISSUES[0])).toEqual(['/projects', 'proj1', 'goals', 10]);
+  });
+
+  it('routeFor returns null for an unmapped entity type', async () => {
+    fixture.detectChanges();
+    httpTesting.expectOne(r => r.url.includes('open-issues')).flush([]);
+    await flush();
+    expect(comp.routeFor({ ...MOCK_ISSUES[0], entityType: 'Unknown' })).toBeNull();
+  });
+
+  it('renders a routerLink anchor for mapped issues', async () => {
+    fixture.detectChanges();
+    httpTesting.expectOne(r => r.url.includes('open-issues')).flush(MOCK_ISSUES);
+    await flush();
+    fixture.detectChanges();
+    const a = fixture.nativeElement.querySelector('[data-testid="open-issue-entity-link"]');
+    expect(a.tagName).toBe('A');
+    expect(a.getAttribute('href')).toBe('/projects/proj1/goals/10');
   });
 
   it('errorMessage set when HTTP request fails', async () => {

--- a/requel-angular/src/app/features/open-issues/open-issues.ts
+++ b/requel-angular/src/app/features/open-issues/open-issues.ts
@@ -19,7 +19,7 @@
  *
  */
 import { Component, OnDestroy, OnInit, signal } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
@@ -55,7 +55,7 @@ const ENTITY_ROUTES: Record<string, string> = {
 @Component({
   selector: 'app-open-issues',
   standalone: true,
-  imports: [ListPageComponent, TableModule, ButtonModule, BadgeModule, MessageModule],
+  imports: [ListPageComponent, RouterLink, TableModule, ButtonModule, BadgeModule, MessageModule],
   template: `
     <app-list-page title="Open Issues" searchPlaceholder="Search issues..."
                    (search)="dt.filterGlobal($event, 'contains')">
@@ -88,7 +88,11 @@ const ENTITY_ROUTES: Record<string, string> = {
           <tr>
             <td>{{ issue.entityType }}</td>
             <td>
-              <a class="entity-link" data-testid="open-issue-entity-link" (click)="navigateTo(issue)">{{ issue.entityName }}</a>
+              @if (routeFor(issue); as route) {
+                <a class="entity-link" data-testid="open-issue-entity-link" [routerLink]="route">{{ issue.entityName }}</a>
+              } @else {
+                <span data-testid="open-issue-entity-name">{{ issue.entityName }}</span>
+              }
             </td>
             <td>{{ issue.issueText }}</td>
             <td>
@@ -158,10 +162,9 @@ export class OpenIssuesComponent implements OnInit, OnDestroy {
     }
   }
 
-  navigateTo(issue: OpenIssueDto): void {
+  /** Router link array for the issue's entity, or null when the type has no route. */
+  routeFor(issue: OpenIssueDto): (string | number)[] | null {
     const segment = ENTITY_ROUTES[issue.entityType];
-    if (segment) {
-      this.router.navigate(['/projects', this.projectName, segment, issue.entityId]);
-    }
+    return segment ? ['/projects', this.projectName, segment, issue.entityId] : null;
   }
 }

--- a/requel-angular/src/app/features/scenarios/scenario-editor.spec.ts
+++ b/requel-angular/src/app/features/scenarios/scenario-editor.spec.ts
@@ -90,6 +90,20 @@ describe('ScenarioEditorComponent', () => {
     expect(comp.stepNodes()[0].name).toBe('User opens login page');
   });
 
+  it('renders the add-step controls as real buttons that add a step', async () => {
+    paramMap$.next(convertToParamMap({ name: 'proj1', scenarioId: '15' }));
+    fixture.detectChanges();
+    await flush();
+    fixture.detectChanges();
+    const top = fixture.nativeElement.querySelector('[data-testid="scenario-add-step-top"]');
+    const bottom = fixture.nativeElement.querySelector('[data-testid="scenario-add-step-bottom"]');
+    expect(top.tagName).toBe('BUTTON');
+    expect(bottom.tagName).toBe('BUTTON');
+    const before = comp.stepNodes().length;
+    bottom.click();
+    expect(comp.stepNodes().length).toBe(before + 1);
+  });
+
   it('addStep() appends a new step node and sets stepsSaveNeeded', () => {
     fixture.detectChanges();
     expect(comp.stepNodes().length).toBe(0);

--- a/requel-angular/src/app/features/scenarios/scenario-editor.ts
+++ b/requel-angular/src/app/features/scenarios/scenario-editor.ts
@@ -20,7 +20,7 @@
  */
 import { Component, OnDestroy, OnInit, signal } from '@angular/core';
 import { PageHeaderComponent } from '../../shared/page-header';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Location } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
@@ -63,7 +63,7 @@ interface StepNodeData {
 @Component({
   selector: 'app-scenario-editor',
   standalone: true,
-  imports: [PageHeaderComponent, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
+  imports: [PageHeaderComponent, RouterLink, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
             MessageModule, ConfirmDialogModule, TooltipModule, DragDropModule,
             ScenarioSelectorDialogComponent, AnnotationsSectionComponent],
   providers: [ConfirmationService],
@@ -132,9 +132,9 @@ interface StepNodeData {
                (cdkDropListDropped)="onDrop($event)"
                class="step-list">
             @if (canEdit()) {
-              <div class="add-step-row" data-testid="scenario-add-step-top" (click)="addStepAt(0)">
-                <i class="pi pi-plus"></i> Add step
-              </div>
+              <button type="button" class="add-step-row" data-testid="scenario-add-step-top" (click)="addStepAt(0)">
+                <i class="pi pi-plus" aria-hidden="true"></i> Add step
+              </button>
             }
             @for (step of stepNodes(); track step; let stepIndex = $index) {
               <div cdkDrag class="step-row" data-testid="scenario-step-row"
@@ -149,11 +149,11 @@ interface StepNodeData {
                     <i class="pi pi-sitemap step-icon"></i>
                     <a class="entity-link step-name"
                        data-testid="scenario-step-link"
-                       (click)="navigateToScenario(step.stepId!)">{{ step.name }}</a>
+                       [routerLink]="['/projects', projectName, 'scenarios', step.stepId!]">{{ step.name }}</a>
                     <span class="step-type-badge">{{ step.scenarioType }}</span>
                     @if (canEdit()) {
                       <p-button icon="pi pi-times" severity="danger" [text]="true"
-                                data-testid="scenario-step-remove"
+                                data-testid="scenario-step-remove" [ariaLabel]="'Remove ' + step.name + ' from scenario'"
                                 size="small" pTooltip="Remove from scenario"
                                 (onClick)="removeStep(step)" />
                     }
@@ -167,15 +167,15 @@ interface StepNodeData {
                            (blur)="onStepNameChange()" />
                     @if (canEdit()) {
                       <p-button icon="pi pi-pencil" [text]="true" size="small"
-                                data-testid="scenario-step-edit"
+                                data-testid="scenario-step-edit" ariaLabel="Edit step details"
                                 pTooltip="Edit details" tooltipPosition="top"
                                 (onClick)="openStepEdit(step)" />
                       <p-button icon="pi pi-plus" severity="secondary" [text]="true"
-                                data-testid="scenario-step-add-below"
+                                data-testid="scenario-step-add-below" ariaLabel="Add step below"
                                 size="small" pTooltip="Add step below" tooltipPosition="top"
                                 (onClick)="addStepBelow(step)" />
                       <p-button icon="pi pi-times" severity="danger" [text]="true"
-                                data-testid="scenario-step-remove"
+                                data-testid="scenario-step-remove" ariaLabel="Remove step"
                                 size="small" pTooltip="Remove step" tooltipPosition="top"
                                 (onClick)="removeStep(step)" />
                     }
@@ -185,9 +185,9 @@ interface StepNodeData {
                 </div>
               }
             @if (canEdit()) {
-              <div class="add-step-row" data-testid="scenario-add-step-bottom" (click)="addStep()">
-                <i class="pi pi-plus"></i> Add step
-              </div>
+              <button type="button" class="add-step-row" data-testid="scenario-add-step-bottom" (click)="addStep()">
+                <i class="pi pi-plus" aria-hidden="true"></i> Add step
+              </button>
             }
           </div>
 
@@ -273,6 +273,7 @@ interface StepNodeData {
 
     .add-step-row {
       display: flex; align-items: center; justify-content: center; gap: 0.35rem;
+      width: 100%; border: none; background: transparent; font-family: inherit;
       padding: 0.3rem; cursor: pointer;
       font-size: 0.8rem; color: var(--p-text-secondary-color);
       border-bottom: 1px dashed var(--p-surface-200);
@@ -546,10 +547,6 @@ export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckabl
     }]);
     this.stepsSaveNeeded.set(true);
     this.hasChanges.set(true);
-  }
-
-  navigateToScenario(scenarioId: number): void {
-    this.router.navigate(['/projects', this.projectName, 'scenarios', scenarioId]);
   }
 
   private buildStepInputs(): EditStepInput[] {

--- a/requel-angular/src/app/features/stories/story-editor.ts
+++ b/requel-angular/src/app/features/stories/story-editor.ts
@@ -20,7 +20,7 @@
  */
 import { Component, OnDestroy, OnInit, signal } from '@angular/core';
 import { PageHeaderComponent } from '../../shared/page-header';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
 import { FormsModule } from '@angular/forms';
@@ -46,7 +46,7 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
 @Component({
   selector: 'app-story-editor',
   standalone: true,
-  imports: [PageHeaderComponent, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
+  imports: [PageHeaderComponent, RouterLink, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
             TableModule, MessageModule, ConfirmDialogModule, EntitySelectorDialogComponent,
             AnnotationsSectionComponent],
   providers: [ConfirmationService],
@@ -135,10 +135,10 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
               </ng-template>
               <ng-template #body let-g>
                 <tr data-testid="story-goal-row">
-                  <td><a class="entity-link" data-testid="story-goal-link" (click)="navigateToGoal(g.id)">{{ g.name }}</a></td>
+                  <td><a class="entity-link" data-testid="story-goal-link" [routerLink]="['/projects', projectName, 'goals', g.id]">{{ g.name }}</a></td>
                   @if (canEdit()) {
                     <td><p-button icon="pi pi-trash" severity="danger" [text]="true" size="small"
-                                  data-testid="story-remove-goal"
+                                  data-testid="story-remove-goal" [ariaLabel]="'Remove goal ' + g.name"
                                   (onClick)="onRemoveGoal(g)" /></td>
                   }
                 </tr>
@@ -169,10 +169,10 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
               </ng-template>
               <ng-template #body let-a>
                 <tr data-testid="story-additional-actor-row">
-                  <td><a class="entity-link" data-testid="story-additional-actor-link" (click)="navigateToActor(a.id)">{{ a.name }}</a></td>
+                  <td><a class="entity-link" data-testid="story-additional-actor-link" [routerLink]="['/projects', projectName, 'actors', a.id]">{{ a.name }}</a></td>
                   @if (canEdit()) {
                     <td><p-button icon="pi pi-trash" severity="danger" [text]="true" size="small"
-                                  data-testid="story-remove-additional-actor"
+                                  data-testid="story-remove-additional-actor" [ariaLabel]="'Remove actor ' + a.name"
                                   (onClick)="onRemoveActor(a)" /></td>
                   }
                 </tr>
@@ -528,14 +528,6 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
     } catch {
       this.errorMessage.set('Failed to remove actor.');
     }
-  }
-
-  navigateToGoal(goalId: number): void {
-    this.router.navigate(['/projects', this.projectName, 'goals', goalId]);
-  }
-
-  navigateToActor(actorId: number): void {
-    this.router.navigate(['/projects', this.projectName, 'actors', actorId]);
   }
 
   onBack(): void {

--- a/requel-angular/src/app/features/use-cases/use-case-editor.ts
+++ b/requel-angular/src/app/features/use-cases/use-case-editor.ts
@@ -20,7 +20,7 @@
  */
 import { Component, computed, OnDestroy, OnInit, signal } from '@angular/core';
 import { PageHeaderComponent } from '../../shared/page-header';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Location } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
@@ -53,7 +53,7 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
 @Component({
   selector: 'app-use-case-editor',
   standalone: true,
-  imports: [PageHeaderComponent, FormsModule, ButtonModule, InputText, TextareaModule, MessageModule,
+  imports: [PageHeaderComponent, RouterLink, FormsModule, ButtonModule, InputText, TextareaModule, MessageModule,
             ConfirmDialogModule, TableModule, TooltipModule, SelectModule,
             EntitySelectorDialogComponent, AnnotationsSectionComponent],
   providers: [ConfirmationService],
@@ -134,7 +134,7 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
             <div class="primary-scenario-card" data-testid="use-case-primary-scenario-card">
               <div class="primary-scenario-name" data-testid="use-case-primary-scenario-name">
                 <a class="entity-link" data-testid="use-case-primary-scenario-link"
-                   (click)="navigateTo('scenarios', useCase()!.scenarioId!)">
+                   [routerLink]="['/projects', projectName, 'scenarios', useCase()!.scenarioId!]">
                   {{ useCase()!.scenarioName ?? 'Primary Scenario' }}
                 </a>
                 <span class="step-count">({{ useCase()!.scenarioStepCount ?? 0 }} steps)</span>
@@ -182,12 +182,12 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
             <ng-template pTemplate="body" let-s>
               <tr data-testid="use-case-scenario-row">
                 <td><a class="entity-link" data-testid="use-case-scenario-link"
-                       (click)="navigateTo('scenarios', s.id)">{{ s.name }}</a></td>
+                       [routerLink]="['/projects', projectName, 'scenarios', s.id]">{{ s.name }}</a></td>
                 <td>{{ s.scenarioType }}</td>
                 <td>
                   @if (canEdit()) {
                     <p-button icon="pi pi-times" severity="danger" [text]="true"
-                              data-testid="use-case-remove-scenario"
+                              data-testid="use-case-remove-scenario" [ariaLabel]="'Remove scenario ' + s.name"
                               size="small" pTooltip="Remove scenario"
                               (onClick)="removeScenario(s)" />
                   }
@@ -242,12 +242,12 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
               <tr data-testid="use-case-goal-row">
                 <td>
                   <a class="entity-link" data-testid="use-case-goal-link"
-                     (click)="navigateTo('goals', goal.id)">{{ goal.name }}</a>
+                     [routerLink]="['/projects', projectName, 'goals', goal.id]">{{ goal.name }}</a>
                 </td>
                 <td>
                   @if (canEdit()) {
                     <p-button icon="pi pi-times" severity="danger" [text]="true"
-                              data-testid="use-case-remove-goal"
+                              data-testid="use-case-remove-goal" [ariaLabel]="'Remove goal ' + goal.name"
                               size="small" pTooltip="Remove goal"
                               (onClick)="removeGoal(goal)" />
                   }
@@ -280,13 +280,13 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
               <tr data-testid="use-case-story-row">
                 <td>
                   <a class="entity-link" data-testid="use-case-story-link"
-                     (click)="navigateTo('stories', story.id)">{{ story.name }}</a>
+                     [routerLink]="['/projects', projectName, 'stories', story.id]">{{ story.name }}</a>
                 </td>
                 <td>{{ story.storyType }}</td>
                 <td>
                   @if (canEdit()) {
                     <p-button icon="pi pi-times" severity="danger" [text]="true"
-                              data-testid="use-case-remove-story"
+                              data-testid="use-case-remove-story" [ariaLabel]="'Remove story ' + story.name"
                               size="small" pTooltip="Remove story"
                               (onClick)="removeStory(story)" />
                   }
@@ -319,12 +319,12 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
               <tr data-testid="use-case-actor-row">
                 <td>
                   <a class="entity-link" data-testid="use-case-actor-link"
-                     (click)="navigateTo('actors', actor.id)">{{ actor.name }}</a>
+                     [routerLink]="['/projects', projectName, 'actors', actor.id]">{{ actor.name }}</a>
                 </td>
                 <td>
                   @if (canEdit()) {
                     <p-button icon="pi pi-times" severity="danger" [text]="true"
-                              data-testid="use-case-remove-actor"
+                              data-testid="use-case-remove-actor" [ariaLabel]="'Remove actor ' + actor.name"
                               size="small" pTooltip="Remove actor"
                               (onClick)="removeActor(actor)" />
                   }

--- a/requel-angular/src/app/shared/annotations-section.ts
+++ b/requel-angular/src/app/shared/annotations-section.ts
@@ -93,7 +93,7 @@ import { AnnotationService } from '../core/annotation.service';
               <span class="annotation-creator">{{ note.createdBy }}</span>
               @if (canEdit) {
                 <p-button icon="pi pi-trash" severity="danger" [text]="true" size="small"
-                          data-testid="annotation-delete-note"
+                          data-testid="annotation-delete-note" ariaLabel="Delete note"
                           (onClick)="deleteNote(note)" />
               }
             </div>
@@ -116,7 +116,7 @@ import { AnnotationService } from '../core/annotation.service';
               <span class="annotation-creator">{{ issue.createdBy }}</span>
               @if (canEdit) {
                 <p-button icon="pi pi-trash" severity="danger" [text]="true" size="small"
-                          data-testid="annotation-delete-issue"
+                          data-testid="annotation-delete-issue" ariaLabel="Delete issue"
                           (onClick)="deleteIssue(issue)" />
               }
             </div>
@@ -145,7 +145,7 @@ import { AnnotationService } from '../core/annotation.service';
                   }
                   @if (canEdit) {
                     <p-button icon="pi pi-trash" severity="danger" [text]="true" size="small"
-                              data-testid="annotation-delete-position"
+                              data-testid="annotation-delete-position" ariaLabel="Delete position"
                               (onClick)="deletePosition(pos)" />
                   }
                 </div>
@@ -161,7 +161,7 @@ import { AnnotationService } from '../core/annotation.service';
                       <span class="annotation-creator">{{ arg.createdBy }}</span>
                       @if (canEdit) {
                         <p-button icon="pi pi-trash" severity="danger" [text]="true" size="small"
-                                  data-testid="annotation-delete-argument"
+                                  data-testid="annotation-delete-argument" ariaLabel="Delete argument"
                                   (onClick)="deleteArgument(pos, arg)" />
                       }
                     </div>

--- a/requel-angular/src/app/shared/tag-selector.spec.ts
+++ b/requel-angular/src/app/shared/tag-selector.spec.ts
@@ -99,6 +99,21 @@ describe('TagSelectorComponent', () => {
     expect(screen.getByText('type=business-rule')).toBeInTheDocument();
   });
 
+  it('exposes a contextful accessible name on the tag remove button', async () => {
+    tagServiceMock.getTagsOnEntity.mockResolvedValue([
+      { id: 1, version: 1, category: 'type', value: 'business-rule', projectId: 9,
+        color: null, createdBy: 'admin' }
+    ]);
+    const { fixture } = await render(TagSelectorComponent, {
+      providers: providers(),
+      inputs: { projectName: 'proj1', entityType: 'Goal', entityId: 1, canEdit: true }
+    });
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const btn = screen.getByRole('button', { name: 'Remove tag type=business-rule' });
+    expect(btn.tagName).toBe('BUTTON');
+  });
+
   it('addTag() creates then assigns a tag and clears the inputs', async () => {
     const { fixture } = await render(TagSelectorComponent, {
       providers: providers(),

--- a/requel-angular/src/app/shared/tag-selector.ts
+++ b/requel-angular/src/app/shared/tag-selector.ts
@@ -49,7 +49,7 @@ import { TagService } from '../core/tag.service';
               <span class="tag-chip-label">{{ label(t) }}</span>
               @if (canEdit) {
                 <button type="button" class="chip-x" data-testid="tag-remove"
-                        aria-label="Remove tag" (click)="removeTag(t)">×</button>
+                        [attr.aria-label]="'Remove tag ' + label(t)" (click)="removeTag(t)"><span aria-hidden="true">×</span></button>
               }
             </span>
           }

--- a/requel-angular/src/styles.scss
+++ b/requel-angular/src/styles.scss
@@ -7,3 +7,13 @@ html, body {
   background: var(--p-surface-ground);
   color: var(--p-text-color);
 }
+
+// Visible keyboard focus indicator for all interactive elements (WCAG 2.4.7).
+// Uses :focus-visible so the ring shows on keyboard focus only, not on mouse click.
+// Matches the PrimeNG Aura focus-ring tokens (outline-based) with literal fallbacks
+// mirroring the Aura primitive, so custom controls look identical to native components.
+:focus-visible {
+  outline: var(--p-focus-ring-width, 1px) var(--p-focus-ring-style, solid)
+           var(--p-focus-ring-color, var(--p-primary-color));
+  outline-offset: var(--p-focus-ring-offset, 2px);
+}


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/136

Make interactive elements keyboard-operable, named, and focus-visible (Findings 4.2 + 4.3)

Addresses UI/UX review Findings 4.2 and 4.3 (WCAG 2.1.1 Keyboard, 2.1.3 Keyboard No
Exception, 2.4.7 Focus Visible, 4.1.2 Name/Role/Value, 2.5.3 Label in Name). Finding 4.3
(#137, accessible names on icon-only buttons) is folded in as an attribute-only change to
the same files. All navigation targets were already clean routes, so anchor conversions
carry no behavior change.

Changes:

- requel-angular/src/styles.scss: add a global :focus-visible outline rule so custom
  controls show a keyboard focus ring. Uses the PrimeNG Aura focus-ring tokens
  (--p-focus-ring-*) with literal fallbacks (1px solid, offset 2px) mirroring the Aura
  primitive, which is outline-based, so custom controls match native PrimeNG controls.
  :focus-visible (not :focus) shows the ring on keyboard focus only, not on mouse click.

- Convert click-only entity-link anchors to real [routerLink] anchors (keyboard-operable,
  expose a destination) and add RouterLink to each standalone component's imports:
  goal-editor (2), story-editor (2), actor-editor (3), use-case-editor (5),
  scenario-editor sub-scenario link (1). Removed the now-unused navigate helper methods
  (navigateToGoal/navigateToActor/navigateToScenario, actor onGoalClick/navigate);
  use-case navigateTo is kept because an "Open in Editor" button still uses it.

- open-issues.ts: replace the click anchor with a computed routerLink. New routeFor(issue)
  returns the route array for a mapped entity type or null; the template renders a
  [routerLink] anchor when a route exists and plain text otherwise, preserving the previous
  "unmapped type = not clickable" behavior.

- scenario-editor.ts: convert the two clickable add-step-row <div>s to
  <button type="button">, mark their plus icons aria-hidden, and reset button UA styling
  in .add-step-row (width/border/background/font) so the look is unchanged.

- tag-selector.ts: give the chip remove control a contextful aria-label
  ("Remove tag <label>") and wrap the x glyph in an aria-hidden span.

- Add ariaLabel to icon-only p-buttons (Finding 4.3): annotations-section delete
  note/issue/position/argument; story/actor/use-case relationship removes; scenario step
  remove/edit/add-below; admin global-tags and tag-categories delete rows; and the
  goal-editor remove-relation button in the same table.

- Tests (Vitest): actor-editor and open-issues specs now assert rendered [routerLink]
  hrefs (and routeFor mapped/unmapped) instead of the removed navigate methods;
  scenario-editor asserts the add-step controls are real buttons that add a step;
  tag-selector asserts the remove button's accessible name. Full suite green:
  56 files, 349 tests passing.

Closes #136
Closes #137
