### PR TITLE
Modal accessibility for dialogs and overlays (#139)

### DIFF
--- a/doc/124-lookandfeel-plan.md
+++ b/doc/124-lookandfeel-plan.md
@@ -1,0 +1,248 @@
+# Look-and-Feel Adoption — UI Epic #124
+
+Proposed additions and updates to the sub-issues of
+[#124 — Angular UI/UX, Accessibility, and Front-End Architecture Remediation](https://github.com/rreganjr/Requel/issues/124).
+
+This is a planning doc only. It does not change any GitHub state. Apply it with the
+`gh` commands / helper script in §6–§7 when ready. All new/updated sub-issues keep the
+epic's conventions: parent = #124, milestone `v2.0`, project **Requel 2.0**, labels
+`ui-ux-review` + `priority:{high,medium,low}`.
+
+## Summary
+
+This plan pins Requel's target visual language and the concrete component patterns that
+implement it, and maps them onto the existing UI epic. It fits cleanly:
+`requel-angular` already runs PrimeNG 21 with `@primeuix/themes`, so the target look is
+achievable through a custom `definePreset` plus a small set of shared layout primitives
+— no new UI framework.
+
+The existing epic already covers *that we need* a design system, shared primitives,
+reactive forms, and consistent list/detail patterns (findings 1.1–5.6). What it does
+not yet capture is *the concrete visual target*. This plan fixes that by (a) updating a
+handful of existing sub-issues with specific tokens and acceptance criteria, and
+(b) adding component-level sub-issues for patterns the epic does not yet spell out
+(app-shell chrome, tag/chip system, card surface, data-table pattern, multi-step form
+wizard).
+
+## 1. Target design language
+
+### 1.1 Design tokens
+
+| Token | Target value | Note |
+|---|---|---|
+| Font family | `Figtree, sans-serif` | clean geometric sans; loaded from Google Fonts or bundled |
+| Base font size | `14px` | denser than PrimeNG default 16px |
+| Primary color | `#3b82f6` (blue-500) | hover/active `#2563eb` (blue-600) |
+| Content border radius | `6px` | applied to inputs, buttons, chips, cards |
+| Surface palette | cool, blue-tinted — a slate-blue base (`#1e3a8a`) mixed toward white | surface-0 = white, ramps to slate-blue |
+| Text color | slate-blue (`~#61759d`), muted lighter | not pure gray |
+| Content background | white cards on a light blue-gray canvas | |
+
+### 1.2 Layout & component patterns
+
+- **App shell.** Fixed left sidebar with grouped, labelled sections, icon + label
+  items, and collapsible groups. Top bar with a back button + breadcrumb on the left
+  and search / notifications / account / sidebar-toggle on the right. Content sits on a
+  light blue-gray canvas.
+- **Card surfaces.** Every content block is a white rounded card with a hairline
+  border and very soft shadow, generous padding, and a section title at top-left.
+- **Tags (severity).** Soft-tinted background + matching colored text, in three
+  variants — **default** (rounded rect), **pill** (fully rounded), **icon** (leading
+  icon) — across `primary / success / info / warning / danger`. Used inline as status
+  chips (e.g. Active = green, Inactive = red).
+- **Chips.** Rounded pill, neutral background; variants with leading icon, avatar, or
+  image; optional trailing remove (×).
+- **Data table.** Card wrapper; toolbar row with the list title on the left and a
+  search box + primary **New** button on the right; per-row checkbox selection;
+  first cell = avatar/icon + name; secondary columns in muted text; a status **Tag**
+  column; sortable column headers; a trailing `⋯` row-actions menu; a centered
+  paginator with first/prev/page/next/last controls.
+- **Form wizard.** Two-column card: left = vertical step nav; right = the active
+  step's fields. Each field is a row: **label + helper text on the left**, **input on
+  the right**, rows separated by hairline dividers. A dedicated upload control where an
+  image/attachment is needed. Footer actions: subtle **Cancel** + primary
+  **Save/Continue**.
+
+## 2. Mapping to the existing epic
+
+| Existing sub-issue | Action | Addition |
+|---|---|---|
+| #125 — 1.1 stock Aura, no brand layer | **Update** | Pin the preset to the target tokens (Figtree 14px, `#3b82f6`, blue-tinted surfaces, 6px radius) |
+| #126 — 1.2 component-local CSS fragments consistency | **Update** | Card-surface + severity-tint tokens become the single source, replacing hard-coded colors |
+| #127 — 1.3 typography too flat | **Update** | Adopt Figtree + a defined type scale |
+| #128 — 2.1 project context hidden in sidebar | **Update** | Fold in the top-bar breadcrumb + grouped/collapsible sidebar chrome |
+| #129 — 2.2 inconsistent list/detail, over-relies on row selection | **Update** | Adopt the data-table pattern (toolbar + New, checkbox select, status tag, row `⋯` menu, paginator) |
+| #132 — 3.1 forms template-driven, weak validation | **Update** | Adopt the field-row layout (label+helper / input / divider) and Cancel/Save footer |
+| #146 — 5.5 shared components too thin | **Update** | Name the concrete primitives (see new issues N1–N5) as the shared set to build |
+| #131 — 2.4 loading/empty/failure states | leave | Empty/skeleton styling folds in as a styling detail |
+
+The remaining sub-issues (a11y 4.x, architecture 5.1/5.3/5.4/5.6, errors 3.2/3.3) are
+orthogonal to visual styling and need no change here.
+
+## 3. Proposed updates to existing sub-issues
+
+Append the following to each issue body (do not remove existing content). Keep each
+issue's current priority label. The exact `gh issue edit` commands are in §6.
+
+**#125 (1.1):**
+> Target look-and-feel. `src/app/theme/requel-preset.ts` `definePreset` sets: primary
+> `#3b82f6` (hover `#2563eb`); surface ramp from a cool blue base (`#1e3a8a` mixed
+> toward white) with white cards on a light blue-gray canvas; content border-radius
+> `6px`; base font Figtree at 14px. No component may hard-code these — all read from
+> tokens. Light mode first; leave hooks for a later dark mode.
+
+**#126 (1.2):**
+> Replace hard-coded chip/badge/header colors with the preset's semantic tokens and a
+> shared card-surface token set (`--rq-card-bg`, `--rq-card-border`, `--rq-card-radius`,
+> `--rq-card-shadow`, `--rq-card-pad`). No `#1a1a7e`/`#3b82f6` literals left in
+> component styles.
+
+**#127 (1.3):**
+> Load Figtree; define a type scale (page title, card title, field label, helper,
+> body, caption) as tokens and apply through shared primitives (bold slate titles,
+> muted helper text).
+
+**#128 (2.1):**
+> Restructure the app shell: top bar shows back + breadcrumb (project → section →
+> entity) on the left and search / notifications / account / sidebar-toggle on the
+> right; sidebar uses grouped, labelled, collapsible sections.
+
+**#129 (2.2):**
+> Build/adopt a single data-table pattern: card wrapper; toolbar with title + search +
+> primary **New** action; optional checkbox multi-select; a status **Tag** column;
+> sortable headers; a trailing `⋯` row-actions menu; a centered paginator. List pages
+> stop using whole-row click as the only affordance.
+
+**#132 (3.1):**
+> Reactive-forms migration targets a field-row layout: label + helper text on the left,
+> control on the right, hairline dividers between rows, sticky footer with subtle
+> **Cancel** + primary **Save/Continue**. Inline errors sit under the control.
+
+**#146 (5.5):**
+> Concrete shared primitives to build (tracked as new sub-issues): app-shell chrome,
+> `app-tag`/`app-chip` severity system, `app-card` surface, `app-data-table`,
+> `app-form-wizard` + `app-field`. These are the reusable base the repeated
+> project/goal/story/actor/scenario/use-case views compose from.
+
+## 4. Proposed new sub-issues
+
+Each is a child of #124, milestone `v2.0`, labels `ui-ux-review` + the priority shown.
+Full body text is in the helper script (see §6).
+
+### N1 — App shell: top bar + grouped collapsible sidebar · priority:medium
+Reshape `layout` + `sidebar-nav`. Top bar: left back button + breadcrumb reflecting the
+route (project → section → entity); right cluster for search, notifications (future),
+account menu, and a sidebar collapse toggle. Sidebar: grouped labelled sections,
+icon+label items, collapsible groups, active-item highlight. Content canvas is the light
+blue-gray surface token.
+**Acceptance.** Breadcrumb is keyboard-navigable and reflects route params; sidebar
+collapse persists; header color comes from tokens (no `#1a1a7e` literal); passes the
+a11y landmark checks from #135.
+*Overlaps #128 — do this as the shell-chrome half; #128 keeps the project-context/IA half.*
+
+### N2 — Tag & Chip severity system as shared primitives · priority:medium
+Add `app-tag` and `app-chip` wrappers over PrimeNG Tag/Chip: soft-tinted background +
+colored text; variants default / pill / icon for severities
+`primary|success|info|warning|danger`; chips support leading icon/avatar and optional
+remove (×). Replace the ad-hoc hard-coded tag colors in `goal-list`,
+`annotations-section`, and `tag-selector`.
+**Acceptance.** One component renders every severity/variant from tokens; used for
+entity status, annotation kind, and tag chips; color is never the only signal (icon or
+text label present) to satisfy #141.
+
+### N3 — Card / content-surface primitive (`app-card`) · priority:low
+Extract the repeated card container (title slot, padding, border, radius, soft shadow)
+into `app-card` with tokens `--rq-card-*`. Adopt across list and editor shells.
+**Acceptance.** List pages and editors render inside `app-card`; no per-view card CSS
+duplication; radius/shadow/border come from tokens.
+
+### N4 — Data-table pattern component (`app-data-table`) · priority:medium
+Implement the table pattern as a reusable component over PrimeNG Table: toolbar
+(title + search + primary action), optional selection column, sortable headers, a
+status-tag column via `app-tag`, a `⋯` row-actions menu, and a centered paginator. Drive
+the goal/story/actor/stakeholder/scenario/use-case/term list pages from it.
+**Acceptance.** At least two existing list pages migrated; search + sort + paginate
+work; row actions are real buttons with accessible names (#136/#137); empty state via
+the standard empty component (#131).
+*Concretizes #129 + #146.*
+
+### N5 — Multi-step entity-create wizard (`app-form-wizard` + `app-field`) · priority:medium
+Build the two-column wizard: left vertical step nav, right the active step's fields.
+`app-field` renders the label+helper-left / control-right row with divider and inline
+error slot. Footer: Cancel + primary Continue/Save; step nav shows completion state. Use
+it for a representative create flow (e.g. new Goal or Story).
+**Acceptance.** Built on reactive forms (#132); labels/errors associated (#138); step
+nav keyboard-operable; one create flow migrated end-to-end.
+*Concretizes #132 + #146.*
+
+### N6 — (Optional) Theme switcher + dark mode via config panel · priority:low
+Add a config panel (gear in the top bar) to toggle light/dark and optionally the primary
+color, backed by the preset's dark token set.
+**Acceptance.** Dark mode reads entirely from tokens; preference persists; contrast
+passes AA in both modes (#141). Defer if out of scope for v2.0.
+
+## 5. Sequencing
+
+Slots into the epic's existing phases:
+
+- **Phase 2 (design-system foundation):** #125, #126, #127 updates + N2, N3, N6 (N6 optional).
+- **Phase 4 (IA & workflow polish):** #128, #129 updates + N1, N4.
+- **Phase 3 (forms):** #132 update + N5.
+
+These phase assignments are wired into `phase_of()` in `scripts/epic-rollup-comment.sh`,
+so the rollup comment groups N1–N6 automatically.
+
+N2/N3 are low-risk and unblock N4/N5, so build the preset (#125) → tags/card
+(N2/N3) → table/wizard (N4/N5) → shell (N1).
+
+## 6. Applying this plan
+
+Everything in §3 (updates) and §4 (new sub-issues) is applied by the companion helper
+`scripts/create-ui-ux-lookandfeel.sh`. Run from a clone with `gh` authenticated:
+
+```bash
+DRY_RUN=1 bash scripts/create-ui-ux-lookandfeel.sh   # preview every gh command
+bash scripts/create-ui-ux-lookandfeel.sh             # apply
+```
+
+The script does two things, and the whole script is safe to rerun:
+
+1. **Updates existing sub-issues (§3).** Appends the "Target look-and-feel" block to
+   #125, #126, #127, #128, #129, #132, #146. Self-healing and idempotent — it strips
+   any existing block (matched by its marker heading) and rewrites it, so a rerun
+   replaces rather than duplicates and repairs any earlier bad render.
+2. **Creates the new sub-issues (§4).** Creates N1–N6, each linked to #124 with
+   `--parent`, labelled `ui-ux-review` + priority, on milestone `v2.0`. Guarded against
+   duplicates — it reads the epic's existing sub-issue titles first and skips any that
+   already exist.
+
+**Do not rerun `scripts/create-ui-ux-epic.sh`.** It has no existence guard — every run
+calls `gh issue create` unconditionally, so rerunning it would create a *duplicate*
+epic and 23 duplicate children, not update #124 or append the new ones. That is why the
+new work lives in a separate script.
+
+> If your `gh` build lacks `--parent`, link each child to the epic with the GraphQL
+> `addSubIssue` mutation against the epic's and child's node IDs.
+
+## 7. Project, points, and rollup
+
+- **Project.** #124 is already in the **Requel 2.0** project, and sub-issues are pulled
+  in automatically (they render nested under their parent in the project's hierarchy —
+  cosmetic, not a problem). No manual add needed. `set-points.sh` (below) also re-adds
+  each item, which is a no-op if it is already present.
+- **Story Points.** Set initial estimates with `scripts/set-lookandfeel-points.sh`
+  (delegates to `set-points.sh`). Proposed Fibonacci values — edit before running:
+  N1 = 5, N2 = 3, N3 = 2, N4 = 8, N5 = 8, N6 = 3. Retro is left unset (issues are open).
+
+  ```bash
+  bash scripts/set-lookandfeel-points.sh
+  ```
+
+- **Phase rollup comment.** `phase_of()` in `scripts/epic-rollup-comment.sh` now maps
+  N1–N6 (N2/N3/N6 → Phase 2, N5 → Phase 3, N1/N4 → Phase 4). Update the existing rollup
+  comment in place instead of posting a new one:
+
+  ```bash
+  DRY_RUN=1 bash scripts/epic-rollup-comment.sh                  # preview the regenerated body
+  COMMENT_ID=5113771759 bash scripts/epic-rollup-comment.sh      # edit the existing comment in place
+  ```

--- a/doc/124-remediation-rollup.md
+++ b/doc/124-remediation-rollup.md
@@ -1,0 +1,53 @@
+## Remediation rollup by phase
+
+Grouped from `doc/UI_UX_REVIEW.md` findings 1.1–5.6 plus the look-and-feel items (N1–N6, see `doc/124-lookandfeel-plan.md`). Closed sub-issues are auto-checked; the rest are checked as each PR squash-merges to `release/2.0`.
+
+**Execution order matters — do issues top-to-bottom.** The list below is the intended build order, and the epic's sub-issue list is sorted to match (see `scripts/reorder-ui-ux-subissues.sh`). Key dependencies:
+
+- **N5 #158 (`app-field` + wizard) leads Phase 3.** The reactive-forms migration (3.1 #132), the command-error adapter (3.2 #133), the mini-form contract (3.3 #134), and the label/error-association work (4.4 #138) all bind to the shared `app-field` primitive, so it must land first.
+- **4.4 #138 depends on 3.1 #132**, which in turn depends on **N5 #158**. (4.4 is *not* blocked by 4.5 #139 — dialogs are independent and ship in Phase 1.)
+- Phase 2 (design-system tokens) precedes Phase 3 because `app-field` styles consume the theme tokens.
+
+### Phase 1 — Quick wins & accessibility blockers
+
+- [ ] #135 — 4.1 Skip navigation and heading structure are incomplete
+- [ ] #136 — 4.2 Several interactive elements are mouse-only or not real links/buttons
+- [ ] #137 — 4.3 Icon-only buttons often lack accessible names
+- [ ] #139 — 4.5 Custom dialogs and overlays miss modal accessibility guarantees
+- [ ] #141 — 4.7 Color contrast, color-only meaning, reduced motion, and target size need policy
+
+### Phase 2 — Design-system foundation
+
+- [ ] #125 — 1.1 App uses stock Aura with no Requel brand layer
+- [ ] #126 — 1.2 Component-local CSS fights PrimeNG and fragments visual consistency
+- [ ] #127 — 1.3 Typography and hierarchy are too flat
+- [ ] #146 — 5.5 Shared components exist but are too thin for the app's repeated patterns
+- [ ] #155 — N2 Tag & Chip severity system as shared primitives
+- [ ] #156 — N3 Card / content-surface primitive (app-card)
+- [ ] #159 — N6 Theme switcher + dark mode via config panel (optional)
+
+### Phase 3 — Forms & validation remediation
+
+- [ ] #158 — N5 Multi-step entity-create wizard (app-form-wizard + app-field) — **prerequisite for the rest of this phase**
+- [ ] #132 — 3.1 Forms are mostly template-driven and lack consistent validation
+- [ ] #133 — 3.2 API and command errors are surfaced inconsistently
+- [ ] #134 — 3.3 Mini-forms (annotations, tags, admin, dialogs) need the same validation contract
+- [ ] #138 — 4.4 Form labels and error associations are incomplete
+- [ ] #143 — 5.2 Signals are used, but form/state hygiene is mixed
+
+### Phase 4 — Information architecture & workflow polish
+
+- [ ] #128 — 2.1 Navigation is complete but project context is hidden in the sidebar
+- [ ] #129 — 2.2 List/detail patterns are inconsistent and over-rely on row selection
+- [ ] #130 — 2.3 Dialog and relationship flows need clearer progression
+- [ ] #131 — 2.4 Loading, empty, and failure states are under-specified
+- [ ] #140 — 4.6 Async and SSE updates are not announced
+- [ ] #154 — N1 App shell: top bar + grouped collapsible sidebar
+- [ ] #157 — N4 Data-table pattern component (app-data-table)
+
+### Phase 5 — Deeper Angular architecture refactors
+
+- [ ] #142 — 5.1 Standalone/lazy routes are good, but route groups need structure
+- [ ] #144 — 5.3 Change detection and subscriptions are not modernized
+- [ ] #145 — 5.4 SSE service is thoughtful but disconnected from UX and app-level state
+- [ ] #147 — 5.6 Bundle and dependency posture is reasonable but should be measured

--- a/doc/139-modal-a11y-plan.md
+++ b/doc/139-modal-a11y-plan.md
@@ -1,0 +1,127 @@
+# Issue #139 — Custom dialogs and overlays miss modal accessibility guarantees
+
+Source: `doc/UI_UX_REVIEW.md` Finding 4.5. Priority: High. Effort: Medium (2–4 days).
+WCAG: 2.1.2 No Keyboard Trap, 2.4.3 Focus Order, 2.4.7 Focus Visible, 4.1.2 Name/Role/Value.
+
+## Summary
+
+Two handcrafted fixed-overlay "dialogs" (goal relation-type picker, scenario step-detail editor)
+render as plain `<div>`s with no dialog semantics, no focus trap, no Escape handling, and no
+focus restoration. They will be replaced with PrimeNG `p-dialog [modal]="true"`, which on
+PrimeNG 21 supplies `role="dialog"`, `aria-modal`, focus trap, `closeOnEscape`, and
+focus-restore-to-opener by default. The three existing `p-dialog` usages
+(entity selector, scenario selector, PAT creation) are already largely compliant and get an
+audit/hardening pass. Verification is done two ways: per-dialog behavior specs (role, aria-modal,
+Escape, focus restore) and an axe-core static scan wired into the Vitest suite.
+
+Scope was confirmed with the issue owner: full audit of all five dialogs; both hand-written
+behavior specs and axe-core automated checks; the ConfirmDialog recommendation in the finding is
+general guidance, not a required change for this ticket.
+
+## Current state (audit)
+
+### Custom overlays — must be converted
+
+**Goal relation-type dialog** — `features/goals/goal-editor.ts:178`–`190`.
+`.relation-type-dialog` fixed overlay gated by `@if (pendingRelationGoal())`. Closes only via
+overlay click or the Cancel button. No `role`, no `aria-modal`, no focus trap, no Escape, no focus
+restore. **Opened programmatically** from `onRelationGoalSelected()` (`goal-editor.ts:423`) after
+the entity selector closes — so the element focused at open time is inside the closing selector,
+not a stable opener. Focus restore must be set explicitly to the "Add Relation" button
+(`goal-editor.ts:97`).
+
+**Scenario step-detail dialog** — `features/scenarios/scenario-editor.ts:203`–`224`.
+`.edit-popup-overlay` fixed overlay gated by `@if (editingStep())`. Same missing guarantees.
+Opened from a per-step edit button via `openStepEdit(step)` (`scenario-editor.ts:172`), a direct
+click, so PrimeNG's default restore-to-opener will work once converted. Note the SSE-reload guard
+at `scenario-editor.ts:410` keys off `editingStep() !== null`; keep that signal as the source of
+truth for "dialog open" so the guard still holds after conversion.
+
+### Existing p-dialogs — audit / harden only
+
+**Entity selector** — `shared/entity-selector-dialog.ts:53`. Uses `[modal]="true"`,
+`[header]="'Select ' + entityType"`, `appendTo="body"`, `(onHide)="closed.emit()"`. Compliant.
+Add an explicit `ariaLabelledBy`/`role` only if the axe scan flags it. Minor pre-existing smell:
+`[(visible)]="visible"` two-way-binds onto an `@Input()` (child writes a parent-owned input) —
+not an a11y defect; leave as-is unless we choose to clean it up separately.
+
+**Scenario selector** — `shared/scenario-selector-dialog.ts:51`. Same shape and same notes as the
+entity selector. Compliant.
+
+**PAT creation** — `features/users/api-tokens.ts:91`. `[modal]="true"`, static header,
+label/`for` associations on fields, `[(visible)]` bound to a local signal (correct). Compliant.
+
+## Implementation
+
+1. **Goal relation-type dialog → `p-dialog`.** Replace the `.relation-type-dialog` markup with
+   `<p-dialog [(visible)]="…" [modal]="true" [focusOnShow]="true" header='Relation to "…"'>`.
+   Drive visibility from the existing `pendingRelationGoal` signal (e.g. a `relationDialogVisible`
+   computed, or bind visibility to `pendingRelationGoal() !== null` and clear it on hide). On hide,
+   call `.focus()` on the "Add Relation" button (template ref) to guarantee focus return, since the
+   opener is not the last-focused element. Remove the `.relation-type-dialog`/`.dialog-overlay`/
+   `.dialog-content` styles.
+
+2. **Scenario step-detail dialog → `p-dialog`.** Replace `.edit-popup-overlay` with
+   `<p-dialog [(visible)]="…" [modal]="true" [focusOnShow]="true" header="Step Details">`, driven
+   by the `editingStep` signal. Preserve `closeStepEdit()` semantics (called on hide). Keep
+   `editingStep()` as the open-state signal the SSE guard reads. Remove the overlay styles.
+
+3. **Audit pass on the three existing dialogs.** Confirm each renders with `role="dialog"` +
+   `aria-modal="true"`, has an accessible name (header), traps focus, closes on Escape, and
+   restores focus. Add `ariaLabelledBy` or explicit labels only where the axe scan or manual check
+   flags a gap.
+
+4. **Escape / outside-click parity.** `p-dialog` defaults (`closable`, `closeOnEscape`,
+   `dismissableMask` when `[modal]`) give keyboard users Escape-to-close equivalent to the old
+   outside-click. Set `[dismissableMask]="true"` if we want to preserve click-outside-to-close.
+
+## Verification
+
+Manual gate per `CLAUDE.md`: `mvn clean verify` green, and (frontend changed)
+`cd requel-angular && ng test --watch=false` green.
+
+### (a) Behavior specs (Vitest + TestBed, matching existing `*.spec.ts` pattern)
+
+For each of the five dialogs, add/extend specs asserting:
+
+- the rendered dialog container has `role="dialog"` and `aria-modal="true"`;
+- it has an accessible name (header text / `aria-labelledby`);
+- Escape (or the close control) hides it;
+- on close, focus returns to the opener — for the goal relation-type dialog, assert
+  `document.activeElement` is the "Add Relation" button.
+
+All dialogs use `appendTo="body"` (the correct pattern — keeps the overlay clear of ancestor
+`overflow`/`z-index` traps; keep it as-is everywhere). The only consequence is a test convention:
+query the dialog from the document, not `fixture.nativeElement`. Add one shared helper —
+`getOpenDialog()` returning `document.querySelector('[role="dialog"]')` — and route every dialog
+spec and the axe scan through it. Tear the fixture down in each spec (`fixture.destroy()`) and
+assert the dialog node is removed, so a body-appended overlay can't leak and make the next test's
+`[role="dialog"]` query pass falsely. Reuse the existing setup idiom (`provideNoopAnimations()`,
+`vi.fn()` service mocks, `SimpleChange` for `ngOnChanges`).
+
+### (b) axe-core static scan
+
+- Add `axe-core` as a dev dependency; add a small `expectNoAxeViolations(el)` helper (or
+  `vitest-axe`) under the test setup.
+- Run against the dialog's rendered container in `document.body` (not the component subtree,
+  because of `appendTo="body"`).
+- Disable the `color-contrast` rule for these unit runs — jsdom has no layout/`getComputedStyle`
+  box model, so contrast results are unreliable; contrast is governed separately under Finding 4.7.
+- Assert zero violations for each dialog in its open state.
+
+## Risks / open items
+
+- jsdom cannot evaluate focus-trap cycling or true tab order the way a browser can; behavior specs
+  will assert focus-restore and initial-focus, but full keyboard-trap verification should be spot
+  checked manually (or deferred to e2e).
+- `appendTo="body"` is intentional and stays; the only implication is the test convention above
+  (query the document via the shared helper, destroy the fixture between specs to avoid overlay
+  leakage). Not an app-code change.
+- PrimeNG 21 focus-restore relies on the last-focused element at open; the goal relation-type
+  dialog needs the explicit `.focus()` fallback described above.
+
+## Workflow (per CLAUDE.md — actions taken only when explicitly told)
+
+Branch `139-modal-a11y-dialogs` from `release/2.0`; implement; run the verify gate; write
+`commit.md` with `Closes #139`; commit/push and open a PR against `release/2.0` when instructed;
+close the issue manually after squash-merge.

--- a/requel-angular/e2e/pages/GoalEditorPage.ts
+++ b/requel-angular/e2e/pages/GoalEditorPage.ts
@@ -102,15 +102,19 @@ export class GoalEditorPage {
     await dialog.waitFor({ state: 'visible' });
     await dialog.getByTestId('entity-selector-search').fill(toGoalName);
     await dialog.getByTestId('entity-selector-row').filter({ hasText: toGoalName }).first().click();
-    // Custom relation-type dialog appears after goal is selected
-    await this.page.getByTestId('goal-relation-type-dialog').waitFor({ state: 'visible' });
+    // Relation-type dialog appears after the goal is selected. Like the selector above,
+    // it is now a p-dialog with appendTo="body", so the dialog DOM is teleported to the
+    // document root and the goal-relation-type-dialog testid sits on an empty, never-visible
+    // host element. Match the real dialog by role+name (header is `Relation to "<goal>"`).
+    const relationDialog = this.page.getByRole('dialog', { name: `Relation to "${toGoalName}"` });
+    await relationDialog.waitFor({ state: 'visible' });
     if (relationType !== 'Supports') {
-      await this.page.getByTestId('goal-relation-type-select').click();
+      await relationDialog.getByTestId('goal-relation-type-select').click();
       await this.page.getByRole('option', { name: relationType }).click();
     }
     const [response] = await Promise.all([
       this.page.waitForResponse(r => r.url().includes('/api/commands/EditGoalRelation')),
-      this.page.getByTestId('goal-relation-add').click(),
+      relationDialog.getByTestId('goal-relation-add').click(),
     ]);
     if (!response.ok()) {
       throw new Error(`EditGoalRelation failed: ${response.status()} ${await response.text()}`);

--- a/requel-angular/package-lock.json
+++ b/requel-angular/package-lock.json
@@ -32,6 +32,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/node": "^25.6.0",
         "@vitest/coverage-v8": "^4.1.4",
+        "axe-core": "^4.12.1",
         "jsdom": "^28.0.0",
         "monocart-reporter": "^2.0.0",
         "prettier": "^3.8.1",
@@ -4527,6 +4528,16 @@
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",

--- a/requel-angular/package.json
+++ b/requel-angular/package.json
@@ -39,6 +39,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/node": "^25.6.0",
     "@vitest/coverage-v8": "^4.1.4",
+    "axe-core": "^4.12.1",
     "jsdom": "^28.0.0",
     "monocart-reporter": "^2.0.0",
     "prettier": "^3.8.1",

--- a/requel-angular/src/app/features/goals/goal-editor.a11y.spec.ts
+++ b/requel-angular/src/app/features/goals/goal-editor.a11y.spec.ts
@@ -1,0 +1,111 @@
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter, Router, ActivatedRoute, convertToParamMap } from '@angular/router';
+import { BehaviorSubject, EMPTY } from 'rxjs';
+import { MessageService } from 'primeng/api';
+import { GoalEditorComponent } from './goal-editor';
+import { GoalService } from '../../core/goal.service';
+import { TagService } from '../../core/tag.service';
+import { CommandService } from '../../core/command.service';
+import { ProjectService } from '../../core/project.service';
+import { PermissionService } from '../../core/permission.service';
+import { EventStreamService } from '../../core/event-stream.service';
+import { getOpenDialog, expectNoAxeViolations } from '../../shared/testing/a11y';
+
+const MOCK_GOAL = {
+  id: 10, version: 0, name: 'Improve UX', text: 'Make it great.',
+  relationsFromThisGoal: [], relationsToThisGoal: [], referencedBy: [],
+};
+
+const flush = () => new Promise(r => setTimeout(r, 0));
+
+describe('GoalEditorComponent — relation-type dialog accessibility', () => {
+  let paramMap$: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fixture: any;
+  let comp: GoalEditorComponent;
+
+  beforeEach(() => {
+    paramMap$ = new BehaviorSubject(convertToParamMap({ name: 'proj1', goalId: '10' }));
+
+    TestBed.configureTestingModule({
+      imports: [GoalEditorComponent],
+      providers: [
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: ActivatedRoute, useValue: { paramMap: paramMap$.asObservable() } },
+        { provide: GoalService, useValue: { getGoal: vi.fn().mockResolvedValue(MOCK_GOAL) } },
+        { provide: TagService, useValue: {
+            getTagsOnEntity: vi.fn().mockResolvedValue([]),
+            getTagsForProject: vi.fn().mockResolvedValue([]),
+            getCategories: vi.fn().mockResolvedValue([]),
+            getTypedCategories: vi.fn().mockResolvedValue([]),
+          } },
+        { provide: CommandService, useValue: { execute: vi.fn().mockResolvedValue({ success: true, entity: MOCK_GOAL }) } },
+        { provide: ProjectService, useValue: { notifyTreeChanged: vi.fn() } },
+        { provide: PermissionService, useValue: {
+            loadForProject: vi.fn().mockResolvedValue(undefined),
+            canEdit: vi.fn().mockReturnValue(true),
+            canDelete: vi.fn().mockReturnValue(true),
+          } },
+        { provide: EventStreamService, useValue: {
+            events$: EMPTY,
+            addSubscription: vi.fn().mockResolvedValue(undefined),
+            removeSubscription: vi.fn().mockResolvedValue(undefined),
+          } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
+    });
+    fixture = TestBed.createComponent(GoalEditorComponent);
+    comp = fixture.componentInstance;
+    const router = TestBed.inject(Router);
+    vi.spyOn(router, 'navigate').mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+    expect(getOpenDialog()).toBeNull();
+  });
+
+  /** Render an existing goal, then open the relation-type dialog. */
+  async function openRelationDialog(): Promise<void> {
+    fixture.detectChanges();
+    await flush();
+    fixture.detectChanges();
+    comp.onRelationGoalSelected({ entityType: 'Goal', id: 2, name: 'Reduce churn' });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  it('renders the relation-type dialog as a modal with role and aria-modal', async () => {
+    await openRelationDialog();
+    const dialog = getOpenDialog();
+    expect(dialog).not.toBeNull();
+    expect(dialog!.getAttribute('role')).toBe('dialog');
+    expect(dialog!.getAttribute('aria-modal')).toBe('true');
+  });
+
+  it('names the dialog after the target goal', async () => {
+    await openRelationDialog();
+    expect(getOpenDialog()!.textContent).toContain('Reduce churn');
+  });
+
+  it('has no axe-core violations while open', async () => {
+    await openRelationDialog();
+    await expectNoAxeViolations(getOpenDialog()!);
+  });
+
+  it('restores focus to the "Add Relation" opener when the dialog closes', async () => {
+    await openRelationDialog();
+    const addBtn = document.querySelector<HTMLElement>('[data-testid="goal-add-relation"] button');
+    expect(addBtn).not.toBeNull();
+
+    // onRelationDialogHide runs on every close path (Add, Cancel, Escape, mask). The opener is
+    // programmatic (after the entity selector), so we restore focus explicitly rather than
+    // relying on PrimeNG's last-focused-element default.
+    comp.onRelationDialogHide();
+    expect(document.activeElement).toBe(addBtn);
+    expect(comp.pendingRelationGoal()).toBeNull();
+  });
+});

--- a/requel-angular/src/app/features/goals/goal-editor.ts
+++ b/requel-angular/src/app/features/goals/goal-editor.ts
@@ -18,7 +18,7 @@
  * along with Requel. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import { Component, OnDestroy, OnInit, signal } from '@angular/core';
+import { Component, computed, ElementRef, OnDestroy, OnInit, signal, ViewChild } from '@angular/core';
 import { PageHeaderComponent } from '../../shared/page-header';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Subscription } from 'rxjs';
@@ -30,6 +30,7 @@ import { TextareaModule } from 'primeng/textarea';
 import { SelectModule } from 'primeng/select';
 import { TableModule } from 'primeng/table';
 import { MessageModule } from 'primeng/message';
+import { DialogModule } from 'primeng/dialog';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { GoalDto, GoalRelationDto } from '../../models/goal';
@@ -47,7 +48,7 @@ import { TagSelectorComponent } from '../../shared/tag-selector';
   selector: 'app-goal-editor',
   standalone: true,
   imports: [PageHeaderComponent, RouterLink, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
-            TableModule, MessageModule, ConfirmDialogModule, EntitySelectorDialogComponent,
+            TableModule, MessageModule, DialogModule, ConfirmDialogModule, EntitySelectorDialogComponent,
             AnnotationsSectionComponent, TagSelectorComponent],
   providers: [ConfirmationService],
   template: `
@@ -93,7 +94,7 @@ import { TagSelectorComponent } from '../../shared/tag-selector';
           <div class="section-header">
             <h3>This Goal's Relations</h3>
             @if (canEdit()) {
-              <p-button label="Add Relation" icon="pi pi-plus" size="small" data-testid="goal-add-relation"
+              <p-button #addRelationBtn label="Add Relation" icon="pi pi-plus" size="small" data-testid="goal-add-relation"
                         (onClick)="showRelationSelector = true" />
             }
           </div>
@@ -175,21 +176,20 @@ import { TagSelectorComponent } from '../../shared/tag-selector';
         (closed)="showRelationSelector = false" />
 
       <!-- Relation Type Dialog -->
-      @if (pendingRelationGoal()) {
-        <div class="relation-type-dialog" data-testid="goal-relation-type-dialog">
-          <div class="dialog-overlay" (click)="pendingRelationGoal.set(null)"></div>
-          <div class="dialog-content">
-            <h4>Relation to "{{ pendingRelationGoal()!.name }}"</h4>
-            <p-select [(ngModel)]="newRelationType" data-testid="goal-relation-type-select" [options]="relationTypeOptions"
-                      placeholder="Select relation type" />
-            <div class="dialog-actions">
-              <p-button label="Add" icon="pi pi-check" data-testid="goal-relation-add" (onClick)="onConfirmRelation()" />
-              <p-button label="Cancel" severity="secondary" [outlined]="true"
-                        (onClick)="pendingRelationGoal.set(null)" />
-            </div>
+      <p-dialog [visible]="relationDialogVisible()" (visibleChange)="relationDialogVisible.set($event)"
+                (onHide)="onRelationDialogHide()" [modal]="true" [focusOnShow]="true" [dismissableMask]="true"
+                closeAriaLabel="Close" [style]="{ width: '25rem' }" appendTo="body" [header]="relationDialogHeader()"
+                data-testid="goal-relation-type-dialog">
+        <div class="dialog-body">
+          <p-select [(ngModel)]="newRelationType" data-testid="goal-relation-type-select" [options]="relationTypeOptions"
+                    placeholder="Select relation type" appendTo="body" />
+          <div class="dialog-actions">
+            <p-button label="Add" icon="pi pi-check" data-testid="goal-relation-add" (onClick)="onConfirmRelation()" />
+            <p-button label="Cancel" severity="secondary" [outlined]="true"
+                      (onClick)="relationDialogVisible.set(false)" />
           </div>
         </div>
-      }
+      </p-dialog>
 
       @if (!isNew()) {
         <app-tag-selector
@@ -219,11 +219,8 @@ import { TagSelectorComponent } from '../../shared/tag-selector';
     h4 { margin: 1rem 0 0.5rem; }
     .empty-text { color: var(--p-text-secondary-color); font-style: italic; }
     .entity-link { cursor: pointer; color: var(--p-primary-color); text-decoration: underline; }
-    .relation-type-dialog { position: fixed; top: 0; left: 0; right: 0; bottom: 0; z-index: 1000; display: flex; align-items: center; justify-content: center; }
-    .dialog-overlay { position: absolute; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.3); }
-    .dialog-content { position: relative; background: var(--p-surface-0); padding: 1.5rem; border-radius: 8px; min-width: 300px; box-shadow: 0 4px 12px rgba(0,0,0,0.15); }
-    .dialog-content h4 { margin: 0 0 1rem; }
-    .dialog-actions { display: flex; gap: 0.5rem; margin-top: 1rem; }
+    .dialog-body { display: flex; flex-direction: column; }
+    .dialog-actions { display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 1rem; }
   `]
 })
 export class GoalEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
@@ -235,6 +232,13 @@ export class GoalEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
   canEdit = signal(false);
   canDelete = signal(false);
   pendingRelationGoal = signal<EntityReferenceDto | null>(null);
+  relationDialogVisible = signal(false);
+  relationDialogHeader = computed(() => {
+    const ref = this.pendingRelationGoal();
+    return ref ? `Relation to "${ref.name}"` : '';
+  });
+
+  @ViewChild('addRelationBtn', { read: ElementRef }) addRelationBtn?: ElementRef<HTMLElement>;
 
   name = '';
   text = '';
@@ -423,12 +427,24 @@ export class GoalEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
   onRelationGoalSelected(ref: EntityReferenceDto): void {
     this.pendingRelationGoal.set(ref);
     this.newRelationType = 'Supports';
+    this.relationDialogVisible.set(true);
+  }
+
+  /**
+   * Called after the relation-type dialog closes by any path (Add, Cancel, Escape, mask).
+   * Clears the pending goal and restores focus to the "Add Relation" opener — the dialog is
+   * opened programmatically after the entity selector closes, so PrimeNG's default
+   * restore-to-last-focused-element has no stable target here.
+   */
+  onRelationDialogHide(): void {
+    this.pendingRelationGoal.set(null);
+    this.addRelationBtn?.nativeElement.querySelector('button')?.focus();
   }
 
   async onConfirmRelation(): Promise<void> {
     const ref = this.pendingRelationGoal();
     if (!ref) return;
-    this.pendingRelationGoal.set(null);
+    this.relationDialogVisible.set(false);
 
     const result = await this.commandService.execute('EditGoalRelation', {
       projectName: this.projectName,

--- a/requel-angular/src/app/features/scenarios/scenario-editor.a11y.spec.ts
+++ b/requel-angular/src/app/features/scenarios/scenario-editor.a11y.spec.ts
@@ -1,0 +1,102 @@
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter, Router, ActivatedRoute, convertToParamMap } from '@angular/router';
+import { Location } from '@angular/common';
+import { BehaviorSubject, EMPTY } from 'rxjs';
+import { MessageService } from 'primeng/api';
+import { ScenarioEditorComponent } from './scenario-editor';
+import { ScenarioService } from '../../core/scenario.service';
+import { CommandService } from '../../core/command.service';
+import { ProjectService } from '../../core/project.service';
+import { PermissionService } from '../../core/permission.service';
+import { EventStreamService } from '../../core/event-stream.service';
+import { getOpenDialog, expectNoAxeViolations } from '../../shared/testing/a11y';
+
+const flush = () => new Promise(r => setTimeout(r, 0));
+
+const STEP = {
+  stepId: 1, name: 'User submits credentials', text: 'Additional notes',
+  scenarioType: 'Primary', isScenario: false, isNew: false,
+};
+
+describe('ScenarioEditorComponent — step-detail dialog accessibility', () => {
+  let paramMap$: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fixture: any;
+  let comp: ScenarioEditorComponent;
+
+  beforeEach(() => {
+    paramMap$ = new BehaviorSubject(convertToParamMap({ name: 'proj1', scenarioId: 'new' }));
+
+    TestBed.configureTestingModule({
+      imports: [ScenarioEditorComponent],
+      providers: [
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: ActivatedRoute, useValue: { paramMap: paramMap$.asObservable() } },
+        { provide: Location, useValue: { back: vi.fn() } },
+        { provide: ScenarioService, useValue: { getScenario: vi.fn().mockResolvedValue(null) } },
+        { provide: CommandService, useValue: { execute: vi.fn() } },
+        { provide: ProjectService, useValue: { notifyTreeChanged: vi.fn() } },
+        { provide: PermissionService, useValue: {
+            loadForProject: vi.fn().mockResolvedValue(undefined),
+            canEdit: vi.fn().mockReturnValue(true),
+            canDelete: vi.fn().mockReturnValue(true),
+          } },
+        { provide: EventStreamService, useValue: {
+            events$: EMPTY,
+            addSubscription: vi.fn().mockResolvedValue(undefined),
+            removeSubscription: vi.fn().mockResolvedValue(undefined),
+          } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
+    });
+    fixture = TestBed.createComponent(ScenarioEditorComponent);
+    comp = fixture.componentInstance;
+    const router = TestBed.inject(Router);
+    vi.spyOn(router, 'navigate').mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+    expect(getOpenDialog()).toBeNull();
+  });
+
+  async function openStepDialog(): Promise<void> {
+    fixture.detectChanges();
+    await flush();
+    comp.openStepEdit({ ...STEP });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  it('renders the step-detail dialog as a modal with role and aria-modal', async () => {
+    await openStepDialog();
+    const dialog = getOpenDialog();
+    expect(dialog).not.toBeNull();
+    expect(dialog!.getAttribute('role')).toBe('dialog');
+    expect(dialog!.getAttribute('aria-modal')).toBe('true');
+  });
+
+  it('exposes an accessible name (header) to assistive tech', async () => {
+    await openStepDialog();
+    expect(getOpenDialog()!.textContent).toContain('Step Details');
+  });
+
+  it('has no axe-core violations while open', async () => {
+    await openStepDialog();
+    await expectNoAxeViolations(getOpenDialog()!);
+  });
+
+  it('closes (clears editingStep) when PrimeNG emits visibleChange(false) via Escape/mask', async () => {
+    await openStepDialog();
+    expect(comp.editingStep()).not.toBeNull();
+    comp.onStepDialogVisibleChange(false);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(comp.editingStep()).toBeNull();
+    expect(getOpenDialog()).toBeNull();
+  });
+});

--- a/requel-angular/src/app/features/scenarios/scenario-editor.ts
+++ b/requel-angular/src/app/features/scenarios/scenario-editor.ts
@@ -30,6 +30,7 @@ import { InputText } from 'primeng/inputtext';
 import { TextareaModule } from 'primeng/textarea';
 import { SelectModule } from 'primeng/select';
 import { MessageModule } from 'primeng/message';
+import { DialogModule } from 'primeng/dialog';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { TooltipModule } from 'primeng/tooltip';
 import { DragDropModule, CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
@@ -64,7 +65,7 @@ interface StepNodeData {
   selector: 'app-scenario-editor',
   standalone: true,
   imports: [PageHeaderComponent, RouterLink, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
-            MessageModule, ConfirmDialogModule, TooltipModule, DragDropModule,
+            MessageModule, DialogModule, ConfirmDialogModule, TooltipModule, DragDropModule,
             ScenarioSelectorDialogComponent, AnnotationsSectionComponent],
   providers: [ConfirmationService],
   template: `
@@ -199,31 +200,29 @@ interface StepNodeData {
         </div>
       }
 
-      <!-- Step detail edit popup -->
-      @if (editingStep()) {
-        <div class="edit-popup-overlay" data-testid="scenario-step-edit-overlay" (click)="closeStepEdit()">
-          <div class="edit-popup-content" data-testid="scenario-step-edit-dialog" (click)="$event.stopPropagation()">
-            <h4>Step Details</h4>
-            <div class="edit-popup-grid">
-              <label>Name</label>
-              <input pInputText [(ngModel)]="editingName" data-testid="scenario-step-edit-name"
-                     placeholder="Step description..." />
-              <label>Type</label>
-              <p-select [(ngModel)]="editingType" data-testid="scenario-step-edit-type" [options]="typeOptions"
-                        optionLabel="label" optionValue="value" />
-              <label>Notes</label>
-              <textarea pTextarea [(ngModel)]="editingText" data-testid="scenario-step-edit-text" rows="4"
-                        placeholder="Additional details or notes..."></textarea>
-            </div>
-            <div class="edit-popup-actions">
-              <p-button label="Apply" icon="pi pi-check" size="small" data-testid="scenario-step-edit-apply"
-                        (onClick)="applyStepEdit()" />
-              <p-button label="Cancel" severity="secondary" [outlined]="true" size="small"
-                        (onClick)="closeStepEdit()" />
-            </div>
-          </div>
+      <!-- Step detail edit dialog -->
+      <p-dialog [visible]="editingStep() !== null" (visibleChange)="onStepDialogVisibleChange($event)"
+                [modal]="true" [focusOnShow]="true" [dismissableMask]="true" closeAriaLabel="Close"
+                [style]="{ width: '32rem' }" appendTo="body" header="Step Details"
+                data-testid="scenario-step-edit-dialog">
+        <div class="dialog-grid">
+          <label for="stepEditName">Name</label>
+          <input id="stepEditName" pInputText [(ngModel)]="editingName" data-testid="scenario-step-edit-name"
+                 placeholder="Step description..." />
+          <label for="stepEditType">Type</label>
+          <p-select inputId="stepEditType" [(ngModel)]="editingType" data-testid="scenario-step-edit-type"
+                    [options]="typeOptions" optionLabel="label" optionValue="value" appendTo="body" />
+          <label for="stepEditText">Notes</label>
+          <textarea id="stepEditText" pTextarea [(ngModel)]="editingText" data-testid="scenario-step-edit-text" rows="4"
+                    placeholder="Additional details or notes..."></textarea>
         </div>
-      }
+        <div class="dialog-actions">
+          <p-button label="Apply" icon="pi pi-check" size="small" data-testid="scenario-step-edit-apply"
+                    (onClick)="applyStepEdit()" />
+          <p-button label="Cancel" severity="secondary" [outlined]="true" size="small"
+                    (onClick)="closeStepEdit()" />
+        </div>
+      </p-dialog>
 
       <app-scenario-selector-dialog
         [visible]="showScenarioSelector"
@@ -297,19 +296,9 @@ interface StepNodeData {
       white-space: nowrap; flex-shrink: 0;
     }
 
-    /* Step edit popup */
-    .edit-popup-overlay {
-      position: fixed; top: 0; left: 0; right: 0; bottom: 0;
-      z-index: 1000; display: flex; align-items: center; justify-content: center;
-      background: rgba(0,0,0,0.3);
-    }
-    .edit-popup-content {
-      background: var(--p-surface-0); padding: 1.5rem; border-radius: 8px;
-      min-width: 380px; max-width: 500px; box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-    }
-    .edit-popup-content h4 { margin: 0 0 1rem; }
-    .edit-popup-grid { display: grid; grid-template-columns: 80px 1fr; gap: 0.5rem; align-items: start; }
-    .edit-popup-actions { display: flex; gap: 0.5rem; margin-top: 1rem; }
+    /* Step edit dialog */
+    .dialog-grid { display: grid; grid-template-columns: 80px 1fr; gap: 0.5rem; align-items: start; }
+    .dialog-actions { display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 1rem; }
   `]
 })
 export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
@@ -536,6 +525,18 @@ export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckabl
 
   closeStepEdit(): void {
     this.editingStep.set(null);
+  }
+
+  /**
+   * Bridges PrimeNG's user-initiated closes (Escape, mask click, close icon) back to our
+   * single source of truth. PrimeNG emits visibleChange(false) on those paths; clearing
+   * editingStep drives [visible] false and lets the dialog restore focus to the opener.
+   * (Apply/Cancel already clear editingStep directly.)
+   */
+  onStepDialogVisibleChange(visible: boolean): void {
+    if (!visible && this.editingStep() !== null) {
+      this.closeStepEdit();
+    }
   }
 
   onSubScenarioSelected(ref: ScenarioRef): void {

--- a/requel-angular/src/app/features/users/api-tokens.a11y.spec.ts
+++ b/requel-angular/src/app/features/users/api-tokens.a11y.spec.ts
@@ -1,0 +1,55 @@
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { ApiTokensComponent } from './api-tokens';
+import { TokenService } from '../../core/token.service';
+import { getOpenDialog, expectNoAxeViolations } from '../../shared/testing/a11y';
+
+describe('ApiTokensComponent — create-token dialog accessibility', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fixture: any;
+  let comp: ApiTokensComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ApiTokensComponent],
+      providers: [
+        provideNoopAnimations(),
+        { provide: TokenService, useValue: { list: vi.fn().mockResolvedValue([]) } },
+      ],
+    });
+    fixture = TestBed.createComponent(ApiTokensComponent);
+    comp = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+    expect(getOpenDialog()).toBeNull();
+  });
+
+  async function openDialog(): Promise<void> {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    comp.openCreate();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  it('renders as a modal dialog with role and aria-modal', async () => {
+    await openDialog();
+    const dialog = getOpenDialog();
+    expect(dialog).not.toBeNull();
+    expect(dialog!.getAttribute('role')).toBe('dialog');
+    expect(dialog!.getAttribute('aria-modal')).toBe('true');
+  });
+
+  it('exposes an accessible name (header) to assistive tech', async () => {
+    await openDialog();
+    expect(getOpenDialog()!.textContent).toContain('New personal access token');
+  });
+
+  it('has no axe-core violations while open', async () => {
+    await openDialog();
+    await expectNoAxeViolations(getOpenDialog()!);
+  });
+});

--- a/requel-angular/src/app/features/users/api-tokens.ts
+++ b/requel-angular/src/app/features/users/api-tokens.ts
@@ -89,7 +89,8 @@ import { ApiTokenDto } from '../../models/api-token';
       }
 
       <p-dialog header="New personal access token" [(visible)]="createDialogVisible"
-                [modal]="true" [style]="{ width: '32rem' }" (onHide)="onDialogHide()">
+                [modal]="true" [focusOnShow]="true" closeAriaLabel="Close"
+                [style]="{ width: '32rem' }" (onHide)="onDialogHide()">
         @if (createdToken() === null) {
           <div class="field">
             <label for="patName">Name</label>

--- a/requel-angular/src/app/shared/entity-selector-dialog.a11y.spec.ts
+++ b/requel-angular/src/app/shared/entity-selector-dialog.a11y.spec.ts
@@ -1,0 +1,71 @@
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { SimpleChange } from '@angular/core';
+import { EntitySelectorDialogComponent } from './entity-selector-dialog';
+import { GoalService } from '../core/goal.service';
+import { StoryService } from '../core/story.service';
+import { ActorService } from '../core/actor.service';
+import { ScenarioService } from '../core/scenario.service';
+import { getOpenDialog, expectNoAxeViolations } from './testing/a11y';
+
+const MOCK_GOALS = [
+  { id: 1, name: 'Goal A' },
+  { id: 2, name: 'Goal B' },
+];
+
+describe('EntitySelectorDialogComponent — accessibility', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fixture: any;
+  let comp: EntitySelectorDialogComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [EntitySelectorDialogComponent],
+      providers: [
+        provideNoopAnimations(),
+        { provide: GoalService, useValue: { listGoals: vi.fn().mockResolvedValue(MOCK_GOALS) } },
+        { provide: StoryService, useValue: { listStories: vi.fn().mockResolvedValue([]) } },
+        { provide: ActorService, useValue: { listActors: vi.fn().mockResolvedValue([]) } },
+        { provide: ScenarioService, useValue: { listScenarios: vi.fn().mockResolvedValue([]) } },
+      ],
+    });
+    fixture = TestBed.createComponent(EntitySelectorDialogComponent);
+    comp = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    // Dialogs render on document.body via appendTo="body"; destroy the fixture so the overlay
+    // is removed and cannot leak into the next test's document queries.
+    fixture.destroy();
+    expect(getOpenDialog()).toBeNull();
+  });
+
+  async function openDialog(): Promise<void> {
+    comp.visible = true;
+    comp.projectName = 'proj1';
+    comp.entityType = 'Goal';
+    comp.ngOnChanges({ visible: new SimpleChange(false, true, false) });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  it('renders as a modal dialog with role and aria-modal', async () => {
+    await openDialog();
+    const dialog = getOpenDialog();
+    expect(dialog).not.toBeNull();
+    expect(dialog!.getAttribute('role')).toBe('dialog');
+    expect(dialog!.getAttribute('aria-modal')).toBe('true');
+  });
+
+  it('exposes an accessible name (header) to assistive tech', async () => {
+    await openDialog();
+    const dialog = getOpenDialog();
+    expect(dialog!.textContent).toContain('Select Goal');
+  });
+
+  it('has no axe-core violations while open', async () => {
+    await openDialog();
+    await expectNoAxeViolations(getOpenDialog()!);
+  });
+});

--- a/requel-angular/src/app/shared/entity-selector-dialog.ts
+++ b/requel-angular/src/app/shared/entity-selector-dialog.ts
@@ -51,7 +51,8 @@ import { ScenarioService } from '../core/scenario.service';
   imports: [FormsModule, DialogModule, TableModule, ButtonModule, InputText, SelectModule],
   template: `
     <p-dialog [header]="'Select ' + entityType" [(visible)]="visible" data-testid="entity-selector-dialog"
-              [modal]="true" appendTo="body" [style]="{ width: '500px' }" (onHide)="closed.emit()">
+              [modal]="true" [focusOnShow]="true" closeAriaLabel="Close" appendTo="body"
+              [style]="{ width: '500px' }" (onHide)="closed.emit()">
       <div class="search-bar">
         <span class="p-input-icon-left">
           <i class="pi pi-search"></i>

--- a/requel-angular/src/app/shared/scenario-selector-dialog.a11y.spec.ts
+++ b/requel-angular/src/app/shared/scenario-selector-dialog.a11y.spec.ts
@@ -1,0 +1,63 @@
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { SimpleChange } from '@angular/core';
+import { ScenarioSelectorDialogComponent } from './scenario-selector-dialog';
+import { ScenarioService } from '../core/scenario.service';
+import { CommandService } from '../core/command.service';
+import { getOpenDialog, expectNoAxeViolations } from './testing/a11y';
+
+const MOCK_SCENARIOS = [
+  { id: 1, name: 'Login Flow', scenarioType: 'Primary' },
+  { id: 2, name: 'Logout Flow', scenarioType: 'Alternative' },
+];
+
+describe('ScenarioSelectorDialogComponent — accessibility', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fixture: any;
+  let comp: ScenarioSelectorDialogComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ScenarioSelectorDialogComponent],
+      providers: [
+        provideNoopAnimations(),
+        { provide: ScenarioService, useValue: { listScenarios: vi.fn().mockResolvedValue(MOCK_SCENARIOS) } },
+        { provide: CommandService, useValue: { execute: vi.fn() } },
+      ],
+    });
+    fixture = TestBed.createComponent(ScenarioSelectorDialogComponent);
+    comp = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+    expect(getOpenDialog()).toBeNull();
+  });
+
+  async function openDialog(): Promise<void> {
+    comp.visible = true;
+    comp.projectName = 'proj1';
+    comp.ngOnChanges({ visible: new SimpleChange(false, true, false) });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  it('renders as a modal dialog with role and aria-modal', async () => {
+    await openDialog();
+    const dialog = getOpenDialog();
+    expect(dialog).not.toBeNull();
+    expect(dialog!.getAttribute('role')).toBe('dialog');
+    expect(dialog!.getAttribute('aria-modal')).toBe('true');
+  });
+
+  it('exposes an accessible name (header) to assistive tech', async () => {
+    await openDialog();
+    expect(getOpenDialog()!.textContent).toContain('Add Sub-scenario');
+  });
+
+  it('has no axe-core violations while open', async () => {
+    await openDialog();
+    await expectNoAxeViolations(getOpenDialog()!);
+  });
+});

--- a/requel-angular/src/app/shared/scenario-selector-dialog.ts
+++ b/requel-angular/src/app/shared/scenario-selector-dialog.ts
@@ -48,8 +48,8 @@ const SCENARIO_TYPE_OPTIONS = [
   standalone: true,
   imports: [FormsModule, DialogModule, TableModule, ButtonModule, InputText, SelectModule],
   template: `
-    <p-dialog header="Add Sub-scenario" [(visible)]="visible" [modal]="true"
-              appendTo="body" [style]="{ width: '560px' }" (onHide)="onHide()"
+    <p-dialog header="Add Sub-scenario" [(visible)]="visible" [modal]="true" [focusOnShow]="true"
+              closeAriaLabel="Close" appendTo="body" [style]="{ width: '560px' }" (onHide)="onHide()"
               styleClass="scenario-selector-dialog">
 
       <!-- Inline new-scenario creation form -->

--- a/requel-angular/src/app/shared/testing/a11y.ts
+++ b/requel-angular/src/app/shared/testing/a11y.ts
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import axe from 'axe-core';
+import { expect } from 'vitest';
+
+/**
+ * Returns the currently-rendered modal dialog from the document.
+ *
+ * All app dialogs render with `appendTo="body"` (the correct pattern — it keeps the overlay
+ * clear of ancestor overflow/z-index traps), so the dialog lives on document.body, NOT inside
+ * a component fixture's nativeElement. Always query the document for dialog assertions.
+ */
+export function getOpenDialog(): HTMLElement | null {
+  return document.querySelector<HTMLElement>('[role="dialog"]');
+}
+
+/**
+ * Runs axe-core against `root` (default: the whole document body) and fails the test if there
+ * are any violations, with a readable summary.
+ *
+ * The `color-contrast` rule is disabled: jsdom has no layout engine / real getComputedStyle box
+ * model, so contrast results are unreliable in unit tests. Color contrast is governed separately
+ * (UI/UX review Finding 4.7), not here.
+ */
+export async function expectNoAxeViolations(root: Element = document.body): Promise<void> {
+  const results = await axe.run(root, {
+    rules: { 'color-contrast': { enabled: false } },
+  });
+
+  const summary = results.violations
+    .map(v => `  • ${v.id} [${v.impact}] ${v.help} (${v.nodes.length} node(s))`)
+    .join('\n');
+
+  expect(results.violations, `Accessibility violations found:\n${summary}`).toEqual([]);
+}

--- a/scripts/create-ui-ux-lookandfeel.sh
+++ b/scripts/create-ui-ux-lookandfeel.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+#
+# create-ui-ux-lookandfeel.sh
+# Applies the look-and-feel plan (doc/124-lookandfeel-plan.md) to the existing UI/UX
+# epic #124:
+#   1. Appends the §3 "Target look-and-feel" block to existing sub-issues
+#      #125, #126, #127, #128, #129, #132, #146 (idempotent — safe to rerun).
+#   2. Creates the new N1–N6 sub-issues, each linked to #124 as a real sub-issue.
+#
+# NOTE: This does NOT rerun create-ui-ux-epic.sh (that would duplicate the epic and its
+# 23 existing children). The updates are guarded by a marker so reruns won't
+# double-append; the N1–N6 creation step is NOT guarded, so run it once.
+#
+# Requirements:
+#   - gh CLI v2.94.0+ (for the native --parent flag). Check: gh --version
+#   - Authenticated: gh auth status
+#
+# Usage:
+#   bash scripts/create-ui-ux-lookandfeel.sh           # do it
+#   DRY_RUN=1 bash scripts/create-ui-ux-lookandfeel.sh # print gh commands without running
+#
+set -euo pipefail
+
+REPO="rreganjr/Requel"
+EPIC="124"
+MILESTONE="v2.0"
+DRY_RUN="${DRY_RUN:-0}"
+
+# --- helpers ---------------------------------------------------------------
+
+# Create an issue and echo its number (trailing digits of the printed URL).
+create_issue() {  # args: title body [extra gh flags...]
+  local title="$1"; local body="$2"; shift 2
+  if [[ "$DRY_RUN" == "1" ]]; then
+    printf 'gh issue create --repo %s --title %q --body <…> %s\n' "$REPO" "$title" "$*" >&2
+    echo "NNN"   # placeholder issue number (stdout)
+    return
+  fi
+  gh issue create --repo "$REPO" --title "$title" --body "$body" "$@" \
+    | grep -oE '[0-9]+$'
+}
+
+# Create a child linked to the epic.
+child() {  # args: title priority-label body
+  local title="$1"; local prio="$2"; local body="$3"
+  if grep -qxF "$title" <<<"$EXISTING_TITLES"; then
+    echo "  child already exists — skipping: $title"
+    return
+  fi
+  local num
+  num=$(create_issue "$title" "$body" \
+        --label ui-ux-review --label "$prio" \
+        --milestone "$MILESTONE" --parent "$EPIC")
+  echo "  child #$num  $title"
+}
+
+# Append/refresh the look-and-feel block on an existing issue body. Idempotent AND
+# self-healing: if the block is already present it is stripped and rewritten, so a
+# rerun replaces (never duplicates) it and repairs any earlier bad render.
+MARKER="## Target look-and-feel (see doc/124-lookandfeel-plan.md)"
+append_to_issue() {  # args: issue-number body-block
+  local num="$1"; local block="$2"
+  local current base
+  current=$(gh issue view "$num" --repo "$REPO" --json body -q .body 2>/dev/null || echo "")
+  base="${current%%"$MARKER"*}"                                 # body before any existing block
+  while [[ "$base" == *$'\n' ]]; do base="${base%$'\n'}"; done  # trim trailing newlines
+  if [[ "$DRY_RUN" == "1" ]]; then
+    printf 'gh issue edit %s --repo %s --body-file <base body + look-and-feel block>\n' "$num" "$REPO" >&2
+    return
+  fi
+  local tmp; tmp=$(mktemp)
+  printf '%s\n\n%s\n%s\n' "$base" "$MARKER" "$block" > "$tmp"
+  gh issue edit "$num" --repo "$REPO" --body-file "$tmp"
+  rm -f "$tmp"
+  echo "  updated #$num"
+}
+
+# Titles already linked under the epic — makes the create step (§4) idempotent.
+EXISTING_TITLES=$(gh issue view "$EPIC" --repo "$REPO" --json subIssues \
+  -q '.subIssues.nodes[].title' 2>/dev/null || echo "")
+
+# ===========================================================================
+# Step 1 — Append the §3 look-and-feel block to existing sub-issues
+# ===========================================================================
+echo "Updating existing sub-issues (§3) ..."
+
+append_to_issue 125 "$(cat <<'EOF'
+Target the look-and-feel tokens. `src/app/theme/requel-preset.ts` `definePreset` sets: primary `#3b82f6` (hover `#2563eb`); a surface ramp from a cool blue base (`#1e3a8a` mixed toward white) with white cards on a light blue-gray canvas; content border-radius `6px`; base font Figtree at 14px. No component may hard-code these — all read from tokens. Light mode first; leave hooks for a later dark mode.
+EOF
+)"
+
+append_to_issue 126 "$(cat <<'EOF'
+Replace hard-coded chip/badge/header colors with the preset's semantic tokens and a shared card-surface token set (`--rq-card-bg`, `--rq-card-border`, `--rq-card-radius`, `--rq-card-shadow`, `--rq-card-pad`). No `#1a1a7e`/`#3b82f6` literals left in component styles.
+EOF
+)"
+
+append_to_issue 127 "$(cat <<'EOF'
+Load Figtree; define a type scale (page title, card title, field label, helper, body, caption) as tokens and apply through shared primitives (bold slate titles, muted helper text).
+EOF
+)"
+
+append_to_issue 128 "$(cat <<'EOF'
+Restructure the app shell: top bar shows back + breadcrumb (project → section → entity) on the left and search / notifications / account / sidebar-toggle on the right; sidebar uses grouped, labelled, collapsible sections. Shell-chrome build is tracked in N1.
+EOF
+)"
+
+append_to_issue 129 "$(cat <<'EOF'
+Build/adopt a single data-table pattern: card wrapper; toolbar with title + search + primary **New** action; optional checkbox multi-select; a status **Tag** column; sortable headers; a trailing `⋯` row-actions menu; a centered paginator. List pages stop using whole-row click as the only affordance. Component build is tracked in N4.
+EOF
+)"
+
+append_to_issue 132 "$(cat <<'EOF'
+Reactive-forms migration targets a field-row layout: label + helper text on the left, control on the right, hairline dividers between rows, sticky footer with subtle **Cancel** + primary **Save/Continue**. Inline errors sit under the control. Wizard/field component build is tracked in N5.
+EOF
+)"
+
+append_to_issue 146 "$(cat <<'EOF'
+Concrete shared primitives to build (tracked as new sub-issues): app-shell chrome (N1), `app-tag`/`app-chip` severity system (N2), `app-card` surface (N3), `app-data-table` (N4), `app-form-wizard` + `app-field` (N5). These are the reusable base the repeated project/goal/story/actor/scenario/use-case views compose from.
+EOF
+)"
+
+# ===========================================================================
+# Step 2 — Create the new N1–N6 sub-issues
+# ===========================================================================
+echo "Adding look-and-feel sub-issues to epic #$EPIC ..."
+
+# ===========================================================================
+# N1 — App shell
+# ===========================================================================
+child "N1 App shell: top bar + grouped collapsible sidebar" "priority:medium" "$(cat <<'EOF'
+Part of the look-and-feel adoption in `doc/124-lookandfeel-plan.md`.
+
+Reshape `layout` + `sidebar-nav` to the target app shell.
+
+**Top bar**
+- Left: back button + breadcrumb reflecting the current route (project → section → entity).
+- Right: search, notifications (future), account menu, sidebar collapse toggle.
+
+**Sidebar**
+- Grouped, labelled sections; icon + label items; collapsible groups; active-item highlight.
+
+**Canvas**
+- Light blue-gray surface token; content in white cards.
+
+**Acceptance**
+- Breadcrumb is keyboard-navigable and reflects route params.
+- Sidebar collapse state persists.
+- Header color comes from tokens (no `#1a1a7e` literal).
+- Passes the a11y landmark checks from #135.
+
+Overlaps #128 — this is the shell-chrome half; #128 keeps the project-context/IA half.
+EOF
+)"
+
+# ===========================================================================
+# N2 — Tag & Chip severity system
+# ===========================================================================
+child "N2 Tag & Chip severity system as shared primitives" "priority:medium" "$(cat <<'EOF'
+Part of the look-and-feel adoption in `doc/124-lookandfeel-plan.md`.
+
+Add `app-tag` and `app-chip` wrappers over PrimeNG Tag/Chip.
+
+- Soft-tinted background + matching colored text.
+- Tag variants: default (rounded rect), pill (fully rounded), icon (leading icon).
+- Severities: `primary | success | info | warning | danger`.
+- Chips: leading icon/avatar/image, optional trailing remove (×).
+- Replace ad-hoc hard-coded tag colors in `goal-list`, `annotations-section`, `tag-selector`.
+
+**Acceptance**
+- One component renders every severity/variant from tokens.
+- Used for entity status, annotation kind, and tag chips.
+- Color is never the only signal (icon or text label present) — satisfies #141.
+EOF
+)"
+
+# ===========================================================================
+# N3 — Card / content-surface primitive
+# ===========================================================================
+child "N3 Card / content-surface primitive (app-card)" "priority:low" "$(cat <<'EOF'
+Part of the look-and-feel adoption in `doc/124-lookandfeel-plan.md`.
+
+Extract the repeated card container into `app-card`.
+
+- Title slot, padding, hairline border, 6px radius, soft shadow.
+- Tokens: `--rq-card-bg`, `--rq-card-border`, `--rq-card-radius`, `--rq-card-shadow`, `--rq-card-pad`.
+- Adopt across list and editor shells.
+
+**Acceptance**
+- List pages and editors render inside `app-card`.
+- No per-view card CSS duplication.
+- Radius/shadow/border come from tokens.
+EOF
+)"
+
+# ===========================================================================
+# N4 — Data-table pattern component
+# ===========================================================================
+child "N4 Data-table pattern component (app-data-table)" "priority:medium" "$(cat <<'EOF'
+Part of the look-and-feel adoption in `doc/124-lookandfeel-plan.md`.
+
+Implement the table pattern as a reusable component over PrimeNG Table.
+
+- Toolbar: title + search + primary action.
+- Optional checkbox selection column.
+- Sortable column headers.
+- Status column via `app-tag`.
+- Trailing `⋯` row-actions menu.
+- Centered paginator (first/prev/page/next/last).
+- Drive goal/story/actor/stakeholder/scenario/use-case/term list pages from it.
+
+**Acceptance**
+- At least two existing list pages migrated.
+- Search + sort + paginate work.
+- Row actions are real buttons with accessible names (#136/#137).
+- Empty state via the standard empty component (#131).
+
+Concretizes #129 + #146.
+EOF
+)"
+
+# ===========================================================================
+# N5 — Multi-step entity-create wizard
+# ===========================================================================
+child "N5 Multi-step entity-create wizard (app-form-wizard + app-field)" "priority:medium" "$(cat <<'EOF'
+Part of the look-and-feel adoption in `doc/124-lookandfeel-plan.md`.
+
+Build the two-column create wizard.
+
+- Left: vertical step nav with completion state.
+- Right: the active step's fields.
+- `app-field`: label + helper text on the left, control on the right, hairline divider, inline error slot.
+- Footer: subtle Cancel + primary Continue/Save.
+- Use for a representative create flow (e.g. new Goal or Story).
+
+**Acceptance**
+- Built on reactive forms (#132).
+- Labels/errors associated (#138).
+- Step nav keyboard-operable.
+- One create flow migrated end-to-end.
+
+Concretizes #132 + #146.
+EOF
+)"
+
+# ===========================================================================
+# N6 — (Optional) Theme switcher + dark mode
+# ===========================================================================
+child "N6 Theme switcher + dark mode via config panel (optional)" "priority:low" "$(cat <<'EOF'
+Part of the look-and-feel adoption in `doc/124-lookandfeel-plan.md`.
+
+Add a config panel (gear in the top bar) to toggle light/dark and optionally the
+primary color, backed by the preset's dark token set.
+
+**Acceptance**
+- Dark mode reads entirely from tokens.
+- Preference persists.
+- Contrast passes AA in both modes (#141).
+
+Defer if out of scope for v2.0.
+EOF
+)"
+
+echo "Done. Verify: gh issue view $EPIC --repo $REPO --json title,subIssues"

--- a/scripts/epic-rollup-comment.sh
+++ b/scripts/epic-rollup-comment.sh
@@ -10,9 +10,10 @@
 # Requirements: gh CLI v2.94.0+ (sub-issue JSON), authenticated.
 #
 # Usage:
-#   bash scripts/epic-rollup-comment.sh             # post the comment on #124
-#   EPIC=124 bash scripts/epic-rollup-comment.sh    # override epic number
-#   DRY_RUN=1 bash scripts/epic-rollup-comment.sh   # print the comment, post nothing
+#   bash scripts/epic-rollup-comment.sh                       # post a new comment on #124
+#   COMMENT_ID=5113771759 bash scripts/epic-rollup-comment.sh # edit the EXISTING rollup comment in place
+#   EPIC=124 bash scripts/epic-rollup-comment.sh              # override epic number
+#   DRY_RUN=1 bash scripts/epic-rollup-comment.sh             # print the comment, do nothing
 #
 set -euo pipefail
 
@@ -23,12 +24,12 @@ DRY_RUN="${DRY_RUN:-0}"
 # Finding -> phase mapping (from doc/UI_UX_REVIEW.md "Proposed Phased Roadmap").
 phase_of() {
   case "$1" in
-    4.1|4.2|4.3|4.5|4.7) echo 1 ;;   # quick wins & a11y blockers
-    1.1|1.2|1.3|5.5)     echo 2 ;;   # design-system foundation
-    3.1|3.2|3.3|4.4|5.2) echo 3 ;;   # forms & validation
-    2.1|2.2|2.3|2.4|4.6) echo 4 ;;   # IA & workflow polish
-    5.1|5.3|5.4|5.6)     echo 5 ;;   # deeper architecture refactors
-    *)                   echo 0 ;;   # unmapped (should not happen)
+    4.1|4.2|4.3|4.5|4.7)        echo 1 ;;   # quick wins & a11y blockers
+    1.1|1.2|1.3|5.5|N2|N3|N6)   echo 2 ;;   # design-system foundation (+ look-and-feel N2/N3/N6)
+    3.1|3.2|3.3|4.4|5.2|N5)     echo 3 ;;   # forms & validation (+ look-and-feel N5)
+    2.1|2.2|2.3|2.4|4.6|N1|N4)  echo 4 ;;   # IA & workflow polish (+ look-and-feel N1/N4)
+    5.1|5.3|5.4|5.6)            echo 5 ;;   # deeper architecture refactors
+    *)                          echo 0 ;;   # unmapped (should not happen)
   esac
 }
 
@@ -45,11 +46,11 @@ phase_name() {
 
 TAB="$(printf '\t')"
 
-# Pull sub-issues as "number<TAB>title" lines.
+# Pull sub-issues as "number<TAB>title<TAB>state" lines.
 tmp="$(mktemp)"
 trap 'rm -f "$tmp"' EXIT
 gh issue view "$EPIC" --repo "$REPO" --json subIssues \
-  --jq '.subIssues.nodes[] | "\(.number)\t\(.title)"' > "$tmp"
+  --jq '.subIssues.nodes[] | "\(.number)\t\(.title)\t\(.state)"' > "$tmp"
 
 if [ ! -s "$tmp" ]; then
   echo "No sub-issues found on #$EPIC — nothing to roll up." >&2
@@ -58,16 +59,18 @@ fi
 
 body="## Remediation rollup by phase
 
-Grouped from \`doc/UI_UX_REVIEW.md\` findings 1.1–5.6. Check off each child as its PR squash-merges to \`release/2.0\`.
+Grouped from \`doc/UI_UX_REVIEW.md\` findings 1.1–5.6 plus the look-and-feel items (N1–N6, see \`doc/124-lookandfeel-plan.md\`). Closed sub-issues are auto-checked; the rest are checked as each PR squash-merges to \`release/2.0\`.
 "
 
 for p in 1 2 3 4 5 0; do
   section=""
-  while IFS="$TAB" read -r num title; do
+  while IFS="$TAB" read -r num title state; do
     [ -n "$num" ] || continue
-    id="${title%% *}"                 # leading "N.N" token
+    id="${title%% *}"                 # leading "N.N" / "NN" token
     if [ "$(phase_of "$id")" = "$p" ]; then
-      section="$section- [ ] #$num $title
+      box="[ ]"
+      [ "$state" = "CLOSED" ] && box="[x]"
+      section="$section- $box #$num $title
 "
     fi
   done < "$tmp"
@@ -80,6 +83,9 @@ done
 
 if [ "$DRY_RUN" = "1" ]; then
   printf '%s\n' "$body"
+elif [ -n "${COMMENT_ID:-}" ]; then
+  gh api -X PATCH "/repos/$REPO/issues/comments/$COMMENT_ID" -f body="$body" >/dev/null
+  echo "Rollup comment #$COMMENT_ID updated in place on #$EPIC."
 else
   gh issue comment "$EPIC" --repo "$REPO" --body "$body"
   echo "Rollup comment posted to #$EPIC."

--- a/scripts/reorder-ui-ux-subissues.sh
+++ b/scripts/reorder-ui-ux-subissues.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# reorder-ui-ux-subissues.sh
+# Reorders the sub-issues of the UI/UX epic (#124) into the intended build
+# order and (optionally) rewrites the "Remediation rollup by phase" comment to
+# match. The desired order is the phased roadmap in doc/124-remediation-rollup.md.
+#
+# Why this exists: sub-issues were added in creation order (#125..#147, then
+# #154..#159), and within Phase 3 the shared app-field primitive (N5 #158) sat
+# *after* the form tickets (#132/#133/#134/#138) that depend on it. This sorts
+# the epic's sub-issue list so it reads top-to-bottom in dependency order.
+#
+# Requirements:
+#   - gh CLI, authenticated (gh auth status) with repo write access.
+#   - The GitHub sub-issues REST API (issues/{n}/sub_issues/priority).
+#
+# Usage:
+#   bash scripts/reorder-ui-ux-subissues.sh              # reorder sub-issues only
+#   bash scripts/reorder-ui-ux-subissues.sh --comment    # also patch the rollup comment
+#   DRY_RUN=1 bash scripts/reorder-ui-ux-subissues.sh    # print API calls, change nothing
+#
+set -euo pipefail
+
+REPO="${REPO:-rreganjr/Requel}"
+EPIC="${EPIC:-124}"
+COMMENT_ID="${COMMENT_ID:-5113771759}"          # the "Remediation rollup by phase" comment
+COMMENT_FILE="${COMMENT_FILE:-doc/124-remediation-rollup.md}"
+API_VERSION="2022-11-28"
+DRY_RUN="${DRY_RUN:-0}"
+
+PATCH_COMMENT=0
+[[ "${1:-}" == "--comment" ]] && PATCH_COMMENT=1
+
+# Desired build order (issue numbers), top = do first. Must contain every
+# sub-issue of the epic exactly once. Grouped by phase for readability.
+ORDER=(
+  # Phase 1 — Quick wins & accessibility blockers
+  135 136 137 139 141
+  # Phase 2 — Design-system foundation
+  125 126 127 146 155 156 159
+  # Phase 3 — Forms & validation (N5 app-field FIRST; 4.4 depends on 3.1)
+  158 132 133 134 138 143
+  # Phase 4 — Information architecture & workflow polish
+  128 129 130 131 140 154 157
+  # Phase 5 — Deeper Angular architecture refactors
+  142 144 145 147
+)
+
+api() {  # thin wrapper so DRY_RUN prints instead of calling
+  if [[ "$DRY_RUN" == "1" ]]; then
+    printf 'gh api'; printf ' %q' "$@"; echo
+  else
+    gh api "$@"
+  fi
+}
+
+# --- sanity: desired order must match the epic's actual sub-issues ----------
+
+echo ">> Fetching current sub-issues of #$EPIC ..." >&2
+mapfile -t CURRENT < <(gh api --paginate \
+  -H "X-GitHub-Api-Version: $API_VERSION" \
+  "/repos/$REPO/issues/$EPIC/sub_issues" --jq '.[].number' | sort -n)
+
+mapfile -t WANT < <(printf '%s\n' "${ORDER[@]}" | sort -n)
+
+if [[ "${#ORDER[@]}" -ne "${#CURRENT[@]}" ]]; then
+  echo "!! Count mismatch: ORDER has ${#ORDER[@]}, epic has ${#CURRENT[@]} sub-issues." >&2
+fi
+if ! diff <(printf '%s\n' "${WANT[@]}") <(printf '%s\n' "${CURRENT[@]}") >/dev/null; then
+  echo "!! ORDER does not match the epic's sub-issue set. Diff (want vs actual):" >&2
+  diff <(printf '%s\n' "${WANT[@]}") <(printf '%s\n' "${CURRENT[@]}") >&2 || true
+  echo "   Fix the ORDER array (or the epic) and re-run." >&2
+  exit 1
+fi
+echo ">> ${#ORDER[@]} sub-issues verified against the epic." >&2
+
+# --- resolve issue number -> database id (needed by the priority API) -------
+
+declare -A ID
+for num in "${ORDER[@]}"; do
+  ID[$num]=$(gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+    "/repos/$REPO/issues/$num" --jq '.id')
+done
+
+# Current first sub-issue (by list position) — used to anchor the first item.
+FIRST_ID=$(gh api -H "X-GitHub-Api-Version: $API_VERSION" \
+  "/repos/$REPO/issues/$EPIC/sub_issues" --jq '.[0].id')
+
+# --- reprioritize: place each item after its predecessor --------------------
+# The priority endpoint moves one sub-issue relative to another. Chaining every
+# item after the previous one fully determines the order (all items are in the
+# chain, so nothing floats).
+
+prev_id=""
+for num in "${ORDER[@]}"; do
+  id="${ID[$num]}"
+  if [[ -z "$prev_id" ]]; then
+    if [[ "$id" != "$FIRST_ID" ]]; then
+      echo ">> move #$num to top (before current first)" >&2
+      api -X PATCH -H "X-GitHub-Api-Version: $API_VERSION" \
+        "/repos/$REPO/issues/$EPIC/sub_issues/priority" \
+        -F sub_issue_id="$id" -F before_id="$FIRST_ID"
+    fi
+  else
+    echo ">> place #$num after previous" >&2
+    api -X PATCH -H "X-GitHub-Api-Version: $API_VERSION" \
+      "/repos/$REPO/issues/$EPIC/sub_issues/priority" \
+      -F sub_issue_id="$id" -F after_id="$prev_id"
+  fi
+  prev_id="$id"
+done
+echo ">> Sub-issue order updated." >&2
+
+# --- optional: rewrite the rollup comment to match --------------------------
+
+if [[ "$PATCH_COMMENT" == "1" ]]; then
+  if [[ ! -f "$COMMENT_FILE" ]]; then
+    echo "!! $COMMENT_FILE not found; cannot patch comment $COMMENT_ID." >&2
+    exit 1
+  fi
+  echo ">> Patching comment $COMMENT_ID from $COMMENT_FILE ..." >&2
+  api -X PATCH -H "X-GitHub-Api-Version: $API_VERSION" \
+    "/repos/$REPO/issues/comments/$COMMENT_ID" \
+    -f body="$(cat "$COMMENT_FILE")"
+  echo ">> Comment updated." >&2
+fi
+
+echo ">> Done."

--- a/scripts/set-lookandfeel-points.sh
+++ b/scripts/set-lookandfeel-points.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# set-lookandfeel-points.sh — set INITIAL Story Points for the look-and-feel
+# sub-issues (N1–N6, #154–#159) in the "Requel 2.0" project, via set-points.sh.
+#
+# The values below are proposed estimates (Fibonacci) — edit the here-doc to taste
+# before running. Retro is left unset (these issues are still open; set-points.sh
+# only sets Retro for CLOSED issues).
+#
+# Prereqs: same as set-points.sh (classic token with project + repo + read:org).
+#
+# Usage:
+#   bash scripts/set-lookandfeel-points.sh
+#   REQUEL_RELEASE=2.0 bash scripts/set-lookandfeel-points.sh   # target the 2.0 project (default)
+#
+set -euo pipefail
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# issue  points  # rationale
+while read -r num pts _rest; do
+  [ -n "${num:-}" ] || continue
+  case "$num" in \#*|"") continue ;; esac   # skip comments/blank lines
+  echo "==> #$num  Story Points (initial) = $pts"
+  "$DIR/set-points.sh" "$num" "$pts"
+done <<'EOF'
+154 5   # N1 App shell: top bar + breadcrumb + grouped collapsible sidebar (+ a11y, persistence)
+155 3   # N2 Tag & Chip severity system (two wrappers, variants, replace 3 usages)
+156 2   # N3 Card / content-surface primitive
+157 8   # N4 Data-table pattern component + migrate >=2 list pages
+158 8   # N5 Form wizard + app-field + migrate one create flow to reactive forms
+159 3   # N6 Theme switcher + dark mode (optional)
+EOF
+
+echo "Done. Review Story Points in the 'Requel 2.0' project."


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/139

Give all dialogs and overlays proper modal accessibility guarantees

Finding 4.5 of the UI/UX review: two handcrafted fixed-overlay "dialogs" rendered as
plain divs with no dialog semantics, no focus trap, no Escape handling, and no focus
restoration, and the three existing PrimeNG dialogs were never audited for the same.
This converts the custom overlays to p-dialog and hardens all five so they satisfy
WCAG 2.1.2 (No Keyboard Trap), 2.4.3 (Focus Order), 2.4.7 (Focus Visible), and 4.1.2
(Name/Role/Value). Verified with new per-dialog behavior specs and an axe-core static
scan wired into the Vitest suite.

requel-angular/src/app/features/goals/goal-editor.ts
- Replaced the handcrafted `.relation-type-dialog` fixed overlay with a PrimeNG
  `p-dialog [modal]="true" [focusOnShow]="true"`, which supplies role="dialog",
  aria-modal, focus trap, and Escape-to-close by default.
- The dialog opens programmatically after the entity selector closes, so PrimeNG's
  default restore-to-last-focused-element has no stable target. Added an explicit
  focus restore to the "Add Relation" opener via a ViewChild in onRelationDialogHide(),
  which runs on every close path (Add, Cancel, Escape, mask).
- Drove visibility from a `relationDialogVisible` signal with two-way visibleChange
  sync (prevents the reopen flicker one-way [visible] binding causes), kept
  `pendingRelationGoal` as the header/data source via a computed header.
- Added closeAriaLabel so the close (X) button has an accessible name.

requel-angular/src/app/features/scenarios/scenario-editor.ts
- Replaced the handcrafted `.edit-popup-overlay` step-detail overlay with a p-dialog.
  Kept the existing `editingStep` signal as the single source of truth (the SSE reload
  guard reads it), binding [visible]="editingStep() !== null" and routing PrimeNG's
  user-initiated closes back through closeStepEdit() via onStepDialogVisibleChange().
- Associated the Name/Type/Notes fields with their labels (for/id) and added
  closeAriaLabel. Focus returns to the per-step edit button (PrimeNG default) since the
  opener is a real click target.

requel-angular/src/app/shared/entity-selector-dialog.ts
requel-angular/src/app/shared/scenario-selector-dialog.ts
requel-angular/src/app/features/users/api-tokens.ts
- Audit/harden pass on the three existing p-dialogs: added closeAriaLabel (the close
  button rendered with no accessible name — a real axe finding) and explicit
  [focusOnShow]="true" to match the review recommendation. Role/aria-modal/focus
  restore were already provided by [modal]="true".

requel-angular/src/app/shared/testing/a11y.ts (new)
- Shared test helpers: getOpenDialog() queries the document (dialogs render with
  appendTo="body") and expectNoAxeViolations(root) runs axe-core with the color-contrast
  rule disabled (jsdom has no layout box model; contrast is governed by Finding 4.7).

requel-angular/src/app/**/*.a11y.spec.ts (new, 5 files)
- Per-dialog specs asserting role="dialog", aria-modal="true", an accessible name, zero
  axe violations (scanned against the dialog subtree), and — for the goal dialog —
  focus restoration to the opener. Each destroys its fixture in afterEach and asserts the
  overlay is gone, so a body-appended dialog cannot leak into the next test.

requel-angular/package.json, package-lock.json
- Added axe-core as a dev dependency.

doc/139-modal-a11y-plan.md (new)
- Implementation plan / audit notes for the change.

Closes #139
