### PR TITLE
127: Semantic type scale + page-header eyebrow/metadata

### DIFF
--- a/doc/127-typography-rescope.md
+++ b/doc/127-typography-rescope.md
@@ -1,0 +1,149 @@
+# #127 — Typography & Hierarchy: Scope Refinement and Ticket Hand-off
+
+Planning note only. This document does **not** change any GitHub state; apply the `gh`
+commands in §7 when ready (Claude runs them only when explicitly told).
+
+- Source finding: `doc/UI_UX_REVIEW.md` §1.3 — "Typography and hierarchy are too flat"
+- Target look-and-feel: `doc/124-lookandfeel-plan.md`
+- Phase order: `doc/124-remediation-rollup.md` — Phase 2 (design-system foundation)
+- Epic: [#124](https://github.com/rreganjr/Requel/issues/124); milestone `v2.0`;
+  project **Requel 2.0**; labels `ui-ux-review` + `priority:medium`
+
+## 1. Summary
+
+Issue #127 is well-formed but three of its acceptance criteria reach into work that other
+sub-issues own — specifically project/entity context (breadcrumbs, top-bar, workspace
+route) and a list toolbar component. This note pins #127 to the **presentation primitive
+plus type tokens**, and hands the surrounding chrome to #128 and #154, which *consume*
+the #127 primitive rather than rebuild it. This keeps the epic's dependency direction
+intact: Phase 2 builds tokens and primitives; Phase 4 wires them into the shell and IA.
+
+Doing "full context" inside #127 would **not** close #128 or #154 — each carries
+substantial non-typography work — and would build the top bar and breadcrumb twice.
+
+## 2. Scope split across the three tickets
+
+| Ticket | Phase | Owns | Relationship to #127 |
+|---|---|---|---|
+| **#127** (1.3) | 2 | Semantic type-scale tokens; extend the shared page/header primitive with `eyebrow` + `metadata` slots; restyle the existing `list-page` toolbar | Produces the primitive |
+| **#128** (2.1) | 4 | Breadcrumb route/data wiring; `/projects/:name` workspace overview (counts, open issues, recent changes, next actions); editor-header action groups | Consumes the primitive (fills eyebrow/metadata, adds breadcrumb data) |
+| **#154** (N1) | 4 | Top-bar chrome (back button, right cluster: search/notifications/account/collapse toggle); grouped collapsible sidebar; collapse-state persistence | Consumes the primitive (renders it inside the new shell) |
+
+The look-and-feel plan already encodes the #128 vs #154 split: N1 is "the shell-chrome
+half; #128 keeps the project-context/IA half."
+
+## 3. Already satisfied by adjacent work (verify, do not rebuild)
+
+- **Figtree loaded + base 14px** — done in `requel-angular/src/styles.scss` (self-hosted
+  `@fontsource-variable/figtree`); also pinned by #125. Drop "Load Figtree" from the
+  net-new list; just confirm it.
+- **Single `<h1>` per page** — `app-page-header` already renders one `<h1>` and is
+  adopted across editors and lists (from #135). The "one h1 per page" criterion is
+  largely met; #127 confirms and restyles it via tokens.
+- **List search / actions bar** — `app-list-page` already provides a search bar + actions
+  slot used by ~10 list pages. #127 restyles it with the new tokens instead of adding a
+  new component. The reusable table toolbar is #157 (`app-data-table`) / #129.
+
+## 4. Net-new work for #127
+
+1. **Semantic type-scale tokens** in `styles.scss` — role tokens (not just size steps),
+   each carrying font-size + weight + line-height (+ color where it differs):
+   `--rq-text-page-title`, `--rq-text-section-title`, `--rq-text-body`,
+   `--rq-text-label`, `--rq-text-helper`, `--rq-text-caption`. Titles are bold slate
+   (surface-800/900); helper and caption are muted (surface-500).
+2. **Extend the page/header primitive** with an optional `eyebrow` (project name +
+   artifact type) and a `metadata` content slot (status / counts / unsaved state).
+   Breadcrumbs and top-bar stay out of scope.
+3. **Apply the type tokens** through the shared primitives (`page-header`, `list-page`)
+   so titles, labels, and helper text read from tokens, not local literals.
+4. **Restyle the existing `list-page` toolbar** (search + right-aligned actions) with the
+   new density/type tokens and standardize action placement on the two exemplar pages
+   below. No new toolbar component.
+
+Exemplar list pages for the toolbar consistency check: **Goals** (`goal-list.ts`) and
+**Stories** (`story-list.ts`).
+
+## 5. Revised acceptance criteria for #127
+
+- A tokenized **semantic** type scale exists (page title, section title, body, label,
+  helper, caption), each carrying size + weight + line-height, defined in `styles.scss`
+  and consumed by shared primitives — no per-view font-size/weight literals in the
+  migrated pages.
+- The shared page/header primitive exposes `eyebrow` (project + artifact type) and a
+  `metadata` slot; route pages keep a single `<h1>`. Breadcrumb/top-bar context is
+  deferred to #128 / #154, which consume this primitive.
+- The `list-page` toolbar (search + right-aligned actions) reads density/type from
+  tokens and uses consistent action placement across **Goals** and **Stories**.
+- No regression to the single-`<h1>`-per-page heading structure from #135.
+
+## 6. Dependencies / coordination
+
+- Depends on **#125** (preset tokens: Figtree, surface ramp) landing first — Phase 2
+  order.
+- Provides the page/header primitive that **#128** and **#154** build on. Both must wire
+  breadcrumbs/chrome *into* this primitive rather than replacing it.
+
+## 7. `gh` commands to update the three tickets
+
+Run from the repo root. `commit.md` conventions do not apply — these only edit issue
+text. Nothing here touches branches, commits, or PRs.
+
+### 7.1 #127 — replace the body with the refined scope + AC
+
+```bash
+gh issue edit 127 --repo rreganjr/Requel --body-file - <<'EOF'
+Part of the UI/UX remediation epic (#124). Source: `doc/UI_UX_REVIEW.md` Finding 1.3.
+Scope refinement: `doc/127-typography-rescope.md`.
+
+**Priority:** Medium. **Effort:** Small (tokens + primitive + two list-page restyles).
+**Phase:** 2 (design-system foundation).
+
+## Scope
+
+Delivers the **type tokens + presentation primitive** only. Project context chrome
+(breadcrumbs, top bar, workspace route) is **out of scope** and owned by #128 (context/IA)
+and #154 (shell chrome), which consume the primitive this issue produces. See
+`doc/127-typography-rescope.md` §2.
+
+## Already in place (confirm, do not rebuild)
+
+- Figtree bundled + base 14px in `styles.scss` (also pinned by #125).
+- Single `<h1>` per page via `app-page-header` (from #135).
+- `app-list-page` search + actions bar (used by ~10 list pages).
+
+## Net-new work
+
+- Semantic type-scale tokens in `styles.scss`: `--rq-text-{page-title,section-title,body,label,helper,caption}`, each with size + weight + line-height.
+- Extend the page/header primitive with an `eyebrow` (project + artifact type) and a `metadata` slot (status / counts / unsaved).
+- Apply the tokens through `page-header` and `list-page` (no per-view literals).
+- Restyle the existing `list-page` toolbar with the new density/type tokens; standardize action placement on **Goals** (`goal-list.ts`) and **Stories** (`story-list.ts`). No new toolbar component (that is #157 / #129).
+
+## Acceptance criteria
+
+- Tokenized **semantic** type scale (page title, section title, body, label, helper, caption), each with size + weight + line-height, defined in `styles.scss` and consumed by shared primitives — no per-view font-size/weight literals in the migrated pages.
+- The shared page/header primitive exposes `eyebrow` and a `metadata` slot; route pages keep a single `<h1>`. Breadcrumb/top-bar context deferred to #128 / #154.
+- The `list-page` toolbar reads density/type from tokens with consistent action placement across **Goals** and **Stories**.
+- No regression to the single-`<h1>`-per-page structure from #135.
+
+Depends on #125. Provides the primitive consumed by #128 and #154.
+EOF
+```
+
+### 7.2 #128 — comment: consume the #127 primitive, do not rebuild it
+
+```bash
+gh issue comment 128 --repo rreganjr/Requel --body "Scope coordination (see \`doc/127-typography-rescope.md\`): #127 delivers the page/header primitive with \`eyebrow\` + \`metadata\` slots and the semantic type tokens. This issue owns the **context/IA half** — breadcrumb route/data wiring, the \`/projects/:name\` workspace overview, and editor-header action groups — and should fill the #127 primitive's slots rather than introduce a parallel header. Shell chrome (top bar, sidebar) is #154."
+```
+
+### 7.3 #154 — comment: render inside the #127 primitive
+
+```bash
+gh issue comment 154 --repo rreganjr/Requel --body "Scope coordination (see \`doc/127-typography-rescope.md\`): #127 delivers the page/header primitive (\`eyebrow\` + \`metadata\` slots) and semantic type tokens. This issue owns the **shell-chrome half** — top bar (back button + right cluster) and grouped collapsible sidebar — and should render the #127 primitive inside the new shell rather than re-implement page titles/eyebrows. Breadcrumb route/data + workspace route stay with #128."
+```
+
+### 7.4 Optional — link the issues as related
+
+```bash
+# Record the dependency direction as issue references (optional; comments above already cross-link).
+gh issue comment 127 --repo rreganjr/Requel --body "Provides the page/header primitive consumed by #128 (context/IA) and #154 (shell chrome). Depends on #125 (preset tokens)."
+```

--- a/requel-angular/src/app/features/goals/goal-list.ts
+++ b/requel-angular/src/app/features/goals/goal-list.ts
@@ -39,7 +39,7 @@ import { ListPageComponent } from '../../shared/list-page';
   standalone: true,
   imports: [ListPageComponent, TableModule, ButtonModule, MessageModule, SelectModule, FormsModule, SlicePipe],
   template: `
-    <app-list-page title="Goals" searchPlaceholder="Search goals..."
+    <app-list-page title="Goals" [eyebrow]="projectContext()" searchPlaceholder="Search goals..."
                    (search)="dt.filterGlobal($event, 'contains')">
       <ng-container actions>
         <p-select [options]="tagFilterOptions()" [ngModel]="selectedTagId()"
@@ -90,7 +90,8 @@ import { ListPageComponent } from '../../shared/list-page';
     .text-preview { max-width: 400px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .tag-filter { min-width: 200px; }
     .chips { display: inline-flex; flex-wrap: wrap; gap: 0.3rem; }
-    .tag-chip { font-size: 0.7rem; font-weight: 600; padding: 0.1rem 0.45rem; border-radius: 12px;
+    .tag-chip { font-size: var(--rq-text-caption-size); font-weight: var(--rq-font-weight-semibold);
+      padding: 0.1rem 0.45rem; border-radius: 12px;
       background: var(--p-primary-100, #dbeafe); color: var(--p-primary-700, #1d4ed8); white-space: nowrap; }
   `]
 })
@@ -99,6 +100,8 @@ export class GoalListComponent implements OnInit, OnDestroy {
   loading = signal(true);
   errorMessage = signal<string | null>(null);
   canEdit = signal(false);
+  /** Project-name context shown as the page eyebrow (issue #127). */
+  projectContext = signal('');
 
   /** goalId -> tags assigned to it (built from the project's tags). */
   tagsByGoal = signal<Map<number, TagDto[]>>(new Map());
@@ -132,6 +135,7 @@ export class GoalListComponent implements OnInit, OnDestroy {
       const name = params.get('name') ?? '';
       if (name !== this.projectName) {
         this.projectName = name;
+        this.projectContext.set(name);
         await this.permissionService.loadForProject(name);
         this.canEdit.set(this.permissionService.canEdit('Goal'));
         await this.loadGoals();

--- a/requel-angular/src/app/features/stories/story-list.ts
+++ b/requel-angular/src/app/features/stories/story-list.ts
@@ -35,7 +35,7 @@ import { ListPageComponent } from '../../shared/list-page';
   standalone: true,
   imports: [ListPageComponent, TableModule, ButtonModule, MessageModule, SlicePipe],
   template: `
-    <app-list-page title="Stories" searchPlaceholder="Search stories..."
+    <app-list-page title="Stories" [eyebrow]="projectContext()" searchPlaceholder="Search stories..."
                    (search)="dt.filterGlobal($event, 'contains')">
       <ng-container actions>
         @if (canEdit()) {
@@ -81,6 +81,8 @@ export class StoryListComponent implements OnInit, OnDestroy {
   loading = signal(true);
   errorMessage = signal<string | null>(null);
   canEdit = signal(false);
+  /** Project-name context shown as the page eyebrow (issue #127). */
+  projectContext = signal('');
 
   private projectName = '';
   private paramSub?: Subscription;
@@ -97,6 +99,7 @@ export class StoryListComponent implements OnInit, OnDestroy {
       const name = params.get('name') ?? '';
       if (name !== this.projectName) {
         this.projectName = name;
+        this.projectContext.set(name);
         await this.permissionService.loadForProject(name);
         this.canEdit.set(this.permissionService.canEdit('Story'));
         this.loadStories();

--- a/requel-angular/src/app/shared/list-page.ts
+++ b/requel-angular/src/app/shared/list-page.ts
@@ -29,14 +29,14 @@ import { PageHeaderComponent } from './page-header';
   template: `
     <div class="list-page-wrap">
       <div class="page-header">
-        <app-page-header [title]="title" />
+        <app-page-header [title]="title" [eyebrow]="eyebrow" />
         <div class="page-actions">
           <ng-content select="[actions]" />
         </div>
       </div>
       @if (showSearch) {
-        <div class="search-bar">
-          <span class="p-input-icon-left">
+        <div class="list-toolbar">
+          <span class="p-input-icon-left search-field">
             <i class="pi pi-search"></i>
             <input pInputText [value]="searchText" [placeholder]="searchPlaceholder"
                    aria-label="Search"
@@ -47,14 +47,26 @@ import { PageHeaderComponent } from './page-header';
       <ng-content />
     </div>
   `,
+  // Compact, consistent list-page toolbar (issue #127): the title/actions row
+  // and the search toolbar share the same token-driven spacing so density and
+  // action placement match across migrated list pages (Goals, Stories, …).
   styles: [`
-    .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
-    .page-actions { display: flex; gap: 0.5rem; }
-    .search-bar { margin-bottom: 1rem; }
+    .page-header {
+      display: flex; justify-content: space-between; align-items: center;
+      gap: var(--rq-space-4); margin-bottom: var(--rq-space-4);
+    }
+    .page-actions { display: flex; align-items: center; gap: var(--rq-space-2); }
+    .list-toolbar {
+      display: flex; align-items: center; gap: var(--rq-space-2);
+      margin-bottom: var(--rq-space-4);
+    }
+    .search-field { display: inline-flex; align-items: center; }
   `]
 })
 export class ListPageComponent {
   @Input() title = '';
+  /** Optional context line (project name / artifact type) shown above the title. */
+  @Input() eyebrow = '';
   @Input() showSearch = true;
   @Input() searchText = '';
   @Input() searchPlaceholder = 'Search...';

--- a/requel-angular/src/app/shared/page-header.spec.ts
+++ b/requel-angular/src/app/shared/page-header.spec.ts
@@ -5,13 +5,27 @@ import { PageHeaderComponent } from './page-header';
 @Component({
   standalone: true,
   imports: [PageHeaderComponent],
-  template: `<app-page-header [title]="title" />`
+  template: `<app-page-header [title]="title" [eyebrow]="eyebrow" />`
 })
 class HostComponent {
   title = 'My Page';
+  eyebrow = '';
 }
 
-describe('PageHeaderComponent (issue #135)', () => {
+@Component({
+  standalone: true,
+  imports: [PageHeaderComponent],
+  template: `
+    <app-page-header [title]="title" [eyebrow]="eyebrow">
+      <span metadata data-testid="meta-tag">Draft</span>
+    </app-page-header>`
+})
+class MetaHostComponent {
+  title = 'Goals';
+  eyebrow = 'Acme Project';
+}
+
+describe('PageHeaderComponent (issues #135, #127)', () => {
   it('renders exactly one <h1> containing the title and no <h2>', () => {
     TestBed.configureTestingModule({ imports: [HostComponent] });
     const fixture = TestBed.createComponent(HostComponent);
@@ -22,5 +36,29 @@ describe('PageHeaderComponent (issue #135)', () => {
     expect(h1s.length).toBe(1);
     expect(h1s[0].textContent?.trim()).toBe('My Page');
     expect(el.querySelectorAll('h2').length).toBe(0);
+  });
+
+  it('does not render the eyebrow when none is provided', () => {
+    TestBed.configureTestingModule({ imports: [HostComponent] });
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelector('[data-testid="page-eyebrow"]')).toBeNull();
+  });
+
+  it('renders the eyebrow and projected metadata while keeping a single <h1>', () => {
+    TestBed.configureTestingModule({ imports: [MetaHostComponent] });
+    const fixture = TestBed.createComponent(MetaHostComponent);
+    fixture.detectChanges();
+
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelectorAll('h1').length).toBe(1);
+
+    const eyebrow = el.querySelector('[data-testid="page-eyebrow"]');
+    expect(eyebrow?.textContent?.trim()).toBe('Acme Project');
+    expect(eyebrow?.classList.contains('rq-eyebrow')).toBe(true);
+
+    expect(el.querySelector('[data-testid="meta-tag"]')?.textContent?.trim()).toBe('Draft');
   });
 });

--- a/requel-angular/src/app/shared/page-header.ts
+++ b/requel-angular/src/app/shared/page-header.ts
@@ -21,27 +21,48 @@
 import { Component, Input } from '@angular/core';
 
 /**
- * Shared page title. Renders the single <h1> for a route so every page has a
- * consistent, unique top-level heading (WCAG 2.4.6, 1.3.1 - see issue #135).
+ * Shared page-title primitive. Renders the single <h1> for a route so every page
+ * has a consistent, unique top-level heading (WCAG 2.4.6, 1.3.1 - see issue #135),
+ * plus optional context around it (issue #127):
  *
- * The host uses `display: contents` so the <h1> participates directly in the
- * parent layout (e.g. an existing `.page-header` flex row), preserving the
- * previous <h2>-based markup and spacing. The h1 is pinned to the former h2
- * size so converting the tag does not change the visual size.
+ * - `eyebrow` — a short context line above the title (e.g. project name, or
+ *   "Project · Artifact type"). Rendered muted/uppercase via the caption role.
+ * - `[metadata]` slot — projected content below the title for status tags,
+ *   counts, permissions, or unsaved-state indicators.
+ *
+ * Typography comes entirely from the semantic type-scale tokens/role classes in
+ * `styles.scss`; the component holds no font literals. The single `<h1>` is
+ * preserved regardless of whether eyebrow/metadata are present.
+ *
+ * Downstream context chrome (breadcrumbs, top bar, project workspace route) is
+ * intentionally out of scope here and lives in #128 (context/IA) and #154 (app
+ * shell), which compose this primitive.
  */
 @Component({
   selector: 'app-page-header',
   standalone: true,
-  template: `<h1 class="page-title">{{ title }}</h1>`,
+  template: `
+    <div class="page-header-block">
+      @if (eyebrow) {
+        <p class="rq-eyebrow page-eyebrow" data-testid="page-eyebrow">{{ eyebrow }}</p>
+      }
+      <h1 class="rq-page-title page-title">{{ title }}</h1>
+      <div class="page-meta"><ng-content select="[metadata]" /></div>
+    </div>
+  `,
   styles: [`
-    :host { display: contents; }
-    .page-title {
-      margin: 0;
-      font-size: 1.5rem;
-      font-weight: 700;
-    }
+    :host { display: block; }
+    .page-header-block { display: flex; flex-direction: column; }
+    /* Margins (not a column gap) so a title-only header adds no stray spacing. */
+    .page-eyebrow { margin: 0 0 var(--rq-space-1); }
+    .page-title { margin: 0; }
+    .page-meta { display: flex; flex-wrap: wrap; align-items: center; gap: var(--rq-space-2); }
+    .page-meta:not(:empty) { margin-top: var(--rq-space-2); }
   `]
 })
 export class PageHeaderComponent {
+  /** The route's top-level heading text (the single <h1>). */
   @Input() title = '';
+  /** Optional context line above the title (project name / artifact type). */
+  @Input() eyebrow = '';
 }

--- a/requel-angular/src/app/theme/README.md
+++ b/requel-angular/src/app/theme/README.md
@@ -50,7 +50,16 @@ Defined in `src/styles.scss`:
 - **Spacing:** `--rq-space-1|2|3|4|6|8` (0.25rem → 2rem).
 - **Radius:** `--rq-radius-sm` (4px), `--rq-radius-md` (6px, content radius),
   `--rq-radius-lg` (8px).
-- **Type scale:** `--rq-font-size-xs|sm|md|lg|xl`.
+- **Type scale (raw steps):** `--rq-font-size-xs|sm|md|lg|xl`.
+- **Font weights:** `--rq-font-weight-normal|medium|semibold|bold`.
+- **Semantic type scale (#127):** role tokens that bundle size + weight +
+  line-height — `--rq-text-{page-title,section-title,body,label,helper,caption}-{size,weight,line}`
+  — plus `--rq-text-heading-color` (slate-800) and `--rq-text-muted-color`
+  (slate-500). Apply them with the role classes `.rq-page-title`,
+  `.rq-section-title`, `.rq-eyebrow`, `.rq-label`, `.rq-helper`, `.rq-caption`
+  (defined in `styles.scss`), or read the tokens directly. `.rq-page-title` is
+  reserved for the single `<h1>` rendered by `app-page-header`. Route pages and
+  shared primitives must use these instead of per-view font-size/weight literals.
 - **Layout widths:** `--rq-page-max` (76rem), `--rq-editor-max` (48rem).
   Helper class `.rq-page` centers content at `--rq-page-max`.
 - **Focus ring:** `--rq-focus-ring-width|color|offset` (mirror the PrimeNG focus

--- a/requel-angular/src/styles.scss
+++ b/requel-angular/src/styles.scss
@@ -26,12 +26,50 @@
   --rq-radius-md: 6px;
   --rq-radius-lg: 8px;
 
-  // Type scale.
+  // Type scale (raw size steps; 1rem = 14px given the 14px base).
   --rq-font-size-xs: 0.75rem;
   --rq-font-size-sm: 0.875rem;
   --rq-font-size-md: 1rem;
   --rq-font-size-lg: 1.125rem;
   --rq-font-size-xl: 1.5rem;
+
+  // Font weights.
+  --rq-font-weight-normal: 400;
+  --rq-font-weight-medium: 500;
+  --rq-font-weight-semibold: 600;
+  --rq-font-weight-bold: 700;
+
+  // Semantic type scale (issue #127). Each role bundles size + weight +
+  // line-height; the two color tokens below cover where a role differs from
+  // body text. Titles are bold slate (surface-800); helper/caption are muted
+  // (surface-500). Components apply these via the `.rq-*` role classes below or
+  // by reading the tokens directly — never with per-view font literals.
+  --rq-text-heading-color: var(--p-surface-800);
+  --rq-text-muted-color: var(--p-text-muted-color, var(--p-surface-500));
+
+  --rq-text-page-title-size: var(--rq-font-size-xl);        // 1.5rem / 21px
+  --rq-text-page-title-weight: var(--rq-font-weight-bold);
+  --rq-text-page-title-line: 1.2;
+
+  --rq-text-section-title-size: var(--rq-font-size-lg);     // 1.125rem
+  --rq-text-section-title-weight: var(--rq-font-weight-semibold);
+  --rq-text-section-title-line: 1.3;
+
+  --rq-text-body-size: var(--rq-font-size-md);              // 1rem / 14px
+  --rq-text-body-weight: var(--rq-font-weight-normal);
+  --rq-text-body-line: 1.5;
+
+  --rq-text-label-size: var(--rq-font-size-sm);             // 0.875rem
+  --rq-text-label-weight: var(--rq-font-weight-semibold);
+  --rq-text-label-line: 1.4;
+
+  --rq-text-helper-size: var(--rq-font-size-sm);            // 0.875rem
+  --rq-text-helper-weight: var(--rq-font-weight-normal);
+  --rq-text-helper-line: 1.4;
+
+  --rq-text-caption-size: var(--rq-font-size-xs);           // 0.75rem
+  --rq-text-caption-weight: var(--rq-font-weight-medium);
+  --rq-text-caption-line: 1.3;
 
   // Layout widths.
   --rq-page-max: 76rem;
@@ -73,6 +111,51 @@ html, body {
 .rq-page {
   max-width: var(--rq-page-max);
   margin: 0 auto;
+}
+
+// -------------------------------------------------------------------------
+// Semantic type-scale role classes (issue #127)
+//
+// The reusable way to apply the type scale. Shared primitives (page-header,
+// list-page) and route pages use these instead of hard-coding font-size /
+// weight / line-height. `.rq-page-title` is reserved for the single <h1>.
+// -------------------------------------------------------------------------
+.rq-page-title {
+  font-size: var(--rq-text-page-title-size);
+  font-weight: var(--rq-text-page-title-weight);
+  line-height: var(--rq-text-page-title-line);
+  color: var(--rq-text-heading-color);
+}
+.rq-section-title {
+  font-size: var(--rq-text-section-title-size);
+  font-weight: var(--rq-text-section-title-weight);
+  line-height: var(--rq-text-section-title-line);
+  color: var(--rq-text-heading-color);
+}
+.rq-eyebrow {
+  font-size: var(--rq-text-caption-size);
+  font-weight: var(--rq-text-caption-weight);
+  line-height: var(--rq-text-caption-line);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--rq-text-muted-color);
+}
+.rq-label {
+  font-size: var(--rq-text-label-size);
+  font-weight: var(--rq-text-label-weight);
+  line-height: var(--rq-text-label-line);
+}
+.rq-helper {
+  font-size: var(--rq-text-helper-size);
+  font-weight: var(--rq-text-helper-weight);
+  line-height: var(--rq-text-helper-line);
+  color: var(--rq-text-muted-color);
+}
+.rq-caption {
+  font-size: var(--rq-text-caption-size);
+  font-weight: var(--rq-text-caption-weight);
+  line-height: var(--rq-text-caption-line);
+  color: var(--rq-text-muted-color);
 }
 
 // -------------------------------------------------------------------------


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/127

Add a tokenized semantic type scale and extend the shared page/header primitive with eyebrow + metadata context

Implements the typography half of UI/UX finding 1.3 (see doc/127-typography-rescope.md).
Scope is intentionally limited to the type tokens plus the presentation primitive;
breadcrumbs, top-bar chrome, and the project workspace route remain with #128 (context/IA)
and #154 (app shell), which compose this primitive.

requel-angular/src/styles.scss
- Add font-weight tokens (--rq-font-weight-normal|medium|semibold|bold).
- Add a semantic type scale: role tokens for page title, section title, body, label,
  helper, and caption, each bundling size + weight + line-height, plus
  --rq-text-heading-color (slate-800) and --rq-text-muted-color (slate-500).
- Add reusable role classes (.rq-page-title, .rq-section-title, .rq-eyebrow, .rq-label,
  .rq-helper, .rq-caption) so primitives and pages apply the scale without per-view
  font literals. .rq-page-title is reserved for the single <h1>.

requel-angular/src/app/theme/README.md
- Document the font-weight tokens, the semantic type-scale tokens, and the role classes.

requel-angular/src/app/shared/page-header.ts
- Extend the primitive with an optional `eyebrow` input (project/artifact context above
  the title) and a `[metadata]` content slot (status/counts/unsaved-state), while keeping
  exactly one <h1>. Typography now comes from the role classes/tokens (no font literals).
  Metadata spacing uses :not(:empty) margins so a title-only header (all existing callers)
  gains no stray spacing. Host switched from display:contents to block to host the column.

requel-angular/src/app/shared/list-page.ts
- Forward an optional `eyebrow` input to the header primitive.
- Token-ize the title/actions row and the search toolbar (renamed .search-bar to
  .list-toolbar) so density and action placement are consistent across list pages.

requel-angular/src/app/features/goals/goal-list.ts, requel-angular/src/app/features/stories/story-list.ts
- Migrate the two exemplar list pages: expose a projectContext signal and pass it as the
  page eyebrow so project context is visible through the page primitive.
- goal-list: replace the .tag-chip font-size/weight literals with type-scale tokens.

requel-angular/src/app/shared/page-header.spec.ts
- Extend the #135 single-<h1> test with cases for the eyebrow rendering (present/absent)
  and projected metadata, asserting a single <h1> is preserved.

Closes #127.
