### PR TITLE
156: app-card content-surface primitive + list/editor adoption

### DIFF
--- a/doc/156-app-card-plan.md
+++ b/doc/156-app-card-plan.md
@@ -1,0 +1,194 @@
+# Implementation Plan — #156 N3 Card / content-surface primitive (`app-card`)
+
+Part of the look-and-feel adoption epic #124 (see `doc/124-lookandfeel-plan.md`, item N3).
+Extract the repeated card container into a single shared `app-card` primitive driven by
+`--rq-card-*` tokens, and sweep every content surface onto it so there is no per-view
+card CSS left.
+
+## Decisions (locked)
+
+1. **Tokens alias/map existing scale.** `--rq-card-*` are defined in `styles.scss` but
+   resolve to the existing scale rather than new literals — `--rq-card-radius` aliases
+   `--rq-radius-md` (6px), `--rq-card-pad` maps to a `--rq-space-*` value. One source of
+   truth; no parallel magic numbers.
+2. **Component API mirrors `list-page`.** `@Input() title` (string) + a projected
+   `[actions]` slot + default `<ng-content />` for the body. Consistent with the existing
+   shared primitives.
+3. **Full sweep.** Every content surface migrates in this ticket — no "at least one"
+   minimum, no deferred follow-ups.
+4. **One card, never nested.** A surface is a single `app-card`. Inner bordered blocks
+   (e.g. `annotations-section`'s `.annotation` / `.add-form` rows) stay plain bordered
+   elements inside the one card — they do not become nested `app-card`s.
+5. **Option A — `list-page` composes `app-card`.** `app-card` wraps `list-page`'s default
+   content slot, so all 11 list pages get the card surface from a single edit. The
+   title/actions/search toolbar stay *above* the card (card hugs the table/content
+   region), matching the plan's data-table pattern. Editors, which don't use `list-page`,
+   wrap their form shell in `<app-card>` directly.
+
+## 1. The token set (`src/styles.scss`)
+
+Add a card-surface block to the existing `:root` `--rq-*` declarations:
+
+```scss
+/* Card / content surface (issue #156). Values alias the shared scale so the
+   card has no independent magic numbers. */
+--rq-card-bg:     var(--p-surface-0);      /* white card */
+--rq-card-border: var(--p-surface-200);    /* hairline border / divider */
+--rq-card-radius: var(--rq-radius-md);     /* 6px */
+--rq-card-pad:    var(--rq-space-4);       /* 1rem */
+--rq-card-shadow: 0 1px 2px rgba(15, 23, 42, 0.06),
+                  0 1px 3px rgba(15, 23, 42, 0.04); /* very soft */
+```
+
+Notes:
+- `--rq-card-bg`/`--rq-card-border` point at PrimeNG surface tokens (already the Slate
+  ramp from the #125 preset), so light/future-dark theming flows through automatically.
+- Shadow is the one card-specific literal (there is no shadow token yet). Keep it as the
+  single definition here; if a shadow scale is introduced later, `--rq-card-shadow`
+  re-aliases to it.
+
+## 2. The component (`src/app/shared/app-card.ts`)
+
+New standalone component, following `page-header`/`list-page` structure and license header.
+
+```ts
+@Component({
+  selector: 'app-card',
+  standalone: true,
+  template: `
+    <section class="app-card" [class.has-header]="title || hasActions">
+      @if (title || hasActions) {
+        <header class="app-card-header">
+          @if (title) { <h2 class="app-card-title">{{ title }}</h2> }
+          <div class="app-card-actions"><ng-content select="[actions]" /></div>
+        </header>
+      }
+      <div class="app-card-body"><ng-content /></div>
+    </section>
+  `,
+  styles: [`
+    .app-card {
+      background: var(--rq-card-bg);
+      border: 1px solid var(--rq-card-border);
+      border-radius: var(--rq-card-radius);
+      box-shadow: var(--rq-card-shadow);
+      padding: var(--rq-card-pad);
+    }
+    .app-card-header {
+      display: flex; justify-content: space-between; align-items: center;
+      gap: var(--rq-space-4); margin-bottom: var(--rq-space-4);
+    }
+    .app-card-title {
+      margin: 0;
+      font-size: var(--rq-text-section-title-size);
+      font-weight: var(--rq-text-section-title-weight);
+      line-height: var(--rq-text-section-title-line);
+      color: var(--rq-text-heading-color);
+    }
+    .app-card-actions { display: flex; align-items: center; gap: var(--rq-space-2); }
+  `]
+})
+export class AppCardComponent {
+  @Input() title = '';
+  // Header renders when a title is set; card title uses the section-title type token.
+}
+```
+
+Details:
+- Title is a **section-level** heading (`<h2>`, section-title type token) — the page title
+  stays owned by `page-header`, so headings don't collide.
+- The header row only renders when a `title` is supplied (most editor/list cards will pass
+  no title and rely on `page-header` above the card). `[actions]` projection is available
+  for cards that want inline actions in the card header itself.
+- Detecting projected `[actions]` content to toggle `has-header` when there's no title is
+  optional polish; simplest correct behavior is: header renders iff `title` is set.
+  (If we want actions-without-title, use a `@ContentChild`/`@ViewChild` check — decide at
+  build time; not required for the sweep since editors/lists don't use card-header actions.)
+
+## 3. Option A wiring — `list-page` composes `app-card`
+
+`src/app/shared/list-page.ts`: import `AppCardComponent`, and wrap the trailing default
+slot:
+
+```html
+<!-- was: <ng-content /> -->
+<app-card><ng-content /></app-card>
+```
+
+Result: all 11 list pages (`goal-list`, `project-list`, `term-list`, `open-issues`,
+`stakeholder-list`, `use-case-list`, `story-list`, `user-list`, `actor-list`,
+`scenario-list`, `report-list`) render their table inside the card with zero per-page
+edits. Header + search toolbar remain above the card.
+
+## 4. Editor sweep (11 editors)
+
+Each editor is a `<div class="*-editor" data-testid="*-editor">` shell. Wrap the form
+region in `<app-card>` and delete the now-redundant local wrapper CSS (background,
+border, radius, shadow, padding), keeping the `data-testid` on the outer element so tests
+still find it.
+
+Editors: `goal-editor`, `project-editor`, `term-editor`, `stakeholder-editor`,
+`use-case-editor`, `story-editor`, `user-editor`, `actor-editor`, `scenario-editor`,
+`report-editor`.
+
+Per editor:
+- Replace the hand-rolled card `<div class="*-editor">` styling with `<app-card>`, or keep
+  the outer `div` (for `data-testid`) and place `<app-card>` immediately inside it.
+- Leave `.form-grid` / `.form-actions` layout CSS alone — that's field layout (#132),
+  not card surface.
+- `scenario-editor`: the `.step-list` inner block (`border + radius`) stays as a plain
+  bordered inner element — it is content inside the one card, not a nested card (decision 4).
+
+## 5. Other content surfaces
+
+- **`shared/annotations-section.ts`** → wrap the section in one `<app-card>`; the inner
+  `.annotation` / `.add-form` rows keep their own borders as list items (decision 4). Do
+  **not** turn those rows into cards.
+- **`features/auth/login.ts`** → the centered auth card (`border-radius: 8px`,
+  `box-shadow`) becomes `<app-card>` for token consistency. Note it currently uses an 8px
+  radius; adopting `--rq-card-radius` moves it to 6px — acceptable and on-spec.
+
+Explicitly **out of scope** (not content-surface cards):
+- `tag-selector` / `goal-list .tag-chip` chips → belong to N2 (`app-tag`/`app-chip`).
+- `sidebar-nav`, `auth/layout` → app chrome (N1), not cards.
+- `api-tokens` `.token-display code` → an inline code affordance, not a card.
+
+## 6. Tests
+
+- **New:** `app-card.spec.ts` — renders projected content; shows title when set and hides
+  header when not; projects `[actions]`; surface styles read from `--rq-card-*` (assert
+  class presence / computed usage rather than literal values).
+- **Regression:** run the existing editor + list specs (incl. `*.a11y.spec.ts`). The main
+  risk is DOM-structure assertions and `data-testid` lookups shifting when the wrapper
+  changes — fix any spec that queried the old wrapper class, preserving `data-testid`s.
+- `annotations-section.spec.ts` and `goal-editor.a11y.spec.ts` are the most likely to need
+  touch-ups (heading structure: ensure the new card `<h2>` doesn't break landmark/heading
+  order checks from #135).
+
+## 7. Verification gate (per CLAUDE.md)
+
+- Frontend only (no backend change): `cd requel-angular && npm test -- --watch=false` green.
+- Manual smoke: one list page (Goals) and one editor (Goal) render inside the card;
+  hairline border + soft shadow + 6px radius visible; no double border/shadow anywhere
+  (catch accidental nested cards); annotations section is a single card.
+- Grep guard: no remaining component-local card CSS —
+  `grep -rnE "box-shadow|border-radius: (6|8)px" src/app/features src/app/shared` should
+  only surface chips/nav/inner-row cases listed in §5, not content-surface wrappers.
+
+## 8. Acceptance mapping (issue #156)
+
+- `app-card` supports title + action/content slots, padding, border, radius, shadow
+  tokens → §2.
+- At least one list and one editor surface use `app-card` → §3/§4 (all of them).
+- Radius/shadow/border/background/padding come from tokens → §1.
+- No nested-card pattern introduced → decision 4, §4 (scenario step-list), §5
+  (annotations rows).
+- No per-view card CSS duplication → §3 (single `list-page` edit) + §4 (editor CSS
+  deleted) + §7 grep guard.
+
+## 9. Workflow
+
+Branch `156-app-card` off `release/2.0` when 141 clears CI. Frontend-only change →
+`npm test -- --watch=false` is the gate. `commit.md` closes #156, PR targets
+`release/2.0`, close the issue manually after squash-merge (release/2.0 is not the default
+branch). No git actions until explicitly told.

--- a/requel-angular/src/app/features/actors/actor-editor.ts
+++ b/requel-angular/src/app/features/actors/actor-editor.ts
@@ -20,6 +20,7 @@
  */
 import { Component, computed, OnDestroy, OnInit, signal } from '@angular/core';
 import { PageHeaderComponent } from '../../shared/page-header';
+import { AppCardComponent } from '../../shared/app-card';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
@@ -44,7 +45,7 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
 @Component({
   selector: 'app-actor-editor',
   standalone: true,
-  imports: [PageHeaderComponent, RouterLink, FormsModule, ButtonModule, InputText, TextareaModule, TableModule,
+  imports: [PageHeaderComponent, AppCardComponent, RouterLink, FormsModule, ButtonModule, InputText, TextareaModule, TableModule,
             MessageModule, ConfirmDialogModule, EntitySelectorDialogComponent,
             AnnotationsSectionComponent],
   providers: [ConfirmationService],
@@ -72,27 +73,29 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
         <p-message severity="error" [text]="errorMessage()!" data-testid="actor-error" />
       }
 
-      <div class="form-grid">
-        <label for="name">Name</label>
-        <input id="name" pInputText [(ngModel)]="name"
-               placeholder="Actor name" [disabled]="!canEdit()"
-               (ngModelChange)="trackChanges()" />
+      <app-card>
+        <div class="form-grid">
+          <label for="name">Name</label>
+          <input id="name" pInputText [(ngModel)]="name"
+                 placeholder="Actor name" [disabled]="!canEdit()"
+                 (ngModelChange)="trackChanges()" />
 
-        <label for="text">Description</label>
-        <textarea id="text" pTextarea [(ngModel)]="text"
-                  placeholder="Actor description" [rows]="4"
-                  [disabled]="!canEdit()"
-                  (ngModelChange)="trackChanges()"></textarea>
-      </div>
-
-      @if (canEdit()) {
-        <div class="form-actions">
-          <p-button label="{{ isNew() ? 'Create' : 'Save' }}" icon="pi pi-check"
-                    [attr.data-testid]="isNew() ? 'actor-create' : 'actor-save'"
-                    [disabled]="!isNew() && !hasChanges()"
-                    (onClick)="onSave()" />
+          <label for="text">Description</label>
+          <textarea id="text" pTextarea [(ngModel)]="text"
+                    placeholder="Actor description" [rows]="4"
+                    [disabled]="!canEdit()"
+                    (ngModelChange)="trackChanges()"></textarea>
         </div>
-      }
+
+        @if (canEdit()) {
+          <div class="form-actions">
+            <p-button label="{{ isNew() ? 'Create' : 'Save' }}" icon="pi pi-check"
+                      [attr.data-testid]="isNew() ? 'actor-create' : 'actor-save'"
+                      [disabled]="!isNew() && !hasChanges()"
+                      (onClick)="onSave()" />
+          </div>
+        }
+      </app-card>
 
       @if (!isNew()) {
         <div class="goals-section">

--- a/requel-angular/src/app/features/auth/login.ts
+++ b/requel-angular/src/app/features/auth/login.ts
@@ -26,14 +26,15 @@ import { Password } from 'primeng/password';
 import { ButtonModule } from 'primeng/button';
 import { MessageModule } from 'primeng/message';
 import { AuthService } from '../../core/auth.service';
+import { AppCardComponent } from '../../shared/app-card';
 
 @Component({
   selector: 'app-login',
   standalone: true,
-  imports: [FormsModule, InputText, Password, ButtonModule, MessageModule],
+  imports: [FormsModule, InputText, Password, ButtonModule, MessageModule, AppCardComponent],
   template: `
     <div class="login-container">
-      <div class="login-card">
+      <app-card class="login-card">
         <h1>Requel</h1>
         <p class="subtitle">Requirements Elicitation System</p>
 
@@ -58,7 +59,7 @@ import { AuthService } from '../../core/auth.service';
           <p-button type="submit" label="Login" [loading]="loading()"
                     [disabled]="!username() || !password()" styleClass="w-full" />
         </form>
-      </div>
+      </app-card>
     </div>
   `,
   styles: [`
@@ -69,11 +70,10 @@ import { AuthService } from '../../core/auth.service';
       min-height: 100vh;
       background: var(--p-surface-ground);
     }
+    /* The surface (bg, padding, border, radius, shadow) comes from app-card
+       (issue #156); only the login-specific width constraint stays here. */
     .login-card {
-      background: var(--p-surface-card);
-      padding: 2rem;
-      border-radius: 8px;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+      display: block;
       width: 100%;
       max-width: 400px;
     }

--- a/requel-angular/src/app/features/goals/goal-editor.ts
+++ b/requel-angular/src/app/features/goals/goal-editor.ts
@@ -43,13 +43,14 @@ import { EventStreamService } from '../../core/event-stream.service';
 import { EntitySelectorDialogComponent } from '../../shared/entity-selector-dialog';
 import { AnnotationsSectionComponent } from '../../shared/annotations-section';
 import { TagSelectorComponent } from '../../shared/tag-selector';
+import { AppCardComponent } from '../../shared/app-card';
 
 @Component({
   selector: 'app-goal-editor',
   standalone: true,
   imports: [PageHeaderComponent, RouterLink, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
             TableModule, MessageModule, DialogModule, ConfirmDialogModule, EntitySelectorDialogComponent,
-            AnnotationsSectionComponent, TagSelectorComponent],
+            AnnotationsSectionComponent, TagSelectorComponent, AppCardComponent],
   providers: [ConfirmationService],
   template: `
     <div class="goal-editor" data-testid="goal-editor">
@@ -75,18 +76,20 @@ import { TagSelectorComponent } from '../../shared/tag-selector';
         <p-message severity="error" [text]="errorMessage()!" />
       }
 
-      <div class="form-grid">
-        <label for="name">Name</label>
-        <input id="name" pInputText [(ngModel)]="name" placeholder="Goal name" />
+      <app-card>
+        <div class="form-grid">
+          <label for="name">Name</label>
+          <input id="name" pInputText [(ngModel)]="name" placeholder="Goal name" />
 
-        <label for="text">Description</label>
-        <textarea id="text" pTextarea [(ngModel)]="text" rows="6"
-                  placeholder="Goal description"></textarea>
-      </div>
+          <label for="text">Description</label>
+          <textarea id="text" pTextarea [(ngModel)]="text" rows="6"
+                    placeholder="Goal description"></textarea>
+        </div>
 
-      <div class="form-actions">
-        <p-button label="Save" icon="pi pi-check" data-testid="goal-save" (onClick)="onSave()" [loading]="saving()" />
-      </div>
+        <div class="form-actions">
+          <p-button label="Save" icon="pi pi-check" data-testid="goal-save" (onClick)="onSave()" [loading]="saving()" />
+        </div>
+      </app-card>
 
       <!-- Relations: outgoing (this goal supports/conflicts with...) -->
       @if (!isNew() && goal()) {

--- a/requel-angular/src/app/features/projects/project-editor.ts
+++ b/requel-angular/src/app/features/projects/project-editor.ts
@@ -20,6 +20,7 @@
  */
 import { Component, OnInit, OnDestroy, signal, computed, ViewChild } from '@angular/core';
 import { PageHeaderComponent } from '../../shared/page-header';
+import { AppCardComponent } from '../../shared/app-card';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormsModule, NgForm } from '@angular/forms';
 import { InputText } from 'primeng/inputtext';
@@ -42,7 +43,7 @@ import { TagSelectorComponent } from '../../shared/tag-selector';
 @Component({
   selector: 'app-project-editor',
   standalone: true,
-  imports: [PageHeaderComponent, FormsModule, InputText, TextareaModule, ButtonModule, SelectModule, MessageModule, ConfirmDialogModule, TagSelectorComponent],
+  imports: [PageHeaderComponent, AppCardComponent, FormsModule, InputText, TextareaModule, ButtonModule, SelectModule, MessageModule, ConfirmDialogModule, TagSelectorComponent],
   providers: [ConfirmationService],
   template: `
     <div class="project-editor" data-testid="project-editor">
@@ -64,34 +65,36 @@ import { TagSelectorComponent } from '../../shared/tag-selector';
         <p-message severity="success" [text]="successMessage()!" />
       }
 
-      <form #projectForm="ngForm" (ngSubmit)="onSave()">
-        <div class="form-grid">
-          <div class="field">
-            <label for="name">Project Name</label>
-            <input pInputText id="name" [(ngModel)]="name" name="name" required />
+      <app-card>
+        <form #projectForm="ngForm" (ngSubmit)="onSave()">
+          <div class="form-grid">
+            <div class="field">
+              <label for="name">Project Name</label>
+              <input pInputText id="name" [(ngModel)]="name" name="name" required />
+            </div>
+
+            <div class="field">
+              <label for="org">Organization</label>
+              <p-select id="org" [(ngModel)]="selectedOrg" name="org"
+                        [options]="orgOptions()" optionLabel="label" optionValue="value"
+                        [editable]="true" placeholder="Select or type organization" />
+            </div>
+
+            <div class="field full-width">
+              <label for="description">Description</label>
+              <textarea pTextarea id="description" [(ngModel)]="description" name="description"
+                        [rows]="5" [autoResize]="true"></textarea>
+            </div>
           </div>
 
-          <div class="field">
-            <label for="org">Organization</label>
-            <p-select id="org" [(ngModel)]="selectedOrg" name="org"
-                      [options]="orgOptions()" optionLabel="label" optionValue="value"
-                      [editable]="true" placeholder="Select or type organization" />
+          <div class="actions">
+            <p-button type="submit" label="Save" icon="pi pi-check" data-testid="project-save"
+                      [loading]="saving()" [disabled]="!projectForm.dirty" />
+            <p-button label="Cancel" icon="pi pi-times" severity="secondary" data-testid="project-cancel"
+                      (onClick)="onCancel()" [outlined]="true" />
           </div>
-
-          <div class="field full-width">
-            <label for="description">Description</label>
-            <textarea pTextarea id="description" [(ngModel)]="description" name="description"
-                      [rows]="5" [autoResize]="true"></textarea>
-          </div>
-        </div>
-
-        <div class="actions">
-          <p-button type="submit" label="Save" icon="pi pi-check" data-testid="project-save"
-                    [loading]="saving()" [disabled]="!projectForm.dirty" />
-          <p-button label="Cancel" icon="pi pi-times" severity="secondary" data-testid="project-cancel"
-                    (onClick)="onCancel()" [outlined]="true" />
-        </div>
-      </form>
+        </form>
+      </app-card>
 
       @if (!isNew()) {
         <app-tag-selector

--- a/requel-angular/src/app/features/reports/report-editor.ts
+++ b/requel-angular/src/app/features/reports/report-editor.ts
@@ -20,6 +20,7 @@
  */
 import { Component, OnDestroy, OnInit, signal } from '@angular/core';
 import { PageHeaderComponent } from '../../shared/page-header';
+import { AppCardComponent } from '../../shared/app-card';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
@@ -39,7 +40,7 @@ import { FileUploadButtonComponent } from '../../shared/file-upload-button';
 @Component({
   selector: 'app-report-editor',
   standalone: true,
-  imports: [PageHeaderComponent, FormsModule, ButtonModule, InputText, TextareaModule, MessageModule,
+  imports: [PageHeaderComponent, AppCardComponent, FormsModule, ButtonModule, InputText, TextareaModule, MessageModule,
             ConfirmDialogModule, AnnotationsSectionComponent, FileUploadButtonComponent],
   providers: [ConfirmationService],
   template: `
@@ -64,26 +65,28 @@ import { FileUploadButtonComponent } from '../../shared/file-upload-button';
         <p-message severity="error" [text]="errorMessage()!" />
       }
 
-      <div class="form-grid">
-        <label for="name">Name</label>
-        <input id="name" pInputText [(ngModel)]="name" placeholder="Template name" />
+      <app-card>
+        <div class="form-grid">
+          <label for="name">Name</label>
+          <input id="name" pInputText [(ngModel)]="name" placeholder="Template name" />
 
-        <label for="text">XSLT Template</label>
-        <div class="xslt-field">
-          <textarea id="text" pTextarea [(ngModel)]="text" rows="20"
-                    placeholder="Paste XSLT stylesheet here..." class="xslt-textarea"></textarea>
-          <div class="upload-row">
-            <app-file-upload-button label="Upload XSLT" [outlined]="true" size="small"
-                                    accept=".xsl,.xslt,.xml" (fileSelected)="onFileUpload($event)" />
-            <span class="upload-hint">Upload a .xsl/.xslt file to replace the template text.</span>
+          <label for="text">XSLT Template</label>
+          <div class="xslt-field">
+            <textarea id="text" pTextarea [(ngModel)]="text" rows="20"
+                      placeholder="Paste XSLT stylesheet here..." class="xslt-textarea"></textarea>
+            <div class="upload-row">
+              <app-file-upload-button label="Upload XSLT" [outlined]="true" size="small"
+                                      accept=".xsl,.xslt,.xml" (fileSelected)="onFileUpload($event)" />
+              <span class="upload-hint">Upload a .xsl/.xslt file to replace the template text.</span>
+            </div>
           </div>
         </div>
-      </div>
 
-      <div class="form-actions">
-        <p-button label="Save" icon="pi pi-check" data-testid="report-save" (onClick)="onSave()" [loading]="saving()"
-                  [disabled]="!isNew() && !isDirty()" />
-      </div>
+        <div class="form-actions">
+          <p-button label="Save" icon="pi pi-check" data-testid="report-save" (onClick)="onSave()" [loading]="saving()"
+                    [disabled]="!isNew() && !isDirty()" />
+        </div>
+      </app-card>
 
       @if (!isNew()) {
         <app-annotations-section

--- a/requel-angular/src/app/features/scenarios/scenario-editor.ts
+++ b/requel-angular/src/app/features/scenarios/scenario-editor.ts
@@ -20,6 +20,7 @@
  */
 import { Component, OnDestroy, OnInit, signal } from '@angular/core';
 import { PageHeaderComponent } from '../../shared/page-header';
+import { AppCardComponent } from '../../shared/app-card';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Location } from '@angular/common';
 import { Subscription } from 'rxjs';
@@ -64,7 +65,7 @@ interface StepNodeData {
 @Component({
   selector: 'app-scenario-editor',
   standalone: true,
-  imports: [PageHeaderComponent, RouterLink, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
+  imports: [PageHeaderComponent, AppCardComponent, RouterLink, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
             MessageModule, DialogModule, ConfirmDialogModule, TooltipModule, DragDropModule,
             ScenarioSelectorDialogComponent, AnnotationsSectionComponent],
   providers: [ConfirmationService],
@@ -92,27 +93,29 @@ interface StepNodeData {
         <p-message severity="error" [text]="errorMessage()!" />
       }
 
-      <div class="form-grid">
-        <label for="name">Name</label>
-        <input id="name" pInputText [(ngModel)]="name" placeholder="Scenario name"
-               (ngModelChange)="trackChanges()" />
+      <app-card>
+        <div class="form-grid">
+          <label for="name">Name</label>
+          <input id="name" pInputText [(ngModel)]="name" placeholder="Scenario name"
+                 (ngModelChange)="trackChanges()" />
 
-        <label for="type">Type</label>
-        <p-select id="type" inputId="scenarioTypeInput" data-testid="scenario-type" [(ngModel)]="scenarioType" [options]="typeOptions"
-                  optionLabel="label" optionValue="value"
-                  (ngModelChange)="trackChanges()" />
+          <label for="type">Type</label>
+          <p-select id="type" inputId="scenarioTypeInput" data-testid="scenario-type" [(ngModel)]="scenarioType" [options]="typeOptions"
+                    optionLabel="label" optionValue="value"
+                    (ngModelChange)="trackChanges()" />
 
-        <label for="text">Description</label>
-        <textarea id="text" pTextarea [(ngModel)]="text" rows="4"
-                  placeholder="Scenario description"
-                  (ngModelChange)="trackChanges()"></textarea>
-      </div>
+          <label for="text">Description</label>
+          <textarea id="text" pTextarea [(ngModel)]="text" rows="4"
+                    placeholder="Scenario description"
+                    (ngModelChange)="trackChanges()"></textarea>
+        </div>
 
-      <div class="form-actions">
-        <p-button label="Save" icon="pi pi-check" data-testid="scenario-save"
-                  (onClick)="onSave()" [loading]="saving()"
-                  [disabled]="!isNew() && !hasChanges()" />
-      </div>
+        <div class="form-actions">
+          <p-button label="Save" icon="pi pi-check" data-testid="scenario-save"
+                    (onClick)="onSave()" [loading]="saving()"
+                    [disabled]="!isNew() && !hasChanges()" />
+        </div>
+      </app-card>
 
       <!-- Steps section -->
       @if (!isNew()) {

--- a/requel-angular/src/app/features/stakeholders/stakeholder-editor.ts
+++ b/requel-angular/src/app/features/stakeholders/stakeholder-editor.ts
@@ -20,6 +20,7 @@
  */
 import { Component, computed, OnDestroy, OnInit, signal } from '@angular/core';
 import { PageHeaderComponent } from '../../shared/page-header';
+import { AppCardComponent } from '../../shared/app-card';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
@@ -51,7 +52,7 @@ interface PermissionGroup {
 @Component({
   selector: 'app-stakeholder-editor',
   standalone: true,
-  imports: [PageHeaderComponent, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
+  imports: [PageHeaderComponent, AppCardComponent, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
             CheckboxModule, MessageModule, ConfirmDialogModule, TableModule,
             EntitySelectorDialogComponent],
   providers: [ConfirmationService],
@@ -73,66 +74,68 @@ interface PermissionGroup {
         <p-message severity="error" [text]="errorMessage()!" />
       }
 
-      <div class="form-grid">
-        @if (isUserType()) {
-          <label for="username">User</label>
-          <p-select id="username" [(ngModel)]="username" [options]="userOptions()"
-                    optionLabel="label" optionValue="value"
-                    placeholder="Select a user" [filter]="true"
-                    [disabled]="!isNew()" />
+      <app-card>
+        <div class="form-grid">
+          @if (isUserType()) {
+            <label for="username">User</label>
+            <p-select id="username" [(ngModel)]="username" [options]="userOptions()"
+                      optionLabel="label" optionValue="value"
+                      placeholder="Select a user" [filter]="true"
+                      [disabled]="!isNew()" />
 
-          @if (loadedUserDetails(); as ud) {
-            <label>Email</label>
-            <span class="readonly-field">{{ ud.emailAddress || '—' }}</span>
+            @if (loadedUserDetails(); as ud) {
+              <label>Email</label>
+              <span class="readonly-field">{{ ud.emailAddress || '—' }}</span>
 
-            <label>Phone</label>
-            <span class="readonly-field">{{ ud.phoneNumber || '—' }}</span>
+              <label>Phone</label>
+              <span class="readonly-field">{{ ud.phoneNumber || '—' }}</span>
+            }
+
+            <label for="team">Team</label>
+            <input id="team" pInputText [(ngModel)]="teamName" placeholder="Team name"
+                   (ngModelChange)="trackChanges()" />
           }
 
-          <label for="team">Team</label>
-          <input id="team" pInputText [(ngModel)]="teamName" placeholder="Team name"
-                 (ngModelChange)="trackChanges()" />
-        }
-
-        @if (isUserType() && permissionGroups().length > 0) {
-          <div class="permissions-section">
-            <h3>Permissions</h3>
-            <div class="permission-grid">
-              <div class="permission-header"></div>
-              <div class="permission-header">Edit</div>
-              <div class="permission-header">Delete</div>
-              <div class="permission-header">Grant</div>
-              @for (group of permissionGroups(); track group.entityType) {
-                <div class="permission-entity">{{ group.entityType }}</div>
-                @for (type of ['Edit', 'Delete', 'Grant']; track type) {
-                  <div class="permission-check">
-                    @if (getPermission(group, type); as perm) {
-                      <p-checkbox [(ngModel)]="perm.checked" [binary]="true"
-                                  [name]="perm.key" (onChange)="trackChanges()" />
-                    }
-                  </div>
+          @if (isUserType() && permissionGroups().length > 0) {
+            <div class="permissions-section">
+              <h3>Permissions</h3>
+              <div class="permission-grid">
+                <div class="permission-header"></div>
+                <div class="permission-header">Edit</div>
+                <div class="permission-header">Delete</div>
+                <div class="permission-header">Grant</div>
+                @for (group of permissionGroups(); track group.entityType) {
+                  <div class="permission-entity">{{ group.entityType }}</div>
+                  @for (type of ['Edit', 'Delete', 'Grant']; track type) {
+                    <div class="permission-check">
+                      @if (getPermission(group, type); as perm) {
+                        <p-checkbox [(ngModel)]="perm.checked" [binary]="true"
+                                    [name]="perm.key" (onChange)="trackChanges()" />
+                      }
+                    </div>
+                  }
                 }
-              }
+              </div>
             </div>
-          </div>
-        }
+          }
 
-        @if (!isUserType()) {
-          <label for="name">Name</label>
-          <input id="name" pInputText [(ngModel)]="stakeholderName" placeholder="Stakeholder name"
-                 (ngModelChange)="trackChanges()" />
+          @if (!isUserType()) {
+            <label for="name">Name</label>
+            <input id="name" pInputText [(ngModel)]="stakeholderName" placeholder="Stakeholder name"
+                   (ngModelChange)="trackChanges()" />
 
-          <label for="text">Description</label>
-          <textarea id="text" pTextarea [(ngModel)]="text" rows="4"
-                    placeholder="Description of this stakeholder"
-                    (ngModelChange)="trackChanges()"></textarea>
-        }
-      </div>
+            <label for="text">Description</label>
+            <textarea id="text" pTextarea [(ngModel)]="text" rows="4"
+                      placeholder="Description of this stakeholder"
+                      (ngModelChange)="trackChanges()"></textarea>
+          }
+        </div>
 
-      <div class="form-actions">
-        <p-button label="Save" icon="pi pi-check" (onClick)="onSave()" [loading]="saving()"
-                  [disabled]="!isNew() && !hasChanges()" />
-      </div>
+        <div class="form-actions">
+          <p-button label="Save" icon="pi pi-check" (onClick)="onSave()" [loading]="saving()"
+                    [disabled]="!isNew() && !hasChanges()" />
+        </div>
+      </app-card>
 
       @if (!isNew()) {
         <div class="section">

--- a/requel-angular/src/app/features/stories/story-editor.ts
+++ b/requel-angular/src/app/features/stories/story-editor.ts
@@ -20,6 +20,7 @@
  */
 import { Component, OnDestroy, OnInit, signal } from '@angular/core';
 import { PageHeaderComponent } from '../../shared/page-header';
+import { AppCardComponent } from '../../shared/app-card';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
@@ -46,7 +47,7 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
 @Component({
   selector: 'app-story-editor',
   standalone: true,
-  imports: [PageHeaderComponent, RouterLink, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
+  imports: [PageHeaderComponent, AppCardComponent, RouterLink, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
             TableModule, MessageModule, ConfirmDialogModule, EntitySelectorDialogComponent,
             AnnotationsSectionComponent],
   providers: [ConfirmationService],
@@ -77,41 +78,43 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
         <p-message severity="error" [text]="errorMessage()!" />
       }
 
-      <div class="form-grid">
-        <label for="name">Name</label>
-        <input id="name" pInputText [(ngModel)]="name" placeholder="Story name"
-               (ngModelChange)="trackChanges()" />
+      <app-card>
+        <div class="form-grid">
+          <label for="name">Name</label>
+          <input id="name" pInputText [(ngModel)]="name" placeholder="Story name"
+                 (ngModelChange)="trackChanges()" />
 
-        <label for="type">Type</label>
-        <p-select id="type" inputId="storyTypeInput" data-testid="story-type"
-                  [(ngModel)]="storyType" [options]="storyTypeOptions"
-                  optionLabel="label" optionValue="value"
-                  (ngModelChange)="trackChanges()" />
+          <label for="type">Type</label>
+          <p-select id="type" inputId="storyTypeInput" data-testid="story-type"
+                    [(ngModel)]="storyType" [options]="storyTypeOptions"
+                    optionLabel="label" optionValue="value"
+                    (ngModelChange)="trackChanges()" />
 
-        <label for="primaryActor">Primary Actor</label>
-        <p-select id="primaryActor" inputId="storyPrimaryActorInput"
-                  data-testid="story-primary-actor"
-                  [(ngModel)]="primaryActorName"
-                  [options]="actorOptions()"
-                  optionLabel="label"
-                  optionValue="value"
-                  [showClear]="true"
-                  [pt]="{ clearIcon: { 'data-testid': 'story-primary-actor-clear' } }"
-                  placeholder="Select primary actor"
-                  (ngModelChange)="trackChanges()"
-                  styleClass="w-full" />
+          <label for="primaryActor">Primary Actor</label>
+          <p-select id="primaryActor" inputId="storyPrimaryActorInput"
+                    data-testid="story-primary-actor"
+                    [(ngModel)]="primaryActorName"
+                    [options]="actorOptions()"
+                    optionLabel="label"
+                    optionValue="value"
+                    [showClear]="true"
+                    [pt]="{ clearIcon: { 'data-testid': 'story-primary-actor-clear' } }"
+                    placeholder="Select primary actor"
+                    (ngModelChange)="trackChanges()"
+                    styleClass="w-full" />
 
-        <label for="text">Text</label>
-        <textarea id="text" pTextarea [(ngModel)]="text" rows="8"
-                  placeholder="Story text"
-                  (ngModelChange)="trackChanges()"></textarea>
-      </div>
+          <label for="text">Text</label>
+          <textarea id="text" pTextarea [(ngModel)]="text" rows="8"
+                    placeholder="Story text"
+                    (ngModelChange)="trackChanges()"></textarea>
+        </div>
 
-      <div class="form-actions">
-        <p-button label="Save" icon="pi pi-check" data-testid="story-save"
-                  (onClick)="onSave()" [loading]="saving()"
-                  [disabled]="!isNew() && !hasChanges()" />
-      </div>
+        <div class="form-actions">
+          <p-button label="Save" icon="pi pi-check" data-testid="story-save"
+                    (onClick)="onSave()" [loading]="saving()"
+                    [disabled]="!isNew() && !hasChanges()" />
+        </div>
+      </app-card>
 
       <!-- Goals sub-table -->
       @if (!isNew() && story()) {

--- a/requel-angular/src/app/features/terms/term-editor.ts
+++ b/requel-angular/src/app/features/terms/term-editor.ts
@@ -37,11 +37,12 @@ import { TermService } from '../../core/term.service';
 import { PermissionService } from '../../core/permission.service';
 import { EventStreamService } from '../../core/event-stream.service';
 import { AnnotationsSectionComponent } from '../../shared/annotations-section';
+import { AppCardComponent } from '../../shared/app-card';
 
 @Component({
   selector: 'app-term-editor',
   standalone: true,
-  imports: [PageHeaderComponent, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
+  imports: [PageHeaderComponent, AppCardComponent, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
             TableModule, MessageModule, ConfirmDialogModule, AnnotationsSectionComponent],
   providers: [ConfirmationService],
   template: `
@@ -62,25 +63,27 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
         <p-message severity="error" [text]="errorMessage()!" data-testid="term-error" />
       }
 
-      <div class="form-grid">
-        <label for="name">Term</label>
-        <input id="name" pInputText [(ngModel)]="name" placeholder="Term name" />
+      <app-card>
+        <div class="form-grid">
+          <label for="name">Term</label>
+          <input id="name" pInputText [(ngModel)]="name" placeholder="Term name" />
 
-        <label for="text">Definition</label>
-        <textarea id="text" pTextarea [(ngModel)]="text" rows="5"
-                  placeholder="Definition of this term"></textarea>
+          <label for="text">Definition</label>
+          <textarea id="text" pTextarea [(ngModel)]="text" rows="5"
+                    placeholder="Definition of this term"></textarea>
 
-        <label for="canonical">Canonical Term</label>
-        <p-select id="canonical" [options]="canonicalOptions()" [(ngModel)]="canonicalTermId"
-                  optionLabel="label" optionValue="value"
-                  data-testid="term-canonical-select"
-                  placeholder="None (this is a canonical term)" [showClear]="true" />
-      </div>
+          <label for="canonical">Canonical Term</label>
+          <p-select id="canonical" [options]="canonicalOptions()" [(ngModel)]="canonicalTermId"
+                    optionLabel="label" optionValue="value"
+                    data-testid="term-canonical-select"
+                    placeholder="None (this is a canonical term)" [showClear]="true" />
+        </div>
 
-      <div class="form-actions">
-        <p-button label="Save" icon="pi pi-check" data-testid="term-save" (onClick)="onSave()" [loading]="saving()"
-                  [disabled]="!isNew() && !isDirty()" />
-      </div>
+        <div class="form-actions">
+          <p-button label="Save" icon="pi pi-check" data-testid="term-save" (onClick)="onSave()" [loading]="saving()"
+                    [disabled]="!isNew() && !isDirty()" />
+        </div>
+      </app-card>
 
       <!-- Alternate Terms (terms that point to this as their canonical) -->
       @if (!isNew() && term()?.alternateTerms?.length) {

--- a/requel-angular/src/app/features/use-cases/use-case-editor.ts
+++ b/requel-angular/src/app/features/use-cases/use-case-editor.ts
@@ -20,6 +20,7 @@
  */
 import { Component, computed, OnDestroy, OnInit, signal } from '@angular/core';
 import { PageHeaderComponent } from '../../shared/page-header';
+import { AppCardComponent } from '../../shared/app-card';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Location } from '@angular/common';
 import { Subscription } from 'rxjs';
@@ -53,7 +54,7 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
 @Component({
   selector: 'app-use-case-editor',
   standalone: true,
-  imports: [PageHeaderComponent, RouterLink, FormsModule, ButtonModule, InputText, TextareaModule, MessageModule,
+  imports: [PageHeaderComponent, AppCardComponent, RouterLink, FormsModule, ButtonModule, InputText, TextareaModule, MessageModule,
             ConfirmDialogModule, TableModule, TooltipModule, SelectModule,
             EntitySelectorDialogComponent, AnnotationsSectionComponent],
   providers: [ConfirmationService],
@@ -81,35 +82,37 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
         <p-message severity="error" [text]="errorMessage()!" />
       }
 
-      <div class="form-grid">
-        <label for="name">Name</label>
-        <input id="name" pInputText [(ngModel)]="name" placeholder="Use case name"
-               (ngModelChange)="trackChanges()" />
+      <app-card>
+        <div class="form-grid">
+          <label for="name">Name</label>
+          <input id="name" pInputText [(ngModel)]="name" placeholder="Use case name"
+                 (ngModelChange)="trackChanges()" />
 
-        <label for="primaryActor">Primary Actor</label>
-        <p-select id="primaryActor" inputId="useCasePrimaryActorInput"
-                  data-testid="use-case-primary-actor"
-                  [(ngModel)]="primaryActorName"
-                  [options]="actorOptions()"
-                  optionLabel="label"
-                  optionValue="value"
-                  [showClear]="true"
-                  [pt]="{ clearIcon: { 'data-testid': 'use-case-primary-actor-clear' } }"
-                  placeholder="Select primary actor"
-                  (ngModelChange)="trackChanges()"
-                  styleClass="w-full" />
+          <label for="primaryActor">Primary Actor</label>
+          <p-select id="primaryActor" inputId="useCasePrimaryActorInput"
+                    data-testid="use-case-primary-actor"
+                    [(ngModel)]="primaryActorName"
+                    [options]="actorOptions()"
+                    optionLabel="label"
+                    optionValue="value"
+                    [showClear]="true"
+                    [pt]="{ clearIcon: { 'data-testid': 'use-case-primary-actor-clear' } }"
+                    placeholder="Select primary actor"
+                    (ngModelChange)="trackChanges()"
+                    styleClass="w-full" />
 
-        <label for="text">Description</label>
-        <textarea id="text" pTextarea [(ngModel)]="text" rows="4"
-                  placeholder="Use case description"
-                  (ngModelChange)="trackChanges()"></textarea>
-      </div>
+          <label for="text">Description</label>
+          <textarea id="text" pTextarea [(ngModel)]="text" rows="4"
+                    placeholder="Use case description"
+                    (ngModelChange)="trackChanges()"></textarea>
+        </div>
 
-      <div class="form-actions">
-        <p-button label="Save" icon="pi pi-check" data-testid="use-case-save"
-                  (onClick)="onSave()" [loading]="saving()"
-                  [disabled]="!isNew() && !hasChanges()" />
-      </div>
+        <div class="form-actions">
+          <p-button label="Save" icon="pi pi-check" data-testid="use-case-save"
+                    (onClick)="onSave()" [loading]="saving()"
+                    [disabled]="!isNew() && !hasChanges()" />
+        </div>
+      </app-card>
 
       <!-- Primary Scenario section -->
       @if (!isNew()) {

--- a/requel-angular/src/app/features/users/user-editor.ts
+++ b/requel-angular/src/app/features/users/user-editor.ts
@@ -20,6 +20,7 @@
  */
 import { ChangeDetectorRef, Component, OnDestroy, OnInit, signal, computed, ViewChild } from '@angular/core';
 import { PageHeaderComponent } from '../../shared/page-header';
+import { AppCardComponent } from '../../shared/app-card';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { FormsModule, NgForm } from '@angular/forms';
@@ -38,7 +39,7 @@ import { CommandService } from '../../core/command.service';
 @Component({
   selector: 'app-user-editor',
   standalone: true,
-  imports: [PageHeaderComponent, FormsModule, InputText, Password, ButtonModule, CheckboxModule, SelectModule, MessageModule],
+  imports: [PageHeaderComponent, AppCardComponent, FormsModule, InputText, Password, ButtonModule, CheckboxModule, SelectModule, MessageModule],
   template: `
     <div class="user-editor" data-testid="user-editor">
       <app-page-header [title]="isNew() ? 'New User' : 'Edit User: ' + username" />
@@ -50,83 +51,85 @@ import { CommandService } from '../../core/command.service';
         <p-message severity="success" [text]="successMessage()!" />
       }
 
-      <form #userForm="ngForm" (ngSubmit)="onSave()">
-        <div class="form-grid">
-          <div class="field">
-            <label for="username">Username</label>
-            <input pInputText id="username" [(ngModel)]="username" name="username"
-                   [disabled]="!isNew()" />
-          </div>
-
-          <div class="field">
-            <label for="name">Name</label>
-            <input pInputText id="name" [(ngModel)]="name" name="name" />
-          </div>
-
-          <div class="field">
-            <label for="email">Email</label>
-            <input pInputText id="email" [(ngModel)]="emailAddress" name="email" type="email" />
-          </div>
-
-          <div class="field">
-            <label for="phone">Phone</label>
-            <input pInputText id="phone" [(ngModel)]="phoneNumber" name="phone" />
-          </div>
-
-          <div class="field">
-            <label for="org">Organization</label>
-            <p-select id="org" inputId="userOrgInput" data-testid="user-organization"
-                      [(ngModel)]="organizationName" name="org"
-                      [options]="orgOptions()" [editable]="true"
-                      appendTo="body"
-                      placeholder="Select or type organization" />
-          </div>
-
-          <div class="field">
-            <label for="password">Password</label>
-            <p-password id="password" [(ngModel)]="password" name="password"
-                        [feedback]="false" [toggleMask]="true" />
-          </div>
-
-          <div class="field">
-            <label for="repassword">Confirm Password</label>
-            <p-password id="repassword" [(ngModel)]="repassword" name="repassword"
-                        [feedback]="false" [toggleMask]="true" />
-          </div>
-        </div>
-
-        <div class="roles-section" data-testid="user-roles-section">
-          <h3>Roles &amp; Permissions</h3>
-          @for (role of availableRoles(); track role.roleName) {
-            <div class="role-group" data-testid="user-role-group" [attr.data-role-name]="role.roleName">
-              <label class="checkbox-label" data-testid="user-role-label">
-                <p-checkbox [(ngModel)]="selectedRoleNames" [name]="'role_' + role.roleName"
-                            [value]="role.roleName" />
-                {{ role.displayName }}
-              </label>
-              @if (isRoleSelected(role.roleName)) {
-                <div class="permissions">
-                  @for (perm of role.availablePermissions; track perm.name) {
-                    <label class="checkbox-label">
-                      <p-checkbox [(ngModel)]="selectedPermissions[role.roleName]"
-                                  [name]="'perm_' + role.roleName + '_' + perm.name"
-                                  [value]="perm.name" />
-                      {{ perm.name }}
-                    </label>
-                  }
-                </div>
-              }
+      <app-card>
+        <form #userForm="ngForm" (ngSubmit)="onSave()">
+          <div class="form-grid">
+            <div class="field">
+              <label for="username">Username</label>
+              <input pInputText id="username" [(ngModel)]="username" name="username"
+                     [disabled]="!isNew()" />
             </div>
-          }
-        </div>
 
-        <div class="actions">
-          <p-button type="submit" label="Save" icon="pi pi-check" data-testid="user-save"
-                    [loading]="saving()" [disabled]="!userForm.dirty" />
-          <p-button label="Cancel" icon="pi pi-times" severity="secondary"
-                    (onClick)="onCancel()" [outlined]="true" />
-        </div>
-      </form>
+            <div class="field">
+              <label for="name">Name</label>
+              <input pInputText id="name" [(ngModel)]="name" name="name" />
+            </div>
+
+            <div class="field">
+              <label for="email">Email</label>
+              <input pInputText id="email" [(ngModel)]="emailAddress" name="email" type="email" />
+            </div>
+
+            <div class="field">
+              <label for="phone">Phone</label>
+              <input pInputText id="phone" [(ngModel)]="phoneNumber" name="phone" />
+            </div>
+
+            <div class="field">
+              <label for="org">Organization</label>
+              <p-select id="org" inputId="userOrgInput" data-testid="user-organization"
+                        [(ngModel)]="organizationName" name="org"
+                        [options]="orgOptions()" [editable]="true"
+                        appendTo="body"
+                        placeholder="Select or type organization" />
+            </div>
+
+            <div class="field">
+              <label for="password">Password</label>
+              <p-password id="password" [(ngModel)]="password" name="password"
+                          [feedback]="false" [toggleMask]="true" />
+            </div>
+
+            <div class="field">
+              <label for="repassword">Confirm Password</label>
+              <p-password id="repassword" [(ngModel)]="repassword" name="repassword"
+                          [feedback]="false" [toggleMask]="true" />
+            </div>
+          </div>
+
+          <div class="roles-section" data-testid="user-roles-section">
+            <h3>Roles &amp; Permissions</h3>
+            @for (role of availableRoles(); track role.roleName) {
+              <div class="role-group" data-testid="user-role-group" [attr.data-role-name]="role.roleName">
+                <label class="checkbox-label" data-testid="user-role-label">
+                  <p-checkbox [(ngModel)]="selectedRoleNames" [name]="'role_' + role.roleName"
+                              [value]="role.roleName" />
+                  {{ role.displayName }}
+                </label>
+                @if (isRoleSelected(role.roleName)) {
+                  <div class="permissions">
+                    @for (perm of role.availablePermissions; track perm.name) {
+                      <label class="checkbox-label">
+                        <p-checkbox [(ngModel)]="selectedPermissions[role.roleName]"
+                                    [name]="'perm_' + role.roleName + '_' + perm.name"
+                                    [value]="perm.name" />
+                        {{ perm.name }}
+                      </label>
+                    }
+                  </div>
+                }
+              </div>
+            }
+          </div>
+
+          <div class="actions">
+            <p-button type="submit" label="Save" icon="pi pi-check" data-testid="user-save"
+                      [loading]="saving()" [disabled]="!userForm.dirty" />
+            <p-button label="Cancel" icon="pi pi-times" severity="secondary"
+                      (onClick)="onCancel()" [outlined]="true" />
+          </div>
+        </form>
+      </app-card>
     </div>
   `,
   styles: [`

--- a/requel-angular/src/app/shared/annotations-section.ts
+++ b/requel-angular/src/app/shared/annotations-section.ts
@@ -28,14 +28,16 @@ import { SelectModule } from 'primeng/select';
 import { MessageService } from 'primeng/api';
 import { AnnotationsDto, IssueDto, NoteDto, PositionDto, SUPPORT_LEVEL_OPTIONS } from '../models/annotation';
 import { AnnotationService } from '../core/annotation.service';
+import { AppCardComponent } from './app-card';
 
 @Component({
   selector: 'app-annotations-section',
   standalone: true,
-  imports: [FormsModule, ButtonModule, InputText, TextareaModule, CheckboxModule, SelectModule],
+  imports: [FormsModule, ButtonModule, InputText, TextareaModule, CheckboxModule, SelectModule, AppCardComponent],
   template: `
     @if (entityId != null) {
       <div class="annotations-section" data-testid="annotations-section">
+        <app-card>
         <div class="section-header">
           <h3>Annotations</h3>
           @if (canEdit) {
@@ -213,6 +215,7 @@ import { AnnotationService } from '../core/annotation.service';
         @if (annotations().notes.length === 0 && annotations().issues.length === 0 && !showNoteForm() && !showIssueForm()) {
           <p class="empty-text">No annotations.</p>
         }
+        </app-card>
       </div>
     }
   `,

--- a/requel-angular/src/app/shared/app-card.spec.ts
+++ b/requel-angular/src/app/shared/app-card.spec.ts
@@ -1,0 +1,64 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { AppCardComponent } from './app-card';
+
+@Component({
+  standalone: true,
+  imports: [AppCardComponent],
+  template: `
+    <app-card [title]="title">
+      <p data-testid="card-body">Body content</p>
+    </app-card>`
+})
+class BodyHostComponent {
+  title = '';
+}
+
+@Component({
+  standalone: true,
+  imports: [AppCardComponent],
+  template: `
+    <app-card [title]="title">
+      <button actions data-testid="card-action">New</button>
+      <p data-testid="card-body">Body content</p>
+    </app-card>`
+})
+class TitledHostComponent {
+  title = 'Details';
+}
+
+describe('AppCardComponent (issue #156)', () => {
+  it('renders the card surface and projected body content', () => {
+    TestBed.configureTestingModule({ imports: [BodyHostComponent] });
+    const fixture = TestBed.createComponent(BodyHostComponent);
+    fixture.detectChanges();
+
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelector('section.app-card')).not.toBeNull();
+    expect(el.querySelector('[data-testid="card-body"]')?.textContent?.trim()).toBe(
+      'Body content'
+    );
+  });
+
+  it('does not render a card header (or <h2>) when no title is set', () => {
+    TestBed.configureTestingModule({ imports: [BodyHostComponent] });
+    const fixture = TestBed.createComponent(BodyHostComponent);
+    fixture.detectChanges();
+
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelector('.app-card-header')).toBeNull();
+    expect(el.querySelectorAll('h2').length).toBe(0);
+  });
+
+  it('renders the title as an <h2> and projects the [actions] slot when titled', () => {
+    TestBed.configureTestingModule({ imports: [TitledHostComponent] });
+    const fixture = TestBed.createComponent(TitledHostComponent);
+    fixture.detectChanges();
+
+    const el: HTMLElement = fixture.nativeElement;
+    const h2 = el.querySelector('h2.app-card-title');
+    expect(h2?.textContent?.trim()).toBe('Details');
+    expect(h2?.classList.contains('rq-section-title')).toBe(true);
+    expect(el.querySelector('[data-testid="card-action"]')?.textContent?.trim()).toBe('New');
+  });
+});

--- a/requel-angular/src/app/shared/app-card.ts
+++ b/requel-angular/src/app/shared/app-card.ts
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import { Component, Input } from '@angular/core';
+
+/**
+ * Shared card / content-surface primitive (issue #156). The single white
+ * rounded card that every content block (list tables, editor forms, the
+ * annotations panel, the auth card) renders inside, so the surface look
+ * (hairline border, 6px radius, very soft shadow, generous padding) lives in
+ * one place instead of being duplicated per view.
+ *
+ * All surface styling reads from the `--rq-card-*` tokens in `styles.scss`; the
+ * component holds no color/radius/shadow literals.
+ *
+ * API (mirrors `list-page`/`page-header` for consistency):
+ * - `title` — optional section heading (an `<h2>`, section-title type role). The
+ *   optional card header only renders when a title is set; most cards leave it
+ *   empty because the page's single `<h1>` is owned by `page-header` above the
+ *   card, avoiding a competing heading. Use `title` only for a genuinely titled
+ *   sub-surface.
+ * - `[actions]` slot — inline actions shown at the right of the card header
+ *   (only rendered alongside a title; actions-without-title is intentionally out
+ *   of scope for the #156 sweep).
+ * - default content — the card body.
+ *
+ * Nesting: a surface is a single `app-card`. Inner bordered blocks (e.g. the
+ * annotations rows, the scenario step list) stay plain bordered elements inside
+ * the one card — they must not become nested `app-card`s.
+ */
+@Component({
+  selector: 'app-card',
+  standalone: true,
+  template: `
+    <section class="app-card">
+      @if (title) {
+        <header class="app-card-header">
+          <h2 class="rq-section-title app-card-title">{{ title }}</h2>
+          <div class="app-card-actions"><ng-content select="[actions]" /></div>
+        </header>
+      }
+      <div class="app-card-body"><ng-content /></div>
+    </section>
+  `,
+  styles: [`
+    :host { display: block; }
+    .app-card {
+      background: var(--rq-card-bg);
+      border: 1px solid var(--rq-card-border);
+      border-radius: var(--rq-card-radius);
+      box-shadow: var(--rq-card-shadow);
+      padding: var(--rq-card-pad);
+    }
+    .app-card-header {
+      display: flex; justify-content: space-between; align-items: center;
+      gap: var(--rq-space-4); margin-bottom: var(--rq-space-4);
+    }
+    .app-card-title { margin: 0; }
+    .app-card-actions { display: flex; align-items: center; gap: var(--rq-space-2); }
+  `]
+})
+export class AppCardComponent {
+  /** Optional section heading for the card (rendered as an <h2>). */
+  @Input() title = '';
+}

--- a/requel-angular/src/app/shared/list-page.ts
+++ b/requel-angular/src/app/shared/list-page.ts
@@ -21,11 +21,12 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { InputText } from 'primeng/inputtext';
 import { PageHeaderComponent } from './page-header';
+import { AppCardComponent } from './app-card';
 
 @Component({
   selector: 'app-list-page',
   standalone: true,
-  imports: [PageHeaderComponent, InputText],
+  imports: [PageHeaderComponent, InputText, AppCardComponent],
   template: `
     <div class="list-page-wrap">
       <div class="page-header">
@@ -44,7 +45,7 @@ import { PageHeaderComponent } from './page-header';
           </span>
         </div>
       }
-      <ng-content />
+      <app-card><ng-content /></app-card>
     </div>
   `,
   // Compact, consistent list-page toolbar (issue #127): the title/actions row

--- a/requel-angular/src/styles.scss
+++ b/requel-angular/src/styles.scss
@@ -84,6 +84,20 @@
   --rq-header-bg: var(--p-primary-900);
   --rq-header-fg: var(--p-surface-0);
 
+  // Card / content surface (issue #156). The single source of truth for the
+  // white rounded card used by list and editor shells. Values alias the shared
+  // scale so the card has no independent magic numbers: bg/border read the
+  // Slate surface ramp from the #125 preset (so light/future-dark theming flows
+  // through), radius = md (6px), padding = space-4 (1rem). The soft shadow is
+  // the one card-specific literal — there is no shadow scale yet; if one is
+  // added later, re-alias --rq-card-shadow to it.
+  --rq-card-bg: var(--p-surface-0);
+  --rq-card-border: var(--p-surface-200);
+  --rq-card-radius: var(--rq-radius-md);
+  --rq-card-pad: var(--rq-space-4);
+  --rq-card-shadow: 0 1px 2px rgba(15, 23, 42, 0.06),
+    0 1px 3px rgba(15, 23, 42, 0.04);
+
   // Minimum hit-area sizes for custom (non-PrimeNG) interactive controls
   // (issue #141, WCAG 2.2 SC 2.5.8 Target Size). `min` is the hard 24px floor
   // for controls packed inline among siblings (e.g. a chip's remove button);


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/156

Add app-card content-surface primitive and adopt it across list pages and editors (N3)

Extracts the repeated white card container into a single shared `app-card`
primitive driven by `--rq-card-*` tokens, then sweeps every content surface onto
it so there is no per-view card CSS duplication. Part of the look-and-feel
adoption epic #124 (item N3, see doc/124-lookandfeel-plan.md); implementation
plan in doc/156-app-card-plan.md.

Closes #156

requel-angular/src/styles.scss
- Add the card-surface token block (--rq-card-bg, --rq-card-border,
  --rq-card-radius, --rq-card-shadow, --rq-card-pad). Values alias the existing
  scale rather than introduce new literals: bg/border read the Slate surface ramp
  from the #125 preset, radius aliases --rq-radius-md (6px), pad maps to
  --rq-space-4. The soft shadow is the only card-specific literal (no shadow
  scale exists yet).

requel-angular/src/app/shared/app-card.ts (new)
- Standalone app-card component. Optional @Input() title renders a section <h2>
  (only when set, so it never competes with the page-header <h1>), an [actions]
  projection slot for inline card-header actions, and default content for the
  body. All surface styling reads from the --rq-card-* tokens; no literals.

requel-angular/src/app/shared/app-card.spec.ts (new)
- Covers body projection, header/<h2> shown only when titled, and [actions]
  projection.

requel-angular/src/app/shared/list-page.ts
- Option A wiring: wrap the shared list shell's default content slot in app-card,
  so all 11 list pages (goals, projects, terms, open-issues, stakeholders,
  use-cases, stories, users, actors, scenarios, reports) get the card surface
  from one edit. Title/actions/search toolbar stay above the card, matching the
  plan's data-table pattern.

11 editors (goal, project, term, stakeholder, use-case, story, user, actor,
scenario, report)
- Wrap the primary edit form (form-grid + save action, or the whole <form> for
  project/user) in app-card. data-testids and the error <p-message> are
  preserved; the message stays above the card. Secondary table sections
  (relations, referenced-by, etc.) are intentionally left for the data-table
  pattern work (#129 / N4) and remain siblings below the form card.

requel-angular/src/app/shared/annotations-section.ts
- Wrap the section body in one app-card. Inner .annotation / .add-form rows keep
  their own borders as plain list items — no nested cards (per the issue's
  no-nested-card rule).

requel-angular/src/app/features/auth/login.ts
- Convert the bespoke .login-card (its own padding/8px radius/shadow) to
  app-card; only the login-specific width constraint remains in component CSS.
  Card radius moves to the token-driven 6px.

doc/156-app-card-plan.md (new)
- Implementation plan and locked decisions.

Verification: `ng build` (development) compiles clean — all templates and imports
wire up. Grep guard confirms no content-surface card CSS remains outside app-card
(only the allowed inner rows: scenario .step-list, annotations
.add-form/.annotation). Karma unit tests were not runnable in the build sandbox
(no browser); run `cd requel-angular && npm test -- --watch=false` in the dev
environment as the gate.
