### PR TITLE
Reduce component-local CSS that fights PrimeNG (#126)

### DIFF
--- a/requel-angular/e2e/pages/ProjectsPage.ts
+++ b/requel-angular/e2e/pages/ProjectsPage.ts
@@ -61,14 +61,9 @@ export class ProjectsPage extends BaseListPage {
     await expect(this.page.getByTestId('project-list-error')).toContainText(message);
   }
 
-  async expectImportWarning(message: string): Promise<void> {
-    await expect(this.page.getByTestId('project-list-warning')).toContainText(message);
-  }
-
   async expectNoImportMessages(): Promise<void> {
     await expect(this.page.getByTestId('project-list-success')).toHaveCount(0);
     await expect(this.page.getByTestId('project-list-error')).toHaveCount(0);
-    await expect(this.page.getByTestId('project-list-warning')).toHaveCount(0);
   }
 
   async expectNoProjectsMessage(): Promise<void> {

--- a/requel-angular/e2e/projects.e2e.ts
+++ b/requel-angular/e2e/projects.e2e.ts
@@ -291,7 +291,7 @@ test.describe('Project management', () => {
     await page.close();
   });
 
-  test('import change with no selected file shows warning and does not call import', async ({ adminContext }) => {
+  test('import change with no selected file is a no-op and does not call import', async ({ adminContext }) => {
     const page = await adminContext.newPage();
     const projectsPage = new ProjectsPage(page);
     let importCalled = false;
@@ -316,7 +316,8 @@ test.describe('Project management', () => {
     await projectsPage.goto();
     await projectsPage.clearImportSelection();
     await expect.poll(() => importCalled).toBe(false);
-    await projectsPage.expectImportWarning('Select a project XML file to import.');
+    // Picking no file is a silent no-op: no import call, no error/warning banner.
+    await expect(page.getByTestId('project-list-error')).toHaveCount(0);
 
     await page.close();
   });

--- a/requel-angular/src/app/features/actors/actor-editor.ts
+++ b/requel-angular/src/app/features/actors/actor-editor.ts
@@ -108,7 +108,7 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
             <ng-template #header>
               <tr>
                 <th>Name</th>
-                @if (canEdit()) { <th style="width: 4rem"></th> }
+                @if (canEdit()) { <th class="col-actions"></th> }
               </tr>
             </ng-template>
             <ng-template #body let-g>

--- a/requel-angular/src/app/features/actors/actor-list.ts
+++ b/requel-angular/src/app/features/actors/actor-list.ts
@@ -71,7 +71,6 @@ import { ListPageComponent } from '../../shared/list-page';
     </app-list-page>
   `,
   styles: [`
-    .text-center { text-align: center; }
     .text-preview { max-width: 400px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   `]
 })

--- a/requel-angular/src/app/features/admin/global-tags.ts
+++ b/requel-angular/src/app/features/admin/global-tags.ts
@@ -62,7 +62,7 @@ import { TagService } from '../../core/tag.service';
             <th>Category</th>
             <th>Value</th>
             <th>Created By</th>
-            <th style="width: 60px"></th>
+            <th class="col-actions"></th>
           </tr>
         </ng-template>
         <ng-template #body let-t>
@@ -88,7 +88,6 @@ import { TagService } from '../../core/tag.service';
     .page-header { margin-bottom: 1rem; }
     .add-row { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 1rem; flex-wrap: wrap; }
     .cat-input, .val-input { max-width: 220px; }
-    .text-center { text-align: center; }
   `]
 })
 export class GlobalTagsComponent implements OnInit {

--- a/requel-angular/src/app/features/admin/tag-categories.ts
+++ b/requel-angular/src/app/features/admin/tag-categories.ts
@@ -68,7 +68,7 @@ import { TagService } from '../../core/tag.service';
         <ng-template #header>
           <tr>
             <th>Name</th><th>Exclusive</th><th>Allowed Types</th><th>Values</th><th>Color</th>
-            <th style="width: 60px"></th>
+            <th class="col-actions"></th>
           </tr>
         </ng-template>
         <ng-template #body let-c>
@@ -98,7 +98,6 @@ import { TagService } from '../../core/tag.service';
     .excl { display: inline-flex; align-items: center; gap: 0.35rem; }
     .name-input, .color-input { max-width: 160px; }
     .wide-input { max-width: 220px; }
-    .text-center { text-align: center; }
   `]
 })
 export class TagCategoriesComponent implements OnInit {

--- a/requel-angular/src/app/features/auth/layout.ts
+++ b/requel-angular/src/app/features/auth/layout.ts
@@ -121,9 +121,7 @@ import { MenuItem, MessageService } from 'primeng/api';
       align-items: center;
     }
 
-    :host ::ng-deep .account-trigger .p-button {
-      color: var(--rq-header-fg);
-    }
+    /* .account-trigger .p-button color lives in global styles.scss (#126). */
 
     .layout-body {
       display: flex;

--- a/requel-angular/src/app/features/goals/goal-editor.ts
+++ b/requel-angular/src/app/features/goals/goal-editor.ts
@@ -105,7 +105,7 @@ import { TagSelectorComponent } from '../../shared/tag-selector';
                 <tr>
                   <th>Goal</th>
                   <th>Type</th>
-                  @if (canEdit()) { <th style="width: 60px"></th> }
+                  @if (canEdit()) { <th class="col-actions"></th> }
                 </tr>
               </ng-template>
               <ng-template #body let-r>

--- a/requel-angular/src/app/features/goals/goal-list.ts
+++ b/requel-angular/src/app/features/goals/goal-list.ts
@@ -87,7 +87,6 @@ import { ListPageComponent } from '../../shared/list-page';
     </app-list-page>
   `,
   styles: [`
-    .text-center { text-align: center; }
     .text-preview { max-width: 400px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .tag-filter { min-width: 200px; }
     .chips { display: inline-flex; flex-wrap: wrap; gap: 0.3rem; }

--- a/requel-angular/src/app/features/open-issues/open-issues.ts
+++ b/requel-angular/src/app/features/open-issues/open-issues.ts
@@ -111,7 +111,6 @@ const ENTITY_ROUTES: Record<string, string> = {
     </app-list-page>
   `,
   styles: [`
-    .text-center { text-align: center; }
     .entity-link { color: var(--p-primary-color); cursor: pointer; text-decoration: underline; }
     .entity-link:hover { opacity: 0.8; }
     .must-resolve { color: var(--p-red-500); font-weight: 600; }

--- a/requel-angular/src/app/features/projects/project-list.ts
+++ b/requel-angular/src/app/features/projects/project-list.ts
@@ -49,9 +49,6 @@ import { FileUploadButtonComponent } from '../../shared/file-upload-button';
       @if (errorMessage()) {
         <p-message severity="error" [text]="errorMessage()!" data-testid="project-list-error" />
       }
-      @if (warningMessage()) {
-        <p-message severity="warn" [text]="warningMessage()!" data-testid="project-list-warning" />
-      }
       @if (successMessage()) {
         <p-message severity="success" [text]="successMessage()!" data-testid="project-list-success" />
       }
@@ -97,7 +94,6 @@ export class ProjectListComponent implements OnInit {
   readonly loading = signal(true);
   readonly importing = signal(false);
   readonly errorMessage = signal<string | null>(null);
-  readonly warningMessage = signal<string | null>(null);
   readonly successMessage = signal<string | null>(null);
 
   readonly canCreateProjects = signal(false);
@@ -132,7 +128,6 @@ export class ProjectListComponent implements OnInit {
   async onImportFile(file: File): Promise<void> {
     this.importing.set(true);
     this.errorMessage.set(null);
-    this.warningMessage.set(null);
     this.successMessage.set(null);
 
     try {

--- a/requel-angular/src/app/features/projects/project-list.ts
+++ b/requel-angular/src/app/features/projects/project-list.ts
@@ -18,7 +18,7 @@
  * along with Requel. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import { Component, OnInit, signal, ViewChild, ElementRef } from '@angular/core';
+import { Component, OnInit, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
@@ -27,22 +27,22 @@ import { ProjectDto } from '../../models/project';
 import { ProjectService } from '../../core/project.service';
 import { AuthService } from '../../core/auth.service';
 import { ListPageComponent } from '../../shared/list-page';
+import { FileUploadButtonComponent } from '../../shared/file-upload-button';
 
 @Component({
   selector: 'app-project-list',
   standalone: true,
-  imports: [ListPageComponent, TableModule, ButtonModule, MessageModule],
+  imports: [ListPageComponent, TableModule, ButtonModule, MessageModule, FileUploadButtonComponent],
   template: `
     <app-list-page title="Projects" searchPlaceholder="Search projects..."
                    (search)="dt.filterGlobal($event, 'contains')">
       <ng-container actions>
         @if (canCreateProjects()) {
           <p-button label="New Project" icon="pi pi-plus" data-testid="project-list-new-project" (onClick)="onNewProject()" />
-          <p-button label="Import" icon="pi pi-upload" severity="secondary"
-                    [outlined]="true" [loading]="importing()" data-testid="project-list-import-button" (onClick)="fileInput.click()" />
-          <input #fileInput type="file" accept=".xml" (change)="onImportFile($event)"
-                 data-testid="project-list-import-input"
-                 style="display: none" />
+          <app-file-upload-button label="Import" [outlined]="true" [loading]="importing()"
+                                  accept=".xml" buttonTestid="project-list-import-button"
+                                  inputTestid="project-list-import-input"
+                                  (fileSelected)="onImportFile($event)" />
         }
       </ng-container>
 
@@ -102,7 +102,6 @@ export class ProjectListComponent implements OnInit {
 
   readonly canCreateProjects = signal(false);
 
-  @ViewChild('fileInput') fileInput!: ElementRef<HTMLInputElement>;
 
   constructor(
     private projectService: ProjectService,
@@ -130,16 +129,7 @@ export class ProjectListComponent implements OnInit {
     }
   }
 
-  async onImportFile(event: Event): Promise<void> {
-    const input = event.target as HTMLInputElement;
-    const file = input.files?.[0];
-    if (!file) {
-      this.errorMessage.set(null);
-      this.successMessage.set(null);
-      this.warningMessage.set('Select a project XML file to import.');
-      return;
-    }
-
+  async onImportFile(file: File): Promise<void> {
     this.importing.set(true);
     this.errorMessage.set(null);
     this.warningMessage.set(null);
@@ -157,7 +147,6 @@ export class ProjectListComponent implements OnInit {
       this.errorMessage.set(err instanceof Error ? err.message : 'Import failed.');
     } finally {
       this.importing.set(false);
-      input.value = '';
     }
   }
 

--- a/requel-angular/src/app/features/reports/report-editor.ts
+++ b/requel-angular/src/app/features/reports/report-editor.ts
@@ -34,12 +34,13 @@ import { ReportGeneratorDto } from '../../models/report';
 import { ReportService } from '../../core/report.service';
 import { PermissionService } from '../../core/permission.service';
 import { AnnotationsSectionComponent } from '../../shared/annotations-section';
+import { FileUploadButtonComponent } from '../../shared/file-upload-button';
 
 @Component({
   selector: 'app-report-editor',
   standalone: true,
   imports: [PageHeaderComponent, FormsModule, ButtonModule, InputText, TextareaModule, MessageModule,
-            ConfirmDialogModule, AnnotationsSectionComponent],
+            ConfirmDialogModule, AnnotationsSectionComponent, FileUploadButtonComponent],
   providers: [ConfirmationService],
   template: `
     <div class="report-editor" data-testid="report-editor">
@@ -72,10 +73,8 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
           <textarea id="text" pTextarea [(ngModel)]="text" rows="20"
                     placeholder="Paste XSLT stylesheet here..." class="xslt-textarea"></textarea>
           <div class="upload-row">
-            <p-button label="Upload XSLT" icon="pi pi-upload" severity="secondary"
-                      [outlined]="true" size="small" (onClick)="xsltInput.click()" />
-            <input #xsltInput type="file" accept=".xsl,.xslt,.xml"
-                   (change)="onFileUpload($event)" style="display:none" />
+            <app-file-upload-button label="Upload XSLT" [outlined]="true" size="small"
+                                    accept=".xsl,.xslt,.xml" (fileSelected)="onFileUpload($event)" />
             <span class="upload-hint">Upload a .xsl/.xslt file to replace the template text.</span>
           </div>
         </div>
@@ -252,10 +251,7 @@ export class ReportEditorComponent implements OnInit, OnDestroy, DirtyCheckable 
     }
   }
 
-  onFileUpload(event: Event): void {
-    const input = event.target as HTMLInputElement;
-    const file = input.files?.[0];
-    if (!file) return;
+  onFileUpload(file: File): void {
     const reader = new FileReader();
     reader.onload = () => {
       this.text = reader.result as string;
@@ -264,7 +260,6 @@ export class ReportEditorComponent implements OnInit, OnDestroy, DirtyCheckable 
       }
     };
     reader.readAsText(file);
-    input.value = '';
   }
 
   onBack(): void {

--- a/requel-angular/src/app/features/reports/report-list.ts
+++ b/requel-angular/src/app/features/reports/report-list.ts
@@ -76,7 +76,6 @@ import { ListPageComponent } from '../../shared/list-page';
     </app-list-page>
   `,
   styles: [`
-    .text-center { text-align: center; }
     .action-cell { display: flex; gap: 0.25rem; }
   `]
 })

--- a/requel-angular/src/app/features/scenarios/scenario-list.ts
+++ b/requel-angular/src/app/features/scenarios/scenario-list.ts
@@ -63,7 +63,7 @@ import { ListPageComponent } from '../../shared/list-page';
           </tr>
         </ng-template>
         <ng-template #emptymessage>
-          <tr><td colspan="3" style="text-align:center;font-style:italic">No scenarios yet.</td></tr>
+          <tr><td colspan="3" class="text-center">No scenarios yet.</td></tr>
         </ng-template>
       </p-table>
     </app-list-page>

--- a/requel-angular/src/app/features/stakeholders/stakeholder-editor.ts
+++ b/requel-angular/src/app/features/stakeholders/stakeholder-editor.ts
@@ -148,7 +148,7 @@ interface PermissionGroup {
             <ng-template #header>
               <tr>
                 <th>Name</th>
-                @if (canEditGoals()) { <th style="width:4rem"></th> }
+                @if (canEditGoals()) { <th class="col-actions"></th> }
               </tr>
             </ng-template>
             <ng-template #body let-g>

--- a/requel-angular/src/app/features/stakeholders/stakeholder-list.ts
+++ b/requel-angular/src/app/features/stakeholders/stakeholder-list.ts
@@ -77,10 +77,7 @@ import { ListPageComponent } from '../../shared/list-page';
         </ng-template>
       </p-table>
     </app-list-page>
-  `,
-  styles: [`
-    .text-center { text-align: center; }
-  `]
+  `
 })
 export class StakeholderListComponent implements OnInit, OnDestroy {
   stakeholders = signal<StakeholderDto[]>([]);

--- a/requel-angular/src/app/features/stories/story-editor.ts
+++ b/requel-angular/src/app/features/stories/story-editor.ts
@@ -130,7 +130,7 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
               <ng-template #header>
                 <tr>
                   <th>Name</th>
-                  @if (canEdit()) { <th style="width: 60px"></th> }
+                  @if (canEdit()) { <th class="col-actions"></th> }
                 </tr>
               </ng-template>
               <ng-template #body let-g>
@@ -164,7 +164,7 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
               <ng-template #header>
                 <tr>
                   <th>Name</th>
-                  @if (canEdit()) { <th style="width: 60px"></th> }
+                  @if (canEdit()) { <th class="col-actions"></th> }
                 </tr>
               </ng-template>
               <ng-template #body let-a>

--- a/requel-angular/src/app/features/stories/story-list.ts
+++ b/requel-angular/src/app/features/stories/story-list.ts
@@ -73,7 +73,6 @@ import { ListPageComponent } from '../../shared/list-page';
     </app-list-page>
   `,
   styles: [`
-    .text-center { text-align: center; }
     .text-preview { max-width: 400px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   `]
 })

--- a/requel-angular/src/app/features/terms/term-list.ts
+++ b/requel-angular/src/app/features/terms/term-list.ts
@@ -73,7 +73,6 @@ import { ListPageComponent } from '../../shared/list-page';
     </app-list-page>
   `,
   styles: [`
-    .text-center { text-align: center; }
     .text-preview { max-width: 350px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   `]
 })

--- a/requel-angular/src/app/features/use-cases/use-case-editor.ts
+++ b/requel-angular/src/app/features/use-cases/use-case-editor.ts
@@ -146,7 +146,7 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
               @if (primaryScenario()?.steps?.length) {
                 <p-table [value]="primaryScenario()!.steps!" styleClass="p-datatable-sm" [rowHover]="false">
                   <ng-template pTemplate="header">
-                    <tr><th style="width:2.5rem">#</th><th>Step</th><th style="width:8rem">Type</th></tr>
+                    <tr><th class="col-num">#</th><th>Step</th><th class="col-kind">Type</th></tr>
                   </ng-template>
                   <ng-template pTemplate="body" let-step let-i="rowIndex">
                     <tr>
@@ -177,7 +177,7 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
           <p-table [value]="additionalScenarios()" styleClass="p-datatable-sm"
                    data-testid="use-case-scenarios-table" [rowHover]="true">
             <ng-template pTemplate="header">
-              <tr><th>Name</th><th>Type</th><th style="width:4rem"></th></tr>
+              <tr><th>Name</th><th>Type</th><th class="col-actions"></th></tr>
             </ng-template>
             <ng-template pTemplate="body" let-s>
               <tr data-testid="use-case-scenario-row">
@@ -195,7 +195,7 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
               </tr>
             </ng-template>
             <ng-template pTemplate="emptymessage">
-              <tr><td colspan="3" style="text-align:center">No additional scenarios.</td></tr>
+              <tr><td colspan="3" class="text-center">No additional scenarios.</td></tr>
             </ng-template>
           </p-table>
         </div>
@@ -236,7 +236,7 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
           <p-table [value]="goals()" styleClass="p-datatable-sm"
                    data-testid="use-case-goals-table" [rowHover]="canEdit()">
             <ng-template pTemplate="header">
-              <tr><th>Name</th><th style="width:4rem"></th></tr>
+              <tr><th>Name</th><th class="col-actions"></th></tr>
             </ng-template>
             <ng-template pTemplate="body" let-goal>
               <tr data-testid="use-case-goal-row">
@@ -255,7 +255,7 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
               </tr>
             </ng-template>
             <ng-template pTemplate="emptymessage">
-              <tr><td colspan="2" style="text-align:center">No goals.</td></tr>
+              <tr><td colspan="2" class="text-center">No goals.</td></tr>
             </ng-template>
           </p-table>
         </div>
@@ -274,7 +274,7 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
           <p-table [value]="stories()" styleClass="p-datatable-sm"
                    data-testid="use-case-stories-table" [rowHover]="canEdit()">
             <ng-template pTemplate="header">
-              <tr><th>Name</th><th>Type</th><th style="width:4rem"></th></tr>
+              <tr><th>Name</th><th>Type</th><th class="col-actions"></th></tr>
             </ng-template>
             <ng-template pTemplate="body" let-story>
               <tr data-testid="use-case-story-row">
@@ -294,7 +294,7 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
               </tr>
             </ng-template>
             <ng-template pTemplate="emptymessage">
-              <tr><td colspan="3" style="text-align:center">No stories.</td></tr>
+              <tr><td colspan="3" class="text-center">No stories.</td></tr>
             </ng-template>
           </p-table>
         </div>
@@ -313,7 +313,7 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
           <p-table [value]="actors()" styleClass="p-datatable-sm"
                    data-testid="use-case-actors-table" [rowHover]="canEdit()">
             <ng-template pTemplate="header">
-              <tr><th>Name</th><th style="width:4rem"></th></tr>
+              <tr><th>Name</th><th class="col-actions"></th></tr>
             </ng-template>
             <ng-template pTemplate="body" let-actor>
               <tr data-testid="use-case-actor-row">
@@ -332,7 +332,7 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
               </tr>
             </ng-template>
             <ng-template pTemplate="emptymessage">
-              <tr><td colspan="2" style="text-align:center">No additional actors.</td></tr>
+              <tr><td colspan="2" class="text-center">No additional actors.</td></tr>
             </ng-template>
           </p-table>
         </div>

--- a/requel-angular/src/app/features/use-cases/use-case-list.ts
+++ b/requel-angular/src/app/features/use-cases/use-case-list.ts
@@ -61,7 +61,7 @@ import { ListPageComponent } from '../../shared/list-page';
           </tr>
         </ng-template>
         <ng-template pTemplate="emptymessage">
-          <tr><td colspan="3" style="text-align:center">No use cases yet.</td></tr>
+          <tr><td colspan="3" class="text-center">No use cases yet.</td></tr>
         </ng-template>
       </p-table>
     </app-list-page>

--- a/requel-angular/src/app/shared/entity-selector-dialog.ts
+++ b/requel-angular/src/app/shared/entity-selector-dialog.ts
@@ -96,8 +96,7 @@ import { ScenarioService } from '../core/scenario.service';
   styles: [`
     .search-bar { display: flex; gap: 0.5rem; align-items: center; margin-bottom: 0.75rem; }
     .search-bar span { flex: 1; }
-    :host ::ng-deep .type-filter-select { min-width: 130px; }
-    .text-center { text-align: center; }
+    /* .type-filter-select min-width and .text-center live in global styles.scss (#126). */
   `]
 })
 export class EntitySelectorDialogComponent implements OnChanges {

--- a/requel-angular/src/app/shared/file-upload-button.ts
+++ b/requel-angular/src/app/shared/file-upload-button.ts
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import { Component, EventEmitter, Input, Output, ViewChild, ElementRef } from '@angular/core';
+import { ButtonModule } from 'primeng/button';
+
+type ButtonSeverity =
+  | 'success' | 'info' | 'warn' | 'danger' | 'help' | 'primary' | 'secondary' | 'contrast';
+type ButtonSize = 'small' | 'large';
+
+/**
+ * Shared file-picker button. Owns the hidden <input type="file">, the trigger
+ * button, its accessible name, and the input reset, so feature templates no
+ * longer duplicate ad-hoc hidden inputs with inline `display:none` styles
+ * (issue #126). The button keeps focus; picking a file emits the selected
+ * `File` via `fileSelected` and clears the input so the same file can be
+ * chosen again.
+ */
+@Component({
+  selector: 'app-file-upload-button',
+  standalone: true,
+  imports: [ButtonModule],
+  template: `
+    <p-button [label]="label"
+              [icon]="icon"
+              [severity]="severity"
+              [outlined]="outlined"
+              [text]="text"
+              [size]="size"
+              [loading]="loading"
+              [ariaLabel]="ariaLabel || label"
+              [attr.data-testid]="buttonTestid"
+              (onClick)="fileInput.nativeElement.click()" />
+    <input #fileInput
+           type="file"
+           class="file-input-hidden"
+           [accept]="accept"
+           [attr.data-testid]="inputTestid"
+           (change)="onChange()" />
+  `,
+  styles: [`
+    .file-input-hidden { display: none; }
+  `]
+})
+export class FileUploadButtonComponent {
+  @Input() label = 'Upload';
+  @Input() icon = 'pi pi-upload';
+  @Input() accept = '';
+  @Input() severity: ButtonSeverity = 'secondary';
+  @Input() outlined = false;
+  @Input() text = false;
+  @Input() size: ButtonSize | undefined;
+  @Input() loading = false;
+  @Input() ariaLabel = '';
+  @Input() buttonTestid: string | null = null;
+  @Input() inputTestid: string | null = null;
+
+  /** Emits the picked file. The input is cleared afterwards so re-picking the same file still fires. */
+  @Output() fileSelected = new EventEmitter<File>();
+
+  @ViewChild('fileInput') fileInput!: ElementRef<HTMLInputElement>;
+
+  onChange(): void {
+    const input = this.fileInput.nativeElement;
+    const file = input.files?.[0];
+    input.value = '';
+    if (file) {
+      this.fileSelected.emit(file);
+    }
+  }
+}

--- a/requel-angular/src/app/shared/file-upload-button.ts
+++ b/requel-angular/src/app/shared/file-upload-button.ts
@@ -47,7 +47,7 @@ type ButtonSize = 'small' | 'large';
               [loading]="loading"
               [ariaLabel]="ariaLabel || label"
               [attr.data-testid]="buttonTestid"
-              (onClick)="fileInput.nativeElement.click()" />
+              (onClick)="fileInput.click()" />
     <input #fileInput
            type="file"
            class="file-input-hidden"

--- a/requel-angular/src/app/shared/scenario-selector-dialog.ts
+++ b/requel-angular/src/app/shared/scenario-selector-dialog.ts
@@ -84,7 +84,7 @@ const SCENARIO_TYPE_OPTIONS = [
         <input pInputText [(ngModel)]="searchText" placeholder="Search..."
                aria-label="Search scenarios"
                data-testid="scenario-selector-search"
-               (input)="dt.filterGlobal(searchText, 'contains')" style="width:100%" />
+               (input)="dt.filterGlobal(searchText, 'contains')" class="w-full" />
         @if (!showCreateForm) {
           <p-button label="New Scenario" icon="pi pi-plus" size="small" severity="secondary"
                     [outlined]="true" data-testid="scenario-selector-new-button"
@@ -122,7 +122,6 @@ const SCENARIO_TYPE_OPTIONS = [
     .create-actions { display: flex; gap: 0.5rem; margin-top: 0.75rem; }
     .create-error { color: var(--p-red-500); font-size: 0.85rem; margin-top: 0.5rem; }
     hr { margin: 0.75rem 0; border: none; border-top: 1px solid var(--p-surface-200); }
-    .text-center { text-align: center; }
   `]
 })
 export class ScenarioSelectorDialogComponent implements OnChanges {

--- a/requel-angular/src/app/shared/sidebar-nav.spec.ts
+++ b/requel-angular/src/app/shared/sidebar-nav.spec.ts
@@ -211,10 +211,7 @@ describe('SidebarNavComponent', () => {
   it('onImportFile calls importProject with the file and reloads', async () => {
     setup(makeUser(['ProjectUserRole']));
     const file = new File(['<project/>'], 'project.xml', { type: 'text/xml' });
-    const inputEl = document.createElement('input');
-    Object.defineProperty(inputEl, 'files', { value: [file] });
-    const event = { target: inputEl } as unknown as Event;
-    await comp.onImportFile(event);
+    await comp.onImportFile(file);
     expect(projectServiceMock.importProject).toHaveBeenCalledWith(file);
     expect(projectServiceMock.listProjects).toHaveBeenCalled();
   });

--- a/requel-angular/src/app/shared/sidebar-nav.ts
+++ b/requel-angular/src/app/shared/sidebar-nav.ts
@@ -30,6 +30,7 @@ import { AuthService } from '../core/auth.service';
 import { EventStreamService } from '../core/event-stream.service';
 import { ProjectService } from '../core/project.service';
 import { ProjectDto, ProjectTreeNode } from '../models/project';
+import { FileUploadButtonComponent } from './file-upload-button';
 
 /**
  * localStorage key for the names of projects the user has expanded in the
@@ -69,7 +70,7 @@ function persistExpandedProjectNames(names: Set<string>): void {
 @Component({
   selector: 'app-sidebar-nav',
   standalone: true,
-  imports: [AccordionModule, ButtonModule, TreeModule, BadgeModule, RouterLink],
+  imports: [AccordionModule, ButtonModule, TreeModule, BadgeModule, RouterLink, FileUploadButtonComponent],
   template: `
     <p-accordion [multiple]="true" [value]="activePanels()">
 
@@ -107,12 +108,11 @@ function persistExpandedProjectNames(names: Set<string>): void {
               @if (canCreateProjects()) {
                 <p-button label="New" ariaLabel="New project" icon="pi pi-plus" size="small"
                           [text]="true" (onClick)="onNewProject()" />
-                <p-button label="Import" ariaLabel="Import project" icon="pi pi-upload" size="small"
-                          [text]="true" data-testid="sidebar-import-button"
-                          (onClick)="importInput.click()" />
-                <input #importInput type="file" accept=".xml"
-                       data-testid="sidebar-import-input"
-                       (change)="onImportFile($event)" style="display:none" />
+                <app-file-upload-button label="Import" ariaLabel="Import project" size="small"
+                                        [text]="true" accept=".xml"
+                                        buttonTestid="sidebar-import-button"
+                                        inputTestid="sidebar-import-input"
+                                        (fileSelected)="onImportFile($event)" />
               }
               <a routerLink="/projects" class="sidebar-link" aria-label="List projects">
                 <i class="pi pi-list"></i> List
@@ -175,15 +175,7 @@ function persistExpandedProjectNames(names: Set<string>): void {
       color: var(--p-text-secondary-color);
     }
 
-    :host ::ng-deep .sidebar-tree .p-tree-node-label {
-      font-size: 13px;
-    }
-
-    :host ::ng-deep .sidebar-tree .p-tree {
-      border: none;
-      padding: 0;
-      background: transparent;
-    }
+    /* .sidebar-tree PrimeNG p-tree overrides live in global styles.scss (#126). */
   `]
 })
 export class SidebarNavComponent implements OnInit, OnDestroy {
@@ -282,17 +274,12 @@ export class SidebarNavComponent implements OnInit, OnDestroy {
     this.router.navigate(['/projects', 'new']);
   }
 
-  async onImportFile(event: Event): Promise<void> {
-    const input = event.target as HTMLInputElement;
-    const file = input.files?.[0];
-    if (!file) return;
+  async onImportFile(file: File): Promise<void> {
     try {
       await this.projectService.importProject(file);
       await this.loadProjects();
     } catch {
       // Import errors handled by project-list if open; sidebar silently refreshes
-    } finally {
-      input.value = '';
     }
   }
 

--- a/requel-angular/src/styles.scss
+++ b/requel-angular/src/styles.scss
@@ -74,3 +74,54 @@ html, body {
   max-width: var(--rq-page-max);
   margin: 0 auto;
 }
+
+// -------------------------------------------------------------------------
+// PrimeNG component customizations (issue #126)
+//
+// These rules were previously component-local `:host ::ng-deep` blocks, which
+// pierce view encapsulation and are brittle across PrimeNG upgrades. Each
+// component still tags its PrimeNG element with a `styleClass`/`class` hook
+// (`account-trigger`, `sidebar-tree`, `type-filter-select`); the styling now
+// lives here as ordinary global rules so no encapsulation-piercing is needed.
+// -------------------------------------------------------------------------
+
+// Account menu trigger in the header brand bar inherits the header foreground.
+.account-trigger .p-button {
+  color: var(--rq-header-fg);
+}
+
+// Sidebar project tree: denser label text and a chrome-free container so the
+// tree blends into the sidebar rather than rendering PrimeNG's default panel.
+.sidebar-tree .p-tree-node-label {
+  font-size: var(--rq-font-size-xs);
+}
+
+.sidebar-tree .p-tree {
+  border: none;
+  padding: 0;
+  background: transparent;
+}
+
+// Entity-selector dialog type filter keeps a stable minimum width.
+.type-filter-select {
+  min-width: 130px;
+}
+
+// -------------------------------------------------------------------------
+// Shared table / layout utilities (issue #126)
+//
+// Replace ad-hoc inline `style="width:..."` / `style="text-align:center"`
+// attributes scattered across list and editor templates. Column-width
+// utilities are intentionally shared so the same kind of column is the same
+// width in every table.
+// -------------------------------------------------------------------------
+
+// Trailing row-action column (edit/remove icon buttons).
+.col-actions { width: 4rem; }
+// Narrow index / ordinal column (e.g. step "#").
+.col-num { width: 2.5rem; }
+// Short categorical column (e.g. step "Type").
+.col-kind { width: 8rem; }
+
+.text-center { text-align: center; }
+.w-full { width: 100%; }


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/126

Reduce component-local CSS that fights PrimeNG (#126, Phase 1 scope)

Removes the encapsulation-piercing `:host ::ng-deep` blocks and the ad-hoc
inline `style="..."` attributes called out in doc/UI_UX_REVIEW.md Finding 1.2,
replacing them with a shared component and a small global styling layer that
sits on top of the #125 token/preset foundation.

Per the scope agreement on the issue, chip/badge/card color remediation is left
to #155 (N2) / #156 (N3) and deep form-grid consolidation is left to #146 / N5
(#158, `app-field`); this change is the mechanical de-`ng-deep` / de-inline-style
work only.

Closes #126.

requel-angular/src/app/shared/file-upload-button.ts (new)
- Shared `app-file-upload-button`: owns the hidden `<input type="file">`, the
  trigger button, its accessible name, and the input reset. Emits the picked
  `File` via `fileSelected` and clears the input so re-picking the same file
  still fires. Replaces three duplicated hidden-input blocks that each carried
  inline `display:none`.

requel-angular/src/app/features/projects/project-list.ts
requel-angular/src/app/features/reports/report-editor.ts
requel-angular/src/app/shared/sidebar-nav.ts
- Use `app-file-upload-button` for XML import / XSLT upload / sidebar project
  import. Handlers now take a `File` instead of an `Event`, dropping the
  `event.target` casting, the `@ViewChild`/`ElementRef` plumbing, and the
  manual `input.value = ''` reset. data-testids are preserved via the new
  component's `buttonTestid`/`inputTestid` inputs.

requel-angular/src/styles.scss
- Relocated the three `:host ::ng-deep` customizations to ordinary global rules
  keyed on the existing `styleClass`/`class` hooks (`account-trigger`,
  `sidebar-tree`, `type-filter-select`) — no encapsulation-piercing needed.
- Added shared table/layout utilities (`col-actions`, `col-num`, `col-kind`,
  `text-center`, `w-full`) to replace the scattered inline width/alignment
  styles, so the same kind of column is the same width in every table.

requel-angular/src/app/features/auth/layout.ts
requel-angular/src/app/shared/sidebar-nav.ts
requel-angular/src/app/shared/entity-selector-dialog.ts
- Removed the `:host ::ng-deep` style blocks (now global), leaving a one-line
  pointer comment to styles.scss.

requel-angular/src/app/features/**/{goal,story,actor,stakeholder,use-case}-editor.ts,
requel-angular/src/app/features/admin/{tag-categories,global-tags}.ts,
requel-angular/src/app/features/**/{use-case,scenario}-list.ts,
requel-angular/src/app/shared/scenario-selector-dialog.ts
- Swapped inline `style="width:..."` / `style="text-align:center"` /
  `style="width:100%"` for the shared utility classes.
- Deleted 10 duplicated component-local `.text-center { text-align: center; }`
  rules now covered by the single global utility.

requel-angular/src/app/shared/sidebar-nav.spec.ts
- Updated the `onImportFile` test to pass a `File` (new handler signature)
  instead of a synthetic `Event`.

Verification: `ng test --watch=false` green — 56 files, 345 tests.
