### PR TITLE
155: Tag & Chip severity system as shared primitives (app-tag / app-chip)

### DIFF
--- a/doc/124-lookandfeel-plan.md
+++ b/doc/124-lookandfeel-plan.md
@@ -97,7 +97,7 @@ it as a runtime mix.
 | Existing sub-issue | Action | Addition |
 |---|---|---|
 | #125 — 1.1 stock Aura, no brand layer | **Update** | Pin the preset to the target tokens (Figtree 14px, `#3b82f6`, blue-tinted surfaces, 6px radius) |
-| #126 — 1.2 component-local CSS fragments consistency | **Update** | Card-surface + severity-tint tokens become the single source, replacing hard-coded colors |
+| #126 — 1.2 component-local CSS fragments consistency | **Done (PR #162)** | Descoped to the mechanical de-`ng-deep` / de-inline-style pass only; chip/badge/card **color** remediation and the severity-tint tokens were explicitly deferred to #155 (N2) and #156 (N3) |
 | #127 — 1.3 typography too flat | **Update** | Adopt Figtree + a defined type scale |
 | #128 — 2.1 project context hidden in sidebar | **Update** | Fold in the top-bar breadcrumb + grouped/collapsible sidebar chrome |
 | #129 — 2.2 inconsistent list/detail, over-relies on row selection | **Update** | Adopt the data-table pattern (toolbar + New, checkbox select, status tag, row `⋯` menu, paginator) |
@@ -172,13 +172,55 @@ a11y landmark checks from #135.
 
 ### N2 — Tag & Chip severity system as shared primitives · priority:medium
 Add `app-tag` and `app-chip` wrappers over PrimeNG Tag/Chip: soft-tinted background +
-colored text; variants default / pill / icon for severities
-`primary|success|info|warning|danger`; chips support leading icon/avatar and optional
-remove (×). Replace the ad-hoc hard-coded tag colors in `goal-list`,
-`annotations-section`, and `tag-selector`.
-**Acceptance.** One component renders every severity/variant from tokens; used for
-entity status, annotation kind, and tag chips; color is never the only signal (icon or
-text label present) to satisfy #141.
+colored text; variants default / pill / icon. Replace the ad-hoc hard-coded tag colors
+in `goal-list`, `annotations-section`, and `tag-selector`.
+
+**Tokens (owned by N2).** #126 was descoped and did **not** ship the severity-tint
+tokens — N2 defines them. Add a `--rq-tag-{tone}-bg` / `--rq-tag-{tone}-fg` (and matching
+`--rq-chip-*`) scale to `styles.scss`, sourced from the #125 preset ramps. The components
+hold no color literals — all tint/text color reads from these tokens.
+
+**Tones (6).** `primary | success | info | warning | danger | neutral`. `neutral` is
+added beyond the original five because `Position` badges and `Neutral`-support arguments
+are genuinely gray today (`surface-200`) and must stay visually distinct from the blue
+`info` Note badge.
+
+**Chips.** Leading icon **or avatar or image**, plus optional trailing remove (×). The
+avatar/image variants are built now (not deferred) — they are needed for upcoming
+stakeholder/user chips. Remove controls are real `<button>`s with an accessible name and
+an AA target size.
+
+**Generic tone → icon map (for the `icon` variant):**
+
+| Tone | Tint | Icon |
+|---|---|---|
+| `primary` | brand blue | `pi pi-tag` |
+| `success` | green | `pi pi-check-circle` |
+| `info` | sky | `pi pi-info-circle` |
+| `warning` | amber | `pi pi-exclamation-triangle` |
+| `danger` | red | `pi pi-times-circle` |
+| `neutral` | gray | `pi pi-minus-circle` |
+
+**Domain concept → tone / icon map** (replaces the current hard-coded badges):
+
+| Concept | Tone | Icon |
+|---|---|---|
+| Annotation: Note | `info` | `pi pi-comment` |
+| Issue (open) | `warning` | `pi pi-exclamation-triangle` |
+| Issue (resolved) | `success` | `pi pi-check-circle` |
+| Position | `neutral` | `pi pi-flag` |
+| Argument For / StronglyFor | `success` | `pi pi-thumbs-up` |
+| Argument Against / StronglyAgainst | `danger` | `pi pi-thumbs-down` |
+| Argument Neutral | `neutral` | `pi pi-minus-circle` |
+| Must Resolve | `danger` | `pi pi-exclamation-circle` |
+| Entity status — Active | `success` | `pi pi-check-circle` |
+| Entity status — Inactive | `danger` | `pi pi-ban` |
+
+**Acceptance.** One component renders every tone/variant from tokens; used for entity
+status, annotation kind, and tag chips; avatar/image chip variants implemented; remove
+controls have accessible names and AA target size; color is never the only signal (icon
+or text label always present) to satisfy #141; no tag/chip color literals remain in
+`goal-list`, `annotations-section`, or `tag-selector`.
 
 ### N3 — Card / content-surface primitive (`app-card`) · priority:low
 Extract the repeated card container (title slot, padding, border, radius, soft shadow)

--- a/requel-angular/src/app/features/goals/goal-list.ts
+++ b/requel-angular/src/app/features/goals/goal-list.ts
@@ -33,11 +33,12 @@ import { GoalService } from '../../core/goal.service';
 import { TagService } from '../../core/tag.service';
 import { PermissionService } from '../../core/permission.service';
 import { ListPageComponent } from '../../shared/list-page';
+import { AppChipComponent } from '../../shared/app-chip';
 
 @Component({
   selector: 'app-goal-list',
   standalone: true,
-  imports: [ListPageComponent, TableModule, ButtonModule, MessageModule, SelectModule, FormsModule, SlicePipe],
+  imports: [ListPageComponent, TableModule, ButtonModule, MessageModule, SelectModule, FormsModule, SlicePipe, AppChipComponent],
   template: `
     <app-list-page title="Goals" [eyebrow]="projectContext()" searchPlaceholder="Search goals..."
                    (search)="dt.filterGlobal($event, 'contains')">
@@ -73,7 +74,7 @@ import { ListPageComponent } from '../../shared/list-page';
             <td>
               <span class="chips" data-testid="goal-row-tags">
                 @for (t of tagsForGoal(g.id); track t.id) {
-                  <span class="tag-chip" [attr.data-tag]="label(t)">{{ label(t) }}</span>
+                  <app-chip [label]="label(t)" [tone]="'primary'" [attr.data-tag]="label(t)" />
                 }
               </span>
             </td>
@@ -90,9 +91,6 @@ import { ListPageComponent } from '../../shared/list-page';
     .text-preview { max-width: 400px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .tag-filter { min-width: 200px; }
     .chips { display: inline-flex; flex-wrap: wrap; gap: 0.3rem; }
-    .tag-chip { font-size: var(--rq-text-caption-size); font-weight: var(--rq-font-weight-semibold);
-      padding: 0.1rem 0.45rem; border-radius: 12px;
-      background: var(--p-primary-100, #dbeafe); color: var(--p-primary-700, #1d4ed8); white-space: nowrap; }
   `]
 })
 export class GoalListComponent implements OnInit, OnDestroy {

--- a/requel-angular/src/app/shared/annotations-section.spec.ts
+++ b/requel-angular/src/app/shared/annotations-section.spec.ts
@@ -271,12 +271,18 @@ describe('AnnotationsSectionComponent (method coverage)', () => {
     expect(annotationServiceMock.getAnnotations).toHaveBeenCalledTimes(2);
   });
 
-  it('getSupportClass() returns correct CSS class for support levels', () => {
-    expect(comp.getSupportClass('For')).toBe('arg-for');
-    expect(comp.getSupportClass('StronglyFor')).toBe('arg-for');
-    expect(comp.getSupportClass('Against')).toBe('arg-against');
-    expect(comp.getSupportClass('StronglyAgainst')).toBe('arg-against');
-    expect(comp.getSupportClass('Neutral')).toBe('arg-neutral');
+  it('supportTone() maps support levels to app-tag tones', () => {
+    expect(comp.supportTone('For')).toBe('success');
+    expect(comp.supportTone('StronglyFor')).toBe('success');
+    expect(comp.supportTone('Against')).toBe('danger');
+    expect(comp.supportTone('StronglyAgainst')).toBe('danger');
+    expect(comp.supportTone('Neutral')).toBe('neutral');
+  });
+
+  it('supportIcon() maps support levels to leading icons', () => {
+    expect(comp.supportIcon('For')).toBe('pi pi-thumbs-up');
+    expect(comp.supportIcon('StronglyAgainst')).toBe('pi pi-thumbs-down');
+    expect(comp.supportIcon('Neutral')).toBe('pi pi-minus-circle');
   });
 
   it('formatSupportLevel() returns label from SUPPORT_LEVEL_OPTIONS', () => {

--- a/requel-angular/src/app/shared/annotations-section.ts
+++ b/requel-angular/src/app/shared/annotations-section.ts
@@ -29,11 +29,13 @@ import { MessageService } from 'primeng/api';
 import { AnnotationsDto, IssueDto, NoteDto, PositionDto, SUPPORT_LEVEL_OPTIONS } from '../models/annotation';
 import { AnnotationService } from '../core/annotation.service';
 import { AppCardComponent } from './app-card';
+import { AppTagComponent } from './app-tag';
+import { RqTone, supportLevelIcon, supportLevelTone } from './severity';
 
 @Component({
   selector: 'app-annotations-section',
   standalone: true,
-  imports: [FormsModule, ButtonModule, InputText, TextareaModule, CheckboxModule, SelectModule, AppCardComponent],
+  imports: [FormsModule, ButtonModule, InputText, TextareaModule, CheckboxModule, SelectModule, AppCardComponent, AppTagComponent],
   template: `
     @if (entityId != null) {
       <div class="annotations-section" data-testid="annotations-section">
@@ -90,7 +92,7 @@ import { AppCardComponent } from './app-card';
         @for (note of annotations().notes; track note.id) {
           <div class="annotation note-item" data-testid="annotation-note">
             <div class="annotation-row">
-              <span class="annotation-badge note-badge" data-testid="annotation-note-badge">Note</span>
+              <app-tag data-testid="annotation-note-badge" [tone]="'info'" icon="pi pi-comment" label="Note" />
               <span class="annotation-text">{{ note.text }}</span>
               <span class="annotation-creator">{{ note.createdBy }}</span>
               @if (canEdit) {
@@ -107,12 +109,12 @@ import { AppCardComponent } from './app-card';
           <div class="annotation issue-item" data-testid="annotation-issue"
                [attr.data-resolved]="issue.resolved" [class.resolved]="issue.resolved">
             <div class="annotation-row">
-              <span class="annotation-badge issue-badge" data-testid="annotation-issue-badge"
-                    [class.resolved-badge]="issue.resolved">
-                {{ issue.resolved ? 'Resolved' : 'Issue' }}
-              </span>
+              <app-tag data-testid="annotation-issue-badge"
+                       [tone]="issue.resolved ? 'success' : 'warning'"
+                       [icon]="issue.resolved ? 'pi pi-check-circle' : 'pi pi-exclamation-triangle'"
+                       [label]="issue.resolved ? 'Resolved' : 'Issue'" />
               @if (issue.mustBeResolved && !issue.resolved) {
-                <span class="must-resolve-badge">Must Resolve</span>
+                <app-tag [tone]="'danger'" icon="pi pi-exclamation-circle" label="Must Resolve" />
               }
               <span class="annotation-text">{{ issue.text }}</span>
               <span class="annotation-creator">{{ issue.createdBy }}</span>
@@ -136,7 +138,7 @@ import { AppCardComponent } from './app-card';
             @for (pos of issue.positions; track pos.id) {
               <div class="position-item" data-testid="annotation-position">
                 <div class="annotation-row">
-                  <span class="annotation-badge position-badge" data-testid="annotation-position-badge">Position</span>
+                  <app-tag data-testid="annotation-position-badge" [tone]="'neutral'" icon="pi pi-flag" label="Position" />
                   <span class="annotation-text">{{ pos.text }}</span>
                   <span class="annotation-creator">{{ pos.createdBy }}</span>
                   @if (canEdit && !issue.resolved) {
@@ -156,9 +158,9 @@ import { AppCardComponent } from './app-card';
                 @for (arg of pos.arguments; track arg.id) {
                   <div class="argument-item" data-testid="annotation-argument">
                     <div class="annotation-row">
-                      <span class="annotation-badge" [class]="'arg-badge ' + getSupportClass(arg.supportLevel)">
-                        {{ formatSupportLevel(arg.supportLevel) }}
-                      </span>
+                      <app-tag [tone]="supportTone(arg.supportLevel)"
+                               [icon]="supportIcon(arg.supportLevel)"
+                               [label]="formatSupportLevel(arg.supportLevel)" />
                       <span class="annotation-text">{{ arg.text }}</span>
                       <span class="annotation-creator">{{ arg.createdBy }}</span>
                       @if (canEdit) {
@@ -233,25 +235,17 @@ import { AppCardComponent } from './app-card';
     .form-actions { display: flex; gap: 0.5rem; margin-top: 0.5rem; }
 
     .annotation { border: 1px solid var(--p-surface-200); border-radius: 6px; padding: 0.5rem 0.75rem; margin-bottom: 0.5rem; }
-    .note-item { border-left: 3px solid var(--p-primary-color); }
-    .issue-item { border-left: 3px solid var(--p-orange-500, #f97316); }
-    .issue-item.resolved { border-left-color: var(--p-green-500, #22c55e); opacity: 0.8; }
+    /* Left-border accents echo each item's app-tag tone (Note=info, Issue=warning,
+       Resolved=success) so the strip and the badge read as one, from the same tokens. */
+    .note-item { border-left: 3px solid var(--rq-tag-info-fg); }
+    .issue-item { border-left: 3px solid var(--rq-tag-warning-fg); }
+    .issue-item.resolved { border-left-color: var(--rq-tag-success-fg); opacity: 0.8; }
     .position-item { margin-left: 1.5rem; border-left: 3px solid var(--p-surface-400); padding: 0.4rem 0.75rem; margin-top: 0.4rem; }
     .argument-item { margin-left: 1.5rem; padding: 0.25rem 0.5rem; margin-top: 0.25rem; }
 
     .annotation-row { display: flex; align-items: baseline; gap: 0.5rem; flex-wrap: wrap; }
-    .annotation-badge { font-size: 0.7rem; font-weight: 600; padding: 0.1rem 0.4rem; border-radius: 3px; text-transform: uppercase; white-space: nowrap; }
-    .note-badge { background: var(--p-primary-100, #dbeafe); color: var(--p-primary-700, #1d4ed8); }
-    .issue-badge { background: var(--p-orange-100, #ffedd5); color: var(--p-orange-700, #c2410c); }
-    .resolved-badge { background: var(--p-green-100, #dcfce7); color: var(--p-green-700, #15803d); }
-    .position-badge { background: var(--p-surface-200); color: var(--p-text-secondary-color); }
-    .arg-badge { font-size: 0.65rem; }
-    .arg-for { background: var(--p-green-100, #dcfce7); color: var(--p-green-700, #15803d); }
-    .arg-against { background: var(--p-red-100, #fee2e2); color: var(--p-red-700, #b91c1c); }
-    .arg-neutral { background: var(--p-surface-200); color: var(--p-text-secondary-color); }
-    .must-resolve-badge { font-size: 0.65rem; background: var(--p-red-100, #fee2e2); color: var(--p-red-700); padding: 0.1rem 0.4rem; border-radius: 3px; }
     .resolution-row { display: flex; align-items: baseline; gap: 0.4rem; margin-top: 0.25rem; font-size: 0.8rem; flex-wrap: wrap; }
-    .resolution-label { font-weight: 600; color: var(--p-green-700, #15803d); white-space: nowrap; }
+    .resolution-label { font-weight: 600; color: var(--rq-tag-success-fg); white-space: nowrap; }
     .resolution-text { color: var(--p-text-color); font-style: italic; }
 
     .annotation-text { flex: 1; }
@@ -403,10 +397,14 @@ export class AnnotationsSectionComponent implements OnChanges {
     }
   }
 
-  getSupportClass(supportLevel: string): string {
-    if (supportLevel === 'StronglyFor' || supportLevel === 'For') return 'arg-for';
-    if (supportLevel === 'StronglyAgainst' || supportLevel === 'Against') return 'arg-against';
-    return 'arg-neutral';
+  /** Argument support level -> app-tag tone (see severity.ts / the N2 mapping). */
+  supportTone(supportLevel: string): RqTone {
+    return supportLevelTone(supportLevel);
+  }
+
+  /** Argument support level -> app-tag leading icon. */
+  supportIcon(supportLevel: string): string {
+    return supportLevelIcon(supportLevel);
   }
 
   formatSupportLevel(level: string): string {

--- a/requel-angular/src/app/shared/app-chip.spec.ts
+++ b/requel-angular/src/app/shared/app-chip.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import { TestBed } from '@angular/core/testing';
+import { AppChipComponent } from './app-chip';
+
+describe('AppChipComponent (issue #155)', () => {
+  function render(inputs: Partial<AppChipComponent>): { el: HTMLElement; cmp: AppChipComponent } {
+    const fixture = TestBed.createComponent(AppChipComponent);
+    Object.assign(fixture.componentInstance, inputs);
+    fixture.detectChanges();
+    return { el: fixture.nativeElement as HTMLElement, cmp: fixture.componentInstance };
+  }
+
+  it('renders the label and defaults to the neutral tone', () => {
+    const { el } = render({ label: 'Priority' });
+    expect(el.querySelector('.rq-chip-label')?.textContent?.trim()).toBe('Priority');
+    expect(el.querySelector('.rq-chip')?.classList).toContain('rq-chip--neutral');
+  });
+
+  it('applies a tone class when a tone is set', () => {
+    expect(render({ label: 'x', tone: 'primary' }).el.querySelector('.rq-chip')?.classList)
+      .toContain('rq-chip--primary');
+  });
+
+  it('shows a colour dot when dotColor is set and no icon/avatar/image', () => {
+    const dot = render({ label: 'x', dotColor: '#ff0000' }).el.querySelector('.rq-chip-dot') as HTMLElement;
+    expect(dot).not.toBeNull();
+    expect(dot.style.background).toContain('rgb(255, 0, 0)');
+  });
+
+  it('prefers icon over dot, and image over avatar', () => {
+    const iconEl = render({ label: 'x', icon: 'pi pi-tag', dotColor: '#000' }).el;
+    expect(iconEl.querySelector('.rq-chip-icon')).not.toBeNull();
+    expect(iconEl.querySelector('.rq-chip-dot')).toBeNull();
+
+    const mediaEl = render({ label: 'x', avatarUrl: 'a.png', imageUrl: 'b.png' }).el;
+    expect(mediaEl.querySelector('.rq-chip-media')).not.toBeNull();
+    expect(mediaEl.querySelector('.rq-chip-avatar')).toBeNull();
+  });
+
+  it('renders no remove control unless removable', () => {
+    expect(render({ label: 'x' }).el.querySelector('.rq-chip-remove')).toBeNull();
+  });
+
+  it('renders an accessible remove button that emits remove', () => {
+    const { el, cmp } = render({ label: 'Beta', removable: true, removeAriaLabel: 'Remove tag Beta', removeTestid: 'tag-remove' });
+    const btn = el.querySelector('.rq-chip-remove') as HTMLButtonElement;
+    expect(btn).not.toBeNull();
+    expect(btn.getAttribute('aria-label')).toBe('Remove tag Beta');
+    expect(btn.getAttribute('data-testid')).toBe('tag-remove');
+
+    let emitted = false;
+    cmp.remove.subscribe(() => (emitted = true));
+    btn.click();
+    expect(emitted).toBe(true);
+  });
+});

--- a/requel-angular/src/app/shared/app-chip.ts
+++ b/requel-angular/src/app/shared/app-chip.ts
@@ -1,0 +1,106 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { RqTone } from './severity';
+
+/**
+ * Shared chip primitive (issue #155, N2). A rounded pill for entity labels/tags.
+ * Colours come from the `--rq-chip-*` (neutral default) and `--rq-tag-{tone}-*`
+ * (tone-coloured) tokens in `styles.scss` — the component holds no colour literals.
+ *
+ * Leading visual (first one set wins): `imageUrl` > `avatarUrl` > `icon` >
+ * `dotColor` (an arbitrary per-tag swatch, e.g. a user-defined tag colour). A
+ * chip may be `removable`, which renders a real `<button>` remove control with an
+ * accessible name (`removeAriaLabel`) and a >=24px hit area (issue #141,
+ * WCAG 2.5.8) while keeping the × glyph visually small.
+ *
+ * API:
+ * - `label` — visible chip text.
+ * - `tone` — `neutral` (default pill) | `primary | success | info | warning | danger`.
+ * - `icon` — leading PrimeIcon class.
+ * - `avatarUrl` / `imageUrl` — leading circular avatar / square media.
+ * - `dotColor` — leading colour swatch (overridden by icon/avatar/image if set).
+ * - `removable` + `remove` output — trailing × that emits `remove`.
+ * - `removeAriaLabel` — accessible name for the remove button.
+ * - `removeTestid` — optional data-testid forwarded to the remove button.
+ */
+@Component({
+  selector: 'app-chip',
+  standalone: true,
+  template: `
+    <span class="rq-chip" [class]="toneClass" [attr.data-tone]="tone">
+      @if (imageUrl) {
+        <img class="rq-chip-media" [src]="imageUrl" alt="" />
+      } @else if (avatarUrl) {
+        <img class="rq-chip-avatar" [src]="avatarUrl" alt="" />
+      } @else if (icon) {
+        <i class="rq-chip-icon" [class]="icon" aria-hidden="true"></i>
+      } @else if (dotColor) {
+        <span class="rq-chip-dot" [style.background]="dotColor"></span>
+      }
+      <span class="rq-chip-label">{{ label }}</span>
+      @if (removable) {
+        <button type="button" class="rq-chip-remove" [attr.aria-label]="removeAriaLabel"
+                [attr.data-testid]="removeTestid" (click)="remove.emit()">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      }
+    </span>
+  `,
+  styles: [`
+    .rq-chip { display: inline-flex; align-items: center; gap: 0.3rem;
+      font-size: var(--rq-text-caption-size); font-weight: var(--rq-font-weight-semibold);
+      line-height: 1.3; padding: 0.15rem 0.5rem; border-radius: 999px; white-space: nowrap; }
+    .rq-chip--neutral { background: var(--rq-chip-bg); color: var(--rq-chip-fg); }
+    .rq-chip--primary { background: var(--rq-tag-primary-bg); color: var(--rq-tag-primary-fg); }
+    .rq-chip--success { background: var(--rq-tag-success-bg); color: var(--rq-tag-success-fg); }
+    .rq-chip--info    { background: var(--rq-tag-info-bg);    color: var(--rq-tag-info-fg); }
+    .rq-chip--warning { background: var(--rq-tag-warning-bg); color: var(--rq-tag-warning-fg); }
+    .rq-chip--danger  { background: var(--rq-tag-danger-bg);  color: var(--rq-tag-danger-fg); }
+    .rq-chip-icon { font-size: 0.85em; line-height: 1; }
+    .rq-chip-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .rq-chip-avatar { width: 1.1rem; height: 1.1rem; border-radius: 50%; object-fit: cover; }
+    .rq-chip-media { width: 1.1rem; height: 1.1rem; border-radius: 3px; object-fit: cover; }
+    /* Packed inline control: 24px hit-area floor (issue #141, WCAG 2.5.8) via a
+       centred min-box; the glyph stays small so the chip keeps its dense look. */
+    .rq-chip-remove { display: inline-flex; align-items: center; justify-content: center;
+      min-width: var(--rq-target-min); min-height: var(--rq-target-min);
+      border: none; background: transparent; cursor: pointer; font-size: 0.9rem;
+      line-height: 1; color: inherit; padding: 0; margin: -0.15rem -0.35rem -0.15rem 0; }
+  `]
+})
+export class AppChipComponent {
+  @Input() label = '';
+  @Input() tone: RqTone = 'neutral';
+  @Input() icon?: string;
+  @Input() avatarUrl?: string;
+  @Input() imageUrl?: string;
+  @Input() dotColor?: string | null;
+  @Input() removable = false;
+  @Input() removeAriaLabel = 'Remove';
+  @Input() removeTestid?: string;
+
+  @Output() remove = new EventEmitter<void>();
+
+  get toneClass(): string {
+    return 'rq-chip--' + this.tone;
+  }
+}

--- a/requel-angular/src/app/shared/app-tag.spec.ts
+++ b/requel-angular/src/app/shared/app-tag.spec.ts
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import { TestBed } from '@angular/core/testing';
+import { AppTagComponent } from './app-tag';
+import { RQ_TONE_ICON, RqTone } from './severity';
+
+const TONES: RqTone[] = ['primary', 'success', 'info', 'warning', 'danger', 'neutral'];
+
+describe('AppTagComponent (issue #155)', () => {
+  function render(inputs: Partial<AppTagComponent>): HTMLElement {
+    const fixture = TestBed.createComponent(AppTagComponent);
+    Object.assign(fixture.componentInstance, inputs);
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  it('renders a visible label so colour is never the only signal (#141)', () => {
+    const el = render({ tone: 'warning', label: 'Issue' });
+    expect(el.querySelector('.rq-tag-label')?.textContent?.trim()).toBe('Issue');
+  });
+
+  it('applies the tone class and data-tone for every tone', () => {
+    for (const tone of TONES) {
+      const el = render({ tone, label: tone });
+      const tag = el.querySelector('.rq-tag');
+      expect(tag?.classList).toContain('rq-tag--' + tone);
+      expect(tag?.getAttribute('data-tone')).toBe(tone);
+    }
+  });
+
+  it('adds the pill modifier only for the pill variant', () => {
+    expect(render({ variant: 'pill', label: 'x' }).querySelector('.rq-tag')?.classList)
+      .toContain('rq-tag--pill');
+    expect(render({ variant: 'default', label: 'x' }).querySelector('.rq-tag')?.classList)
+      .not.toContain('rq-tag--pill');
+  });
+
+  it('falls back to the tone default icon for the icon variant', () => {
+    const el = render({ tone: 'success', variant: 'icon', label: 'Done' });
+    const icon = el.querySelector('.rq-tag-icon');
+    expect(icon).not.toBeNull();
+    for (const cls of RQ_TONE_ICON.success.split(' ')) {
+      expect(icon?.classList).toContain(cls);
+    }
+  });
+
+  it('prefers an explicit icon over the tone default, on any variant', () => {
+    const el = render({ tone: 'info', variant: 'default', icon: 'pi pi-comment', label: 'Note' });
+    expect(el.querySelector('.rq-tag-icon')?.classList).toContain('pi-comment');
+  });
+
+  it('renders no icon for the default variant when none is supplied', () => {
+    expect(render({ label: 'x' }).querySelector('.rq-tag-icon')).toBeNull();
+  });
+});

--- a/requel-angular/src/app/shared/app-tag.ts
+++ b/requel-angular/src/app/shared/app-tag.ts
@@ -1,0 +1,87 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import { Component, Input } from '@angular/core';
+import { RQ_TONE_ICON, RqTagVariant, RqTone } from './severity';
+
+/**
+ * Shared severity tag primitive (issue #155, N2). A soft-tinted status tag whose
+ * background/text colour comes entirely from the `--rq-tag-{tone}-*` tokens in
+ * `styles.scss` — the component holds no colour literals. It is a token-driven
+ * element rather than a pass-through to PrimeNG `p-tag` on purpose: `p-tag`'s
+ * severity styling does not offer the soft-tint look or the sixth `neutral` tone
+ * the Requel design calls for, so the tint system lives here while radius/spacing
+ * still read the shared `--rq-*` scale for consistency with the rest of Aura.
+ *
+ * Accessibility (issue #141): a tag always carries a visible text {@link label},
+ * so colour is never the only signal. The `icon` variant adds a leading icon; any
+ * variant may also be given an explicit {@link icon} (used for domain meanings
+ * like Note = `pi pi-comment`). Icons are decorative (`aria-hidden`) — the label
+ * is the accessible text.
+ *
+ * API:
+ * - `tone` — one of `primary | success | info | warning | danger | neutral`.
+ * - `variant` — `default` (rounded rect) | `pill` (fully rounded) | `icon`
+ *   (leading icon; falls back to the tone's default icon when `icon` is unset).
+ * - `icon` — explicit PrimeIcon class (e.g. `pi pi-comment`); shown on any variant.
+ * - `label` — the visible tag text (required for the colour-only-signal guarantee).
+ */
+@Component({
+  selector: 'app-tag',
+  standalone: true,
+  template: `
+    <span class="rq-tag" [class]="toneClass" [class.rq-tag--pill]="variant === 'pill'"
+          [attr.data-tone]="tone">
+      @if (displayIcon) {
+        <i class="rq-tag-icon" [class]="displayIcon" aria-hidden="true"></i>
+      }
+      <span class="rq-tag-label">{{ label }}</span>
+    </span>
+  `,
+  styles: [`
+    .rq-tag { display: inline-flex; align-items: center; gap: var(--rq-space-1);
+      font-size: var(--rq-text-caption-size); font-weight: var(--rq-font-weight-semibold);
+      line-height: 1.3; padding: 0.1rem 0.45rem; border-radius: var(--rq-radius-md);
+      white-space: nowrap; }
+    .rq-tag--pill { border-radius: 999px; }
+    .rq-tag-icon { font-size: 0.85em; line-height: 1; }
+    .rq-tag--primary { background: var(--rq-tag-primary-bg); color: var(--rq-tag-primary-fg); }
+    .rq-tag--success { background: var(--rq-tag-success-bg); color: var(--rq-tag-success-fg); }
+    .rq-tag--info    { background: var(--rq-tag-info-bg);    color: var(--rq-tag-info-fg); }
+    .rq-tag--warning { background: var(--rq-tag-warning-bg); color: var(--rq-tag-warning-fg); }
+    .rq-tag--danger  { background: var(--rq-tag-danger-bg);  color: var(--rq-tag-danger-fg); }
+    .rq-tag--neutral { background: var(--rq-tag-neutral-bg); color: var(--rq-tag-neutral-fg); }
+  `]
+})
+export class AppTagComponent {
+  @Input() tone: RqTone = 'primary';
+  @Input() variant: RqTagVariant = 'default';
+  @Input() icon?: string;
+  @Input() label = '';
+
+  get toneClass(): string {
+    return 'rq-tag--' + this.tone;
+  }
+
+  /** Explicit icon wins; otherwise the `icon` variant falls back to the tone default. */
+  get displayIcon(): string | null {
+    return this.icon ?? (this.variant === 'icon' ? RQ_TONE_ICON[this.tone] : null);
+  }
+}

--- a/requel-angular/src/app/shared/severity.ts
+++ b/requel-angular/src/app/shared/severity.ts
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Shared severity-tint vocabulary for the `app-tag` / `app-chip` primitives
+ * (issue #155, N2). One source of truth for the tone set, the tag variants, and
+ * the generic tone -> icon defaults so every consumer maps the same way. Tint /
+ * text colours are not here — they live as `--rq-tag-*` / `--rq-chip-*` CSS
+ * tokens in `styles.scss`; this module is the TypeScript-side contract only.
+ */
+
+/**
+ * The six severity tones. `neutral` is beyond the classic five because genuinely
+ * non-severity labels (Position badges, Neutral-support arguments) are grey today
+ * and must stay visually distinct from the blue `info` tone.
+ */
+export type RqTone = 'primary' | 'success' | 'info' | 'warning' | 'danger' | 'neutral';
+
+/** Tag shape variants: default (rounded rect), pill (fully rounded), icon (leading icon). */
+export type RqTagVariant = 'default' | 'pill' | 'icon';
+
+/**
+ * Generic default PrimeIcon per tone, used by the `icon` tag variant when the
+ * caller does not supply a domain-specific icon. Callers with a domain meaning
+ * (Note, Issue, ...) pass their own icon instead (see the N2 mapping table in
+ * `doc/124-lookandfeel-plan.md`).
+ */
+export const RQ_TONE_ICON: Record<RqTone, string> = {
+  primary: 'pi pi-tag',
+  success: 'pi pi-check-circle',
+  info: 'pi pi-info-circle',
+  warning: 'pi pi-exclamation-triangle',
+  danger: 'pi pi-times-circle',
+  neutral: 'pi pi-minus-circle',
+};
+
+/**
+ * Annotation argument support level -> tone. For/StronglyFor read as success,
+ * Against/StronglyAgainst as danger, everything else (Neutral) as neutral.
+ */
+export function supportLevelTone(supportLevel: string): RqTone {
+  if (supportLevel === 'StronglyFor' || supportLevel === 'For') return 'success';
+  if (supportLevel === 'StronglyAgainst' || supportLevel === 'Against') return 'danger';
+  return 'neutral';
+}
+
+/** Domain icon for an argument support level, paired with {@link supportLevelTone}. */
+export function supportLevelIcon(supportLevel: string): string {
+  const tone = supportLevelTone(supportLevel);
+  if (tone === 'success') return 'pi pi-thumbs-up';
+  if (tone === 'danger') return 'pi pi-thumbs-down';
+  return 'pi pi-minus-circle';
+}

--- a/requel-angular/src/app/shared/tag-selector.ts
+++ b/requel-angular/src/app/shared/tag-selector.ts
@@ -25,6 +25,7 @@ import { InputText } from 'primeng/inputtext';
 import { MessageService } from 'primeng/api';
 import { TagCategoryDto, TagDto, tagLabel } from '../models/tag';
 import { TagService } from '../core/tag.service';
+import { AppChipComponent } from './app-chip';
 
 /**
  * Reusable tag chip/selector for any taggable entity. Shows the entity's assigned tags as
@@ -34,7 +35,7 @@ import { TagService } from '../core/tag.service';
 @Component({
   selector: 'app-tag-selector',
   standalone: true,
-  imports: [FormsModule, ButtonModule, InputText],
+  imports: [FormsModule, ButtonModule, InputText, AppChipComponent],
   template: `
     @if (entityId != null) {
       <div class="tags-section" data-testid="tags-section">
@@ -42,16 +43,10 @@ import { TagService } from '../core/tag.service';
 
         <div class="chips" data-testid="tag-chips">
           @for (t of assigned(); track t.id) {
-            <span class="tag-chip" data-testid="tag-chip" [attr.data-tag]="label(t)">
-              @if (chipColor(t)) {
-                <span class="tag-dot" [style.background]="chipColor(t)"></span>
-              }
-              <span class="tag-chip-label">{{ label(t) }}</span>
-              @if (canEdit) {
-                <button type="button" class="chip-x" data-testid="tag-remove"
-                        [attr.aria-label]="'Remove tag ' + label(t)" (click)="removeTag(t)"><span aria-hidden="true">×</span></button>
-              }
-            </span>
+            <app-chip data-testid="tag-chip" [attr.data-tag]="label(t)" [label]="label(t)"
+                      [dotColor]="chipColor(t)" [removable]="canEdit"
+                      removeTestid="tag-remove" [removeAriaLabel]="'Remove tag ' + label(t)"
+                      (remove)="removeTag(t)" />
           }
           @if (assigned().length === 0) {
             <span class="empty-text">No tags.</span>
@@ -87,16 +82,6 @@ import { TagService } from '../core/tag.service';
     .section-header { margin-bottom: 0.5rem; }
     .section-header h3 { margin: 0; }
     .chips { display: flex; flex-wrap: wrap; gap: 0.4rem; align-items: center; }
-    .tag-chip { display: inline-flex; align-items: center; gap: 0.3rem; font-size: 0.75rem;
-      font-weight: 600; padding: 0.15rem 0.5rem; border-radius: 12px;
-      background: var(--p-primary-100, #dbeafe); color: var(--p-primary-700, #1d4ed8); }
-    .tag-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
-    /* Packed inline control: 24px hit-area floor (issue #141, WCAG 2.5.8) via a
-       centered min-box; the glyph stays small so the chip keeps its dense look. */
-    .chip-x { display: inline-flex; align-items: center; justify-content: center;
-      min-width: var(--rq-target-min); min-height: var(--rq-target-min);
-      border: none; background: transparent; cursor: pointer; font-size: 0.9rem;
-      line-height: 1; color: inherit; padding: 0; }
     .add-row { display: flex; align-items: center; gap: 0.5rem; margin-top: 0.75rem; flex-wrap: wrap; }
     .cat-input, .val-input { max-width: 200px; }
     .empty-text { color: var(--p-text-secondary-color); font-style: italic; }

--- a/requel-angular/src/styles.scss
+++ b/requel-angular/src/styles.scss
@@ -98,6 +98,34 @@
   --rq-card-shadow: 0 1px 2px rgba(15, 23, 42, 0.06),
     0 1px 3px rgba(15, 23, 42, 0.04);
 
+  // Tag / chip severity-tint system (issue #155, N2). The single source of truth
+  // for the soft-tinted status tags and chips (app-tag / app-chip). Each tone
+  // pairs a soft background tint with an AA-contrast text/icon colour, sourced
+  // from the Aura primitive ramps; the literal fallbacks mirror those ramp stops
+  // so tags still render if a primitive var is not emitted (same belt-and-braces
+  // the previous inline badges used). #126 was descoped and did not ship these —
+  // N2 owns them. Tones: primary | success | info | warning | danger | neutral.
+  // `neutral` exists for genuinely non-severity labels (Position badges,
+  // Neutral-support arguments) that must stay distinct from the blue `info` tone.
+  // Components hold no colour literals — they read only these tokens.
+  --rq-tag-primary-bg: var(--p-primary-100, #dbeafe);
+  --rq-tag-primary-fg: var(--p-primary-700, #1d4ed8);
+  --rq-tag-success-bg: var(--p-green-100, #dcfce7);
+  --rq-tag-success-fg: var(--p-green-700, #15803d);
+  --rq-tag-info-bg: var(--p-sky-100, #e0f2fe);
+  --rq-tag-info-fg: var(--p-sky-700, #0369a1);
+  --rq-tag-warning-bg: var(--p-amber-100, #fef3c7);
+  --rq-tag-warning-fg: var(--p-amber-800, #92400e);
+  --rq-tag-danger-bg: var(--p-red-100, #fee2e2);
+  --rq-tag-danger-fg: var(--p-red-700, #b91c1c);
+  --rq-tag-neutral-bg: var(--p-surface-200);
+  --rq-tag-neutral-fg: var(--p-text-secondary-color);
+
+  // Chip surface. The default chip is a neutral pill on the surface ramp; tone-
+  // coloured chips reuse the --rq-tag-* tints above.
+  --rq-chip-bg: var(--p-surface-100);
+  --rq-chip-fg: var(--p-text-color);
+
   // Minimum hit-area sizes for custom (non-PrimeNG) interactive controls
   // (issue #141, WCAG 2.2 SC 2.5.8 Target Size). `min` is the hard 24px floor
   // for controls packed inline among siblings (e.g. a chip's remove button);


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/155

N2: Tag & Chip severity system as shared primitives (app-tag / app-chip)

Adds the token-driven severity-tint system called out in doc/124-lookandfeel-plan.md
(N2) and migrates the three components that carried ad-hoc hard-coded tag/badge/chip
colors onto the new shared primitives. The severity-tint tokens were explicitly
deferred here from #126 (PR #162 shipped only the de-ng-deep/de-inline-style pass), so
this change owns them.

Tones: primary | success | info | warning | danger | neutral. `neutral` is added
beyond the classic five so genuinely non-severity labels (Position badges,
Neutral-support arguments) stay visually distinct from the blue `info` tone. Color is
never the only signal — every tag/chip carries a visible text label (plus an optional
icon), satisfying #141.

requel-angular/src/styles.scss
- New --rq-tag-{tone}-bg/fg scale (6 tones) and --rq-chip-bg/fg, sourced from the #125
  preset ramps with AA-mirroring literal fallbacks. This is the single source of truth
  for tag/chip color; components hold no color literals.

requel-angular/src/app/shared/severity.ts (new)
- Shared TS contract: RqTone, RqTagVariant, RQ_TONE_ICON (generic tone->icon map), and
  supportLevelTone()/supportLevelIcon() for the annotation argument mapping.

requel-angular/src/app/shared/app-tag.ts (new) + app-tag.spec.ts (new)
- Soft-tinted status tag primitive. Inputs: tone, variant (default/pill/icon), icon,
  label. Renders every tone/variant from tokens; icon variant falls back to the tone
  default icon; explicit icon wins on any variant.

requel-angular/src/app/shared/app-chip.ts (new) + app-chip.spec.ts (new)
- Rounded-pill chip primitive. Leading icon/avatar/image or color dot (precedence
  image>avatar>icon>dot), optional trailing remove (real <button>, accessible name,
  >=24px hit area per #141/WCAG 2.5.8). Neutral default; tone-colored via --rq-tag-*.

requel-angular/src/app/features/goals/goal-list.ts
- Row tag chips now render via <app-chip [tone]="'primary'">; dropped the local
  .tag-chip color literals.

requel-angular/src/app/shared/tag-selector.ts
- Assigned-tag chips render via <app-chip> with the per-tag color dot and the removable
  control; preserves the tag-chip / tag-remove testids and aria-labels. Dropped the
  local .tag-chip/.tag-dot/.chip-x styles.

requel-angular/src/app/shared/annotations-section.ts
- Note/Issue/Resolved/Position/Must-Resolve/Argument badges render via <app-tag> with
  the N2 domain tone+icon mapping; preserves the annotation-*-badge testids the e2e
  suite asserts. Left-border accents and the resolution label now read the --rq-tag-*
  tone tokens instead of orange/green literals. getSupportClass() replaced by
  supportTone()/supportIcon() delegating to severity.ts.

requel-angular/src/app/shared/annotations-section.spec.ts
- Updated the support-level test from getSupportClass (CSS class) to supportTone/
  supportIcon (tone + icon).

Verification: `tsc -p tsconfig.spec.json --noEmit` clean; `ng build` (strictTemplates
AOT template typecheck) generates the bundle with no diagnostics. Karma unit run
(npm test -- --watch=false) still to be run in a Chrome-capable environment.

Closes #155
