### PR TITLE
131: Shared loading, empty, and error states

### DIFF
--- a/requel-angular/e2e/pages/BaseListPage.ts
+++ b/requel-angular/e2e/pages/BaseListPage.ts
@@ -25,7 +25,11 @@ export abstract class BaseListPage {
   }
 
   protected async clickNewButton(buttonName: string, targetUrl: string): Promise<void> {
-    await this.page.locator('app-list-page').getByRole('button', { name: buttonName }).click();
+    // Target the list-header action, which precedes the table in the DOM. An
+    // empty list also renders an app-empty-state CTA with the same label (e.g.
+    // "New Goal"), so match the first (header) button to avoid a strict-mode
+    // double-match when the list is empty (issue #131).
+    await this.page.locator('app-list-page').getByRole('button', { name: buttonName }).first().click();
     await this.page.waitForURL(targetUrl);
   }
 

--- a/requel-angular/e2e/pages/ProjectsPage.ts
+++ b/requel-angular/e2e/pages/ProjectsPage.ts
@@ -67,7 +67,7 @@ export class ProjectsPage extends BaseListPage {
   }
 
   async expectNoProjectsMessage(): Promise<void> {
-    await expect(this.page.getByTestId('project-list-empty')).toContainText('No projects found.');
+    await expect(this.page.getByTestId('project-list-empty')).toContainText('No projects yet');
   }
 }
 

--- a/requel-angular/src/app/features/goals/goal-list.ts
+++ b/requel-angular/src/app/features/goals/goal-list.ts
@@ -34,11 +34,12 @@ import { TagService } from '../../core/tag.service';
 import { PermissionService } from '../../core/permission.service';
 import { ListPageComponent } from '../../shared/list-page';
 import { AppChipComponent } from '../../shared/app-chip';
+import { EmptyStateComponent } from '../../shared/empty-state';
 
 @Component({
   selector: 'app-goal-list',
   standalone: true,
-  imports: [ListPageComponent, TableModule, ButtonModule, MessageModule, SelectModule, FormsModule, SlicePipe, AppChipComponent],
+  imports: [ListPageComponent, TableModule, ButtonModule, MessageModule, SelectModule, FormsModule, SlicePipe, AppChipComponent, EmptyStateComponent],
   template: `
     <app-list-page title="Goals" [eyebrow]="projectContext()" searchPlaceholder="Search goals..."
                    (search)="dt.filterGlobal($event, 'contains')">
@@ -82,7 +83,20 @@ import { AppChipComponent } from '../../shared/app-chip';
           </tr>
         </ng-template>
         <ng-template #emptymessage>
-          <tr><td colspan="4" class="text-center">No goals found.</td></tr>
+          <tr>
+            <td colspan="4">
+              @if (selectedTagId() != null) {
+                <app-empty-state title="No goals match this tag"
+                                 message="Try clearing the tag filter to see all goals."
+                                 icon="pi-filter-slash" testid="goal-list-empty" />
+              } @else {
+                <app-empty-state title="No goals yet"
+                                 message="Capture the objectives this project needs to meet."
+                                 icon="pi-flag" actionLabel="New Goal" [showAction]="canEdit()"
+                                 testid="goal-list-empty" (action)="onNewGoal()" />
+              }
+            </td>
+          </tr>
         </ng-template>
       </p-table>
     </app-list-page>

--- a/requel-angular/src/app/features/projects/project-editor.ts
+++ b/requel-angular/src/app/features/projects/project-editor.ts
@@ -39,11 +39,13 @@ import { UserService } from '../../core/user.service';
 import { CommandService } from '../../core/command.service';
 import { PermissionService } from '../../core/permission.service';
 import { TagSelectorComponent } from '../../shared/tag-selector';
+import { LoadingStateComponent } from '../../shared/loading-state';
+import { ErrorStateComponent } from '../../shared/error-state';
 
 @Component({
   selector: 'app-project-editor',
   standalone: true,
-  imports: [PageHeaderComponent, AppCardComponent, FormsModule, InputText, TextareaModule, ButtonModule, SelectModule, MessageModule, ConfirmDialogModule, TagSelectorComponent],
+  imports: [PageHeaderComponent, AppCardComponent, FormsModule, InputText, TextareaModule, ButtonModule, SelectModule, MessageModule, ConfirmDialogModule, TagSelectorComponent, LoadingStateComponent, ErrorStateComponent],
   providers: [ConfirmationService],
   template: `
     <div class="project-editor" data-testid="project-editor">
@@ -65,43 +67,52 @@ import { TagSelectorComponent } from '../../shared/tag-selector';
         <p-message severity="success" [text]="successMessage()!" />
       }
 
-      <app-card>
-        <form #projectForm="ngForm" (ngSubmit)="onSave()">
-          <div class="form-grid">
-            <div class="field">
-              <label for="name">Project Name</label>
-              <input pInputText id="name" [(ngModel)]="name" name="name" required />
+      @if (loading()) {
+        <app-card>
+          <app-loading-state label="Loading project…" [lines]="4" testid="project-editor-loading" />
+        </app-card>
+      } @else if (loadError()) {
+        <app-error-state [message]="loadError()!" testid="project-editor-load-error"
+                         (retry)="retryLoad()" />
+      } @else {
+        <app-card>
+          <form #projectForm="ngForm" (ngSubmit)="onSave()">
+            <div class="form-grid">
+              <div class="field">
+                <label for="name">Project Name</label>
+                <input pInputText id="name" [(ngModel)]="name" name="name" required />
+              </div>
+
+              <div class="field">
+                <label for="org">Organization</label>
+                <p-select id="org" [(ngModel)]="selectedOrg" name="org"
+                          [options]="orgOptions()" optionLabel="label" optionValue="value"
+                          [editable]="true" placeholder="Select or type organization" />
+              </div>
+
+              <div class="field full-width">
+                <label for="description">Description</label>
+                <textarea pTextarea id="description" [(ngModel)]="description" name="description"
+                          [rows]="5" [autoResize]="true"></textarea>
+              </div>
             </div>
 
-            <div class="field">
-              <label for="org">Organization</label>
-              <p-select id="org" [(ngModel)]="selectedOrg" name="org"
-                        [options]="orgOptions()" optionLabel="label" optionValue="value"
-                        [editable]="true" placeholder="Select or type organization" />
+            <div class="actions">
+              <p-button type="submit" label="Save" icon="pi pi-check" data-testid="project-save"
+                        [loading]="saving()" [disabled]="!projectForm.dirty" />
+              <p-button label="Cancel" icon="pi pi-times" severity="secondary" data-testid="project-cancel"
+                        (onClick)="onCancel()" [outlined]="true" />
             </div>
+          </form>
+        </app-card>
 
-            <div class="field full-width">
-              <label for="description">Description</label>
-              <textarea pTextarea id="description" [(ngModel)]="description" name="description"
-                        [rows]="5" [autoResize]="true"></textarea>
-            </div>
-          </div>
-
-          <div class="actions">
-            <p-button type="submit" label="Save" icon="pi pi-check" data-testid="project-save"
-                      [loading]="saving()" [disabled]="!projectForm.dirty" />
-            <p-button label="Cancel" icon="pi pi-times" severity="secondary" data-testid="project-cancel"
-                      (onClick)="onCancel()" [outlined]="true" />
-          </div>
-        </form>
-      </app-card>
-
-      @if (!isNew()) {
-        <app-tag-selector
-          [projectName]="originalName()"
-          entityType="Project"
-          [entityId]="tagEntityId()"
-          [canEdit]="canEdit()" />
+        @if (!isNew()) {
+          <app-tag-selector
+            [projectName]="originalName()"
+            entityType="Project"
+            [entityId]="tagEntityId()"
+            [canEdit]="canEdit()" />
+        }
       }
     </div>
 
@@ -129,9 +140,13 @@ export class ProjectEditorComponent implements OnInit, OnDestroy, DirtyCheckable
   readonly saving = signal(false);
   readonly errorMessage = signal<string | null>(null);
   readonly successMessage = signal<string | null>(null);
+  // Load failures are tracked separately from save/inline errors so the
+  // retryable error state replaces the form only when the initial load fails.
+  readonly loadError = signal<string | null>(null);
   readonly originalName = signal('');
   private projectId: number | null = null;
   private projectVersion: number | null = null;
+  private lastNameParam: string | null = null;
 
   // Form fields
   name = '';
@@ -198,11 +213,18 @@ export class ProjectEditorComponent implements OnInit, OnDestroy, DirtyCheckable
     this.paramSub?.unsubscribe();
   }
 
+  /** Re-run the last attempted load; wired to the error state's (retry) output. */
+  retryLoad(): void {
+    void this.loadProject(this.lastNameParam);
+  }
+
   private async loadProject(nameParam: string | null): Promise<void> {
     const newIsNew = nameParam === 'new' || !nameParam;
     this.isNew.set(newIsNew);
+    this.lastNameParam = nameParam;
     this.errorMessage.set(null);
     this.successMessage.set(null);
+    this.loadError.set(null);
     this.loading.set(true);
 
     try {
@@ -221,6 +243,10 @@ export class ProjectEditorComponent implements OnInit, OnDestroy, DirtyCheckable
         this.description = '';
         this.selectedOrg = null;
       }
+    } catch (err: unknown) {
+      // Previously uncaught: a failed load left a blank form with no feedback.
+      // Surface a retryable error state instead.
+      this.loadError.set(err instanceof Error ? err.message : 'Failed to load project.');
     } finally {
       this.loading.set(false);
       // Reset form dirty state after load

--- a/requel-angular/src/app/features/projects/project-list.ts
+++ b/requel-angular/src/app/features/projects/project-list.ts
@@ -28,11 +28,12 @@ import { ProjectService } from '../../core/project.service';
 import { AuthService } from '../../core/auth.service';
 import { ListPageComponent } from '../../shared/list-page';
 import { FileUploadButtonComponent } from '../../shared/file-upload-button';
+import { EmptyStateComponent } from '../../shared/empty-state';
 
 @Component({
   selector: 'app-project-list',
   standalone: true,
-  imports: [ListPageComponent, TableModule, ButtonModule, MessageModule, FileUploadButtonComponent],
+  imports: [ListPageComponent, TableModule, ButtonModule, MessageModule, FileUploadButtonComponent, EmptyStateComponent],
   template: `
     <app-list-page title="Projects" searchPlaceholder="Search projects..."
                    (search)="dt.filterGlobal($event, 'contains')">
@@ -81,7 +82,15 @@ import { FileUploadButtonComponent } from '../../shared/file-upload-button';
           </tr>
         </ng-template>
         <ng-template #emptymessage>
-          <tr data-testid="project-list-empty"><td colspan="8">No projects found.</td></tr>
+          <tr>
+            <td colspan="8">
+              <app-empty-state title="No projects yet"
+                               message="Create a project to start capturing goals, stories, and use cases — or import an existing one."
+                               icon="pi-folder-open" actionLabel="New Project"
+                               [showAction]="canCreateProjects()" testid="project-list-empty"
+                               (action)="onNewProject()" />
+            </td>
+          </tr>
         </ng-template>
       </p-table>
     </app-list-page>

--- a/requel-angular/src/app/features/scenarios/scenario-editor.spec.ts
+++ b/requel-angular/src/app/features/scenarios/scenario-editor.spec.ts
@@ -224,12 +224,30 @@ describe('ScenarioEditorComponent', () => {
     expect(router.navigate).toHaveBeenCalledWith(['/projects', 'proj1', 'scenarios']);
   });
 
-  it('errorMessage set when loadScenario fails', async () => {
+  it('loadError set (driving the retryable error state) when the initial load fails', async () => {
     scenarioServiceMock.getScenario.mockRejectedValue(new Error('Network error'));
     paramMap$.next(convertToParamMap({ name: 'proj1', scenarioId: '15' }));
     fixture.detectChanges();
     await flush();
-    expect(comp.errorMessage()).toBe('Failed to load scenario.');
+    // Initial (non-SSE) load failures surface the retryable error state, not the
+    // inline errorMessage banner (issue #131).
+    expect(comp.loadError()).toBe('Failed to load scenario.');
+    expect(comp.errorMessage()).toBeNull();
+    expect(comp.loading()).toBe(false);
+  });
+
+  it('retryLoad recovers from a failed initial load', async () => {
+    scenarioServiceMock.getScenario.mockRejectedValueOnce(new Error('Network error'));
+    paramMap$.next(convertToParamMap({ name: 'proj1', scenarioId: '15' }));
+    fixture.detectChanges();
+    await flush();
+    expect(comp.loadError()).toBe('Failed to load scenario.');
+
+    // A subsequent successful fetch clears the error and populates the form.
+    comp.retryLoad();
+    await flush();
+    expect(comp.loadError()).toBeNull();
+    expect(comp.name).toBe('Login Flow');
   });
 
   it('onSave sets errorMessage when command fails', async () => {

--- a/requel-angular/src/app/features/scenarios/scenario-editor.ts
+++ b/requel-angular/src/app/features/scenarios/scenario-editor.ts
@@ -44,6 +44,8 @@ import { PermissionService } from '../../core/permission.service';
 import { EventStreamService } from '../../core/event-stream.service';
 import { ScenarioSelectorDialogComponent, ScenarioRef } from '../../shared/scenario-selector-dialog';
 import { AnnotationsSectionComponent } from '../../shared/annotations-section';
+import { LoadingStateComponent } from '../../shared/loading-state';
+import { ErrorStateComponent } from '../../shared/error-state';
 
 const SCENARIO_TYPE_OPTIONS = [
   { label: 'Primary', value: 'Primary' },
@@ -67,7 +69,7 @@ interface StepNodeData {
   standalone: true,
   imports: [PageHeaderComponent, AppCardComponent, RouterLink, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
             MessageModule, DialogModule, ConfirmDialogModule, TooltipModule, DragDropModule,
-            ScenarioSelectorDialogComponent, AnnotationsSectionComponent],
+            ScenarioSelectorDialogComponent, AnnotationsSectionComponent, LoadingStateComponent, ErrorStateComponent],
   providers: [ConfirmationService],
   template: `
     <div class="scenario-editor" data-testid="scenario-editor">
@@ -93,6 +95,14 @@ interface StepNodeData {
         <p-message severity="error" [text]="errorMessage()!" />
       }
 
+      @if (loading()) {
+        <app-card>
+          <app-loading-state label="Loading scenario…" [lines]="4" testid="scenario-editor-loading" />
+        </app-card>
+      } @else if (loadError()) {
+        <app-error-state [message]="loadError()!" testid="scenario-editor-load-error"
+                         (retry)="retryLoad()" />
+      } @else {
       <app-card>
         <div class="form-grid">
           <label for="name">Name</label>
@@ -201,6 +211,7 @@ interface StepNodeData {
             </div>
           }
         </div>
+      }
       }
 
       <!-- Step detail edit dialog -->
@@ -311,6 +322,10 @@ export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckabl
   scenarioName = signal('');
   scenario = signal<ScenarioDto | null>(null);
   errorMessage = signal<string | null>(null);
+  loading = signal(true);
+  // Load failures tracked separately from save/SSE errors so the retryable
+  // error state replaces the form only when the initial load fails.
+  loadError = signal<string | null>(null);
   saving = signal(false);
   canEdit = signal(false);
   canDelete = signal(false);
@@ -368,6 +383,10 @@ export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckabl
         this.scenarioType = 'Primary';
         this.version = null;
         this.stepNodes.set([]);
+        // New scenarios don't load — resolve the loading/error state so the
+        // form renders immediately instead of the skeleton.
+        this.loading.set(false);
+        this.loadError.set(null);
       }
 
       await this.permissionService.loadForProject(this.projectName);
@@ -394,7 +413,19 @@ export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckabl
     this.sseSub?.unsubscribe();
   }
 
+  /** Re-run the initial load; wired to the error state's (retry) output. */
+  retryLoad(): void {
+    void this.loadScenario();
+  }
+
   private async loadScenario(fromSSE = false): Promise<void> {
+    // Only the user-initiated (non-SSE) load drives the skeleton / retryable
+    // error state; a background SSE refresh must not blank the form the user is
+    // looking at.
+    if (!fromSSE) {
+      this.loading.set(true);
+      this.loadError.set(null);
+    }
     try {
       const s = await this.scenarioService.getScenario(this.projectName, this.scenarioId!);
       // Don't overwrite unsaved user edits when called from an SSE notification.
@@ -417,7 +448,17 @@ export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckabl
       this.stepsSaveNeeded.set(false);
       this.stepNodes.set(this.stepsToNodes(s.steps ?? []));
     } catch {
-      this.errorMessage.set('Failed to load scenario.');
+      // A background refresh failure shows a non-blocking message; an initial
+      // load failure shows the retryable error state in place of the form.
+      if (fromSSE) {
+        this.errorMessage.set('Failed to load scenario.');
+      } else {
+        this.loadError.set('Failed to load scenario.');
+      }
+    } finally {
+      if (!fromSSE) {
+        this.loading.set(false);
+      }
     }
     if (this.scenarioId && !this.sseSub) {
       void this.eventStreamService.addSubscription('Scenario', this.scenarioId);

--- a/requel-angular/src/app/features/stakeholders/stakeholder-list.ts
+++ b/requel-angular/src/app/features/stakeholders/stakeholder-list.ts
@@ -28,11 +28,12 @@ import { StakeholderDto } from '../../models/stakeholder';
 import { StakeholderService } from '../../core/stakeholder.service';
 import { PermissionService } from '../../core/permission.service';
 import { ListPageComponent } from '../../shared/list-page';
+import { EmptyStateComponent } from '../../shared/empty-state';
 
 @Component({
   selector: 'app-stakeholder-list',
   standalone: true,
-  imports: [ListPageComponent, TableModule, ButtonModule, MessageModule],
+  imports: [ListPageComponent, TableModule, ButtonModule, MessageModule, EmptyStateComponent],
   template: `
     <app-list-page title="Stakeholders" searchPlaceholder="Search stakeholders..."
                    (search)="dt.filterGlobal($event, 'contains')">
@@ -73,7 +74,14 @@ import { ListPageComponent } from '../../shared/list-page';
           </tr>
         </ng-template>
         <ng-template #emptymessage>
-          <tr><td colspan="6" class="text-center">No stakeholders found.</td></tr>
+          <tr>
+            <td colspan="6">
+              <app-empty-state title="No stakeholders yet"
+                               message="Add the people and groups with a stake in this project to capture their perspectives."
+                               icon="pi-users" actionLabel="Add User" [showAction]="canEdit()"
+                               testid="stakeholder-list-empty" (action)="onNewUserStakeholder()" />
+            </td>
+          </tr>
         </ng-template>
       </p-table>
     </app-list-page>

--- a/requel-angular/src/app/features/users/user-editor.ts
+++ b/requel-angular/src/app/features/users/user-editor.ts
@@ -35,11 +35,13 @@ import { UserDto } from '../../models/user';
 import { RoleDto } from '../../models/role';
 import { UserService } from '../../core/user.service';
 import { CommandService } from '../../core/command.service';
+import { LoadingStateComponent } from '../../shared/loading-state';
+import { ErrorStateComponent } from '../../shared/error-state';
 
 @Component({
   selector: 'app-user-editor',
   standalone: true,
-  imports: [PageHeaderComponent, AppCardComponent, FormsModule, InputText, Password, ButtonModule, CheckboxModule, SelectModule, MessageModule],
+  imports: [PageHeaderComponent, AppCardComponent, FormsModule, InputText, Password, ButtonModule, CheckboxModule, SelectModule, MessageModule, LoadingStateComponent, ErrorStateComponent],
   template: `
     <div class="user-editor" data-testid="user-editor">
       <app-page-header [title]="isNew() ? 'New User' : 'Edit User: ' + username" />
@@ -51,6 +53,14 @@ import { CommandService } from '../../core/command.service';
         <p-message severity="success" [text]="successMessage()!" />
       }
 
+      @if (loading()) {
+        <app-card>
+          <app-loading-state label="Loading user…" [lines]="5" testid="user-editor-loading" />
+        </app-card>
+      } @else if (loadError()) {
+        <app-error-state [message]="loadError()!" testid="user-editor-load-error"
+                         (retry)="retryLoad()" />
+      } @else {
       <app-card>
         <form #userForm="ngForm" (ngSubmit)="onSave()">
           <div class="form-grid">
@@ -130,6 +140,7 @@ import { CommandService } from '../../core/command.service';
           </div>
         </form>
       </app-card>
+      }
     </div>
   `,
   styles: [`
@@ -155,6 +166,10 @@ export class UserEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
   readonly saving = signal(false);
   readonly errorMessage = signal<string | null>(null);
   readonly successMessage = signal<string | null>(null);
+  // Load failures tracked separately from save/inline errors so the retryable
+  // error state replaces the form only when the initial load fails.
+  readonly loadError = signal<string | null>(null);
+  private lastUsernameParam: string | null = null;
 
   // Form fields — plain properties so [(ngModel)] two-way binding works correctly.
   // readonly signals don't update via the (ngModelChange)="name=$event" write path.
@@ -205,8 +220,15 @@ export class UserEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
     this.paramSub?.unsubscribe();
   }
 
+  /** Re-run the last attempted load; wired to the error state's (retry) output. */
+  retryLoad(): void {
+    void this.loadData(this.lastUsernameParam);
+  }
+
   private async loadData(usernameParam: string | null): Promise<void> {
     this.loading.set(true);
+    this.loadError.set(null);
+    this.lastUsernameParam = usernameParam;
     this.userId = null;
     this.userVersion = 0;
     try {
@@ -233,6 +255,9 @@ export class UserEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
         // selectedPermissions set by the init loop above before populateForm runs.
         this.cdr.detectChanges();
       }
+    } catch (err: unknown) {
+      // Previously uncaught: a failed load left a blank form with no feedback.
+      this.loadError.set(err instanceof Error ? err.message : 'Failed to load user.');
     } finally {
       this.loading.set(false);
     }

--- a/requel-angular/src/app/shared/annotations-section.ts
+++ b/requel-angular/src/app/shared/annotations-section.ts
@@ -30,12 +30,13 @@ import { AnnotationsDto, IssueDto, NoteDto, PositionDto, SUPPORT_LEVEL_OPTIONS }
 import { AnnotationService } from '../core/annotation.service';
 import { AppCardComponent } from './app-card';
 import { AppTagComponent } from './app-tag';
+import { ErrorStateComponent } from './error-state';
 import { RqTone, supportLevelIcon, supportLevelTone } from './severity';
 
 @Component({
   selector: 'app-annotations-section',
   standalone: true,
-  imports: [FormsModule, ButtonModule, InputText, TextareaModule, CheckboxModule, SelectModule, AppCardComponent, AppTagComponent],
+  imports: [FormsModule, ButtonModule, InputText, TextareaModule, CheckboxModule, SelectModule, AppCardComponent, AppTagComponent, ErrorStateComponent],
   template: `
     @if (entityId != null) {
       <div class="annotations-section" data-testid="annotations-section">
@@ -53,6 +54,11 @@ import { RqTone, supportLevelIcon, supportLevelTone } from './severity';
             </div>
           }
         </div>
+
+        @if (loadError()) {
+          <app-error-state severity="warn" [message]="loadError()!" retryLabel="Retry"
+                           testid="annotations-load-error" (retry)="reload()" />
+        }
 
         <!-- Add Note form -->
         @if (showNoteForm()) {
@@ -261,6 +267,10 @@ export class AnnotationsSectionComponent implements OnChanges {
 
   private _annotations = signal<AnnotationsDto>({ notes: [], issues: [] });
   annotations = this._annotations.asReadonly();
+  // Non-blocking inline warning when the supplemental annotation load fails,
+  // instead of the previous silent swallow (issue #131).
+  private _loadError = signal<string | null>(null);
+  loadError = this._loadError.asReadonly();
 
   showNoteForm = signal(false);
   showIssueForm = signal(false);
@@ -287,13 +297,23 @@ export class AnnotationsSectionComponent implements OnChanges {
     }
   }
 
+  /** Re-run the annotation load; wired to the inline warning's (retry) output. */
+  reload(): void {
+    void this.load();
+  }
+
   private async load(): Promise<void> {
     if (!this.entityId) return;
     try {
       const data = await this.annotationService.getAnnotations(this.projectName, this.entityType, this.entityId);
       this._annotations.set(data);
+      this._loadError.set(null);
     } catch {
-      // Silently ignore load failures — annotations are supplemental
+      // Annotations are supplemental, so a failure must not block the editor — but
+      // it is no longer swallowed silently: surface a non-blocking inline warning
+      // so the lost capability is visible and retryable (issue #131). Annotations
+      // are central to requirements triage, so hiding a failure is costly.
+      this._loadError.set('Annotations could not be loaded.');
     }
   }
 

--- a/requel-angular/src/app/shared/empty-state.a11y.spec.ts
+++ b/requel-angular/src/app/shared/empty-state.a11y.spec.ts
@@ -1,0 +1,33 @@
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { EmptyStateComponent } from './empty-state';
+import { expectNoAxeViolations } from './testing/a11y';
+
+describe('EmptyStateComponent — accessibility', () => {
+  function render(inputs: Partial<EmptyStateComponent>) {
+    TestBed.configureTestingModule({
+      imports: [EmptyStateComponent],
+      providers: [provideNoopAnimations()],
+    });
+    const fixture = TestBed.createComponent(EmptyStateComponent);
+    Object.assign(fixture.componentInstance, inputs);
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  it('has no axe-core violations without an action', async () => {
+    const el = render({ title: 'No goals yet', message: 'Create your first goal.' });
+    await expectNoAxeViolations(el);
+  });
+
+  it('has no axe-core violations with a permitted action', async () => {
+    const el = render({
+      title: 'No goals yet',
+      message: 'Create your first goal.',
+      icon: 'pi-flag',
+      actionLabel: 'New Goal',
+      showAction: true,
+    });
+    await expectNoAxeViolations(el);
+  });
+});

--- a/requel-angular/src/app/shared/empty-state.spec.ts
+++ b/requel-angular/src/app/shared/empty-state.spec.ts
@@ -1,0 +1,42 @@
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { EmptyStateComponent } from './empty-state';
+
+describe('EmptyStateComponent (issue #131)', () => {
+  function render(inputs: Partial<EmptyStateComponent> = {}) {
+    TestBed.configureTestingModule({
+      imports: [EmptyStateComponent],
+      providers: [provideNoopAnimations()],
+    });
+    const fixture = TestBed.createComponent(EmptyStateComponent);
+    Object.assign(fixture.componentInstance, inputs);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('renders the title and guidance message', () => {
+    const el: HTMLElement = render({ title: 'No goals yet', message: 'Create your first goal.' }).nativeElement;
+    expect(el.querySelector('.empty-state__title')?.textContent?.trim()).toBe('No goals yet');
+    expect(el.querySelector('.empty-state__message')?.textContent?.trim()).toBe('Create your first goal.');
+  });
+
+  it('does not render a heading element (keeps page heading order intact)', () => {
+    const el: HTMLElement = render({ title: 'No goals yet' }).nativeElement;
+    expect(el.querySelectorAll('h1,h2,h3,h4,h5,h6').length).toBe(0);
+  });
+
+  it('hides the action when showAction is false even if a label is set', () => {
+    const el: HTMLElement = render({ title: 'Empty', actionLabel: 'New Goal', showAction: false }).nativeElement;
+    expect(el.querySelector('[data-testid="empty-state-action"]')).toBeNull();
+  });
+
+  it('shows the action when permitted and emits (action) on click', () => {
+    const fixture = render({ title: 'Empty', actionLabel: 'New Goal', showAction: true });
+    const spy = vi.fn();
+    fixture.componentInstance.action.subscribe(spy);
+    const btn = fixture.nativeElement.querySelector('[data-testid="empty-state-action"] button') as HTMLButtonElement;
+    expect(btn).not.toBeNull();
+    btn.click();
+    expect(spy).toHaveBeenCalledOnce();
+  });
+});

--- a/requel-angular/src/app/shared/empty-state.ts
+++ b/requel-angular/src/app/shared/empty-state.ts
@@ -1,0 +1,98 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ButtonModule } from 'primeng/button';
+
+/**
+ * Shared empty state (issue #131, UI/UX review Finding 2.4). Replaces bare "No X
+ * found." text with a titled block that gives guidance and, when the user is
+ * allowed to create, a call-to-action button.
+ *
+ * Permission gating: the host decides whether the action is shown by binding
+ * `[showAction]` to its existing permission check (e.g.
+ * `PermissionService.canEdit('Goal')` or `canCreateProjects`). A read-only user
+ * sees the guidance without a dead/forbidden button. The action only renders when
+ * `showAction` is true *and* an `actionLabel` is set.
+ *
+ * Heading: the title is a styled paragraph, not an `<h*>`, so dropping the block
+ * into a list/table body does not inject an out-of-order heading (the page's
+ * heading outline stays owned by `page-header`). Typography reads from the
+ * `--rq-text-*` role tokens; the component holds no font/colour literals.
+ *
+ * API:
+ * - `title` — short headline (e.g. "No goals yet").
+ * - `message` — one-line guidance on what to do next.
+ * - `icon` — optional PrimeNG icon name (e.g. "pi-flag"); omitted by default.
+ * - `actionLabel` / `actionIcon` — the CTA button text/icon.
+ * - `showAction` — host-provided permission gate for the CTA.
+ * - `(action)` — emitted when the CTA is clicked.
+ */
+@Component({
+  selector: 'app-empty-state',
+  standalone: true,
+  imports: [ButtonModule],
+  template: `
+    <div class="empty-state" [attr.data-testid]="testid">
+      @if (icon) {
+        <i class="empty-state__icon pi {{ icon }}" aria-hidden="true"></i>
+      }
+      <p class="empty-state__title rq-section-title">{{ title }}</p>
+      @if (message) {
+        <p class="empty-state__message rq-caption">{{ message }}</p>
+      }
+      @if (showAction && actionLabel) {
+        <p-button [label]="actionLabel" [icon]="actionIcon" size="small"
+                  data-testid="empty-state-action" (onClick)="action.emit()" />
+      }
+    </div>
+  `,
+  styles: [`
+    :host { display: block; }
+    .empty-state {
+      display: flex; flex-direction: column; align-items: center; text-align: center;
+      gap: var(--rq-space-2);
+      padding: var(--rq-space-8) var(--rq-space-4);
+    }
+    .empty-state__icon { font-size: 1.75rem; color: var(--rq-text-muted-color); }
+    .empty-state__title { margin: 0; }
+    .empty-state__message { margin: 0; max-width: 32rem; }
+    .empty-state p-button { margin-top: var(--rq-space-2); }
+  `]
+})
+export class EmptyStateComponent {
+  /** Short headline for the empty state. */
+  @Input() title = '';
+  /** One-line guidance on what to do next. */
+  @Input() message = '';
+  /** Optional PrimeNG icon name (e.g. "pi-flag"). */
+  @Input() icon = '';
+  /** CTA button label; the button only renders when this is set and showAction is true. */
+  @Input() actionLabel = '';
+  /** CTA button icon. */
+  @Input() actionIcon = 'pi pi-plus';
+  /** Host-provided permission gate for the CTA. */
+  @Input() showAction = false;
+  /** data-testid for the wrapper element. */
+  @Input() testid = 'empty-state';
+
+  /** Emitted when the CTA button is clicked. */
+  @Output() action = new EventEmitter<void>();
+}

--- a/requel-angular/src/app/shared/error-state.a11y.spec.ts
+++ b/requel-angular/src/app/shared/error-state.a11y.spec.ts
@@ -1,0 +1,32 @@
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { ErrorStateComponent } from './error-state';
+import { expectNoAxeViolations } from './testing/a11y';
+
+describe('ErrorStateComponent — accessibility', () => {
+  function render(inputs: Partial<ErrorStateComponent>) {
+    TestBed.configureTestingModule({
+      imports: [ErrorStateComponent],
+      providers: [provideNoopAnimations()],
+    });
+    const fixture = TestBed.createComponent(ErrorStateComponent);
+    Object.assign(fixture.componentInstance, inputs);
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  it('has no axe-core violations as a blocking error with retry', async () => {
+    const el = render({ message: 'Could not load project.' });
+    await expectNoAxeViolations(el);
+  });
+
+  it('has no axe-core violations as a non-blocking warning with detail', async () => {
+    const el = render({
+      message: 'You do not have permission to view this section.',
+      detail: 'Contact your project admin for access.',
+      severity: 'warn',
+      retryable: false,
+    });
+    await expectNoAxeViolations(el);
+  });
+});

--- a/requel-angular/src/app/shared/error-state.spec.ts
+++ b/requel-angular/src/app/shared/error-state.spec.ts
@@ -1,0 +1,56 @@
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { ErrorStateComponent } from './error-state';
+
+describe('ErrorStateComponent (issue #131)', () => {
+  function render(inputs: Partial<ErrorStateComponent> = {}) {
+    TestBed.configureTestingModule({
+      imports: [ErrorStateComponent],
+      providers: [provideNoopAnimations()],
+    });
+    const fixture = TestBed.createComponent(ErrorStateComponent);
+    Object.assign(fixture.componentInstance, inputs);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('shows the message and, by default, an alert role with a Retry button', () => {
+    const fixture = render({ message: 'Could not load project.' });
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelector('.error-state__message')?.textContent?.trim()).toBe('Could not load project.');
+    expect(el.querySelector('[role="alert"]')).not.toBeNull();
+    expect(el.querySelector('[data-testid="error-state-retry"]')).not.toBeNull();
+  });
+
+  it('emits (retry) when the Retry button is clicked', () => {
+    const fixture = render({ message: 'Boom' });
+    const spy = vi.fn();
+    fixture.componentInstance.retry.subscribe(spy);
+    const btn = fixture.nativeElement.querySelector('[data-testid="error-state-retry"] button') as HTMLButtonElement;
+    btn.click();
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it('renders warn severity as a polite status without a Retry button', () => {
+    const fixture = render({
+      message: 'Tags could not be loaded.',
+      severity: 'warn',
+      retryable: false,
+    });
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelector('[role="status"]')).not.toBeNull();
+    expect(el.querySelector('[role="alert"]')).toBeNull();
+    expect(el.querySelector('.error-state--warn')).not.toBeNull();
+    expect(el.querySelector('[data-testid="error-state-retry"]')).toBeNull();
+  });
+
+  it('shows optional support detail when provided', () => {
+    const fixture = render({
+      message: 'You do not have permission to view this section.',
+      detail: 'Contact your project admin for access.',
+      retryable: false,
+    });
+    expect(fixture.nativeElement.querySelector('[data-testid="error-state-detail"]')?.textContent?.trim())
+      .toBe('Contact your project admin for access.');
+  });
+});

--- a/requel-angular/src/app/shared/error-state.ts
+++ b/requel-angular/src/app/shared/error-state.ts
@@ -1,0 +1,115 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ButtonModule } from 'primeng/button';
+
+/**
+ * Shared failure state (issue #131, UI/UX review Finding 2.4). Two jobs, one
+ * component:
+ *
+ *  - `severity="error"` (default): the blocking failure for a whole editor/page
+ *    load — e.g. the artifact could not be fetched. Rendered as a `role="alert"`
+ *    so assistive tech announces it immediately, with a Retry button that lets
+ *    the host re-run its load method.
+ *  - `severity="warn"`: a *non-blocking* inline warning for a supplemental
+ *    section that failed to load (tags, annotations). Previously these failures
+ *    were swallowed silently; now the section renders this warning in place so a
+ *    lost capability is visible instead of hidden. Rendered as `role="status"`
+ *    (polite) so it does not interrupt.
+ *
+ * Retry contract: the component does not know how to reload — it emits `(retry)`
+ * and the host re-invokes its own existing load method (e.g.
+ * `(retry)="loadProject(originalName())"`). Set `retryable=false` to hide the
+ * button where a retry makes no sense (e.g. a permission denial).
+ *
+ * `detail` carries optional secondary/support text (a reason or a "contact your
+ * admin" hint) shown muted under the message. All colour reads from the
+ * `--rq-tag-danger-*` / `--rq-tag-warning-*` tint tokens; the component holds no
+ * colour literals.
+ */
+@Component({
+  selector: 'app-error-state',
+  standalone: true,
+  imports: [ButtonModule],
+  template: `
+    <div class="error-state" [class.error-state--warn]="severity === 'warn'"
+         [attr.role]="ariaRole" [attr.data-testid]="testid">
+      <i class="error-state__icon pi {{ iconClass }}" aria-hidden="true"></i>
+      <div class="error-state__content">
+        <p class="error-state__message">{{ message }}</p>
+        @if (detail) {
+          <p class="error-state__detail rq-caption" data-testid="error-state-detail">{{ detail }}</p>
+        }
+      </div>
+      @if (retryable) {
+        <p-button [label]="retryLabel" icon="pi pi-refresh" size="small" [text]="true"
+                  severity="secondary" data-testid="error-state-retry"
+                  (onClick)="retry.emit()" />
+      }
+    </div>
+  `,
+  styles: [`
+    :host { display: block; }
+    .error-state {
+      display: flex; align-items: flex-start; gap: var(--rq-space-3);
+      padding: var(--rq-space-3) var(--rq-space-4);
+      border-radius: var(--rq-radius-md);
+      background: var(--rq-tag-danger-bg);
+      color: var(--rq-tag-danger-fg);
+    }
+    .error-state--warn {
+      background: var(--rq-tag-warning-bg);
+      color: var(--rq-tag-warning-fg);
+    }
+    .error-state__icon { margin-top: 0.15rem; flex: 0 0 auto; }
+    .error-state__content { flex: 1 1 auto; min-width: 0; }
+    .error-state__message { margin: 0; font-weight: var(--rq-font-weight-medium); }
+    /* Detail inherits the state colour rather than the muted token so it stays
+       legible on the tinted background. */
+    .error-state__detail { margin: var(--rq-space-1) 0 0; color: inherit; opacity: 0.9; }
+  `]
+})
+export class ErrorStateComponent {
+  /** The primary failure message. */
+  @Input() message = '';
+  /** Optional secondary/support text (reason, "contact your admin", etc.). */
+  @Input() detail = '';
+  /** 'error' = blocking page/editor failure; 'warn' = non-blocking section warning. */
+  @Input() severity: 'error' | 'warn' = 'error';
+  /** Whether to show the Retry button. */
+  @Input() retryable = true;
+  /** Label for the Retry button. */
+  @Input() retryLabel = 'Retry';
+  /** data-testid for the wrapper element. */
+  @Input() testid = 'error-state';
+
+  /** Emitted when the user clicks Retry; the host re-runs its own load method. */
+  @Output() retry = new EventEmitter<void>();
+
+  /** Errors assert (interrupt); non-blocking warnings announce politely. */
+  get ariaRole(): string {
+    return this.severity === 'warn' ? 'status' : 'alert';
+  }
+
+  get iconClass(): string {
+    return this.severity === 'warn' ? 'pi-exclamation-triangle' : 'pi-times-circle';
+  }
+}

--- a/requel-angular/src/app/shared/loading-state.a11y.spec.ts
+++ b/requel-angular/src/app/shared/loading-state.a11y.spec.ts
@@ -1,0 +1,13 @@
+import { TestBed } from '@angular/core/testing';
+import { LoadingStateComponent } from './loading-state';
+import { expectNoAxeViolations } from './testing/a11y';
+
+describe('LoadingStateComponent — accessibility', () => {
+  it('has no axe-core violations', async () => {
+    TestBed.configureTestingModule({ imports: [LoadingStateComponent] });
+    const fixture = TestBed.createComponent(LoadingStateComponent);
+    fixture.componentInstance.label = 'Loading project…';
+    fixture.detectChanges();
+    await expectNoAxeViolations(fixture.nativeElement);
+  });
+});

--- a/requel-angular/src/app/shared/loading-state.spec.ts
+++ b/requel-angular/src/app/shared/loading-state.spec.ts
@@ -1,0 +1,36 @@
+import { TestBed } from '@angular/core/testing';
+import { LoadingStateComponent } from './loading-state';
+
+describe('LoadingStateComponent (issue #131)', () => {
+  function render(inputs: Partial<LoadingStateComponent> = {}): HTMLElement {
+    TestBed.configureTestingModule({ imports: [LoadingStateComponent] });
+    const fixture = TestBed.createComponent(LoadingStateComponent);
+    Object.assign(fixture.componentInstance, inputs);
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  it('renders the default number of skeleton bars', () => {
+    const el = render();
+    expect(el.querySelectorAll('.skeleton-bar').length).toBe(3);
+  });
+
+  it('renders the requested number of skeleton bars', () => {
+    const el = render({ lines: 5 });
+    expect(el.querySelectorAll('.skeleton-bar').length).toBe(5);
+  });
+
+  it('exposes a readable status label to assistive tech and hides the bars', () => {
+    const el = render({ label: 'Loading project…' });
+    const status = el.querySelector('[role="status"]');
+    expect(status?.textContent?.trim()).toBe('Loading project…');
+    expect(status?.getAttribute('aria-live')).toBe('polite');
+    // Decorative bars must be hidden from the accessibility tree.
+    expect(el.querySelector('.skeleton')?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('uses the provided testid', () => {
+    const el = render({ testid: 'project-loading' });
+    expect(el.querySelector('[data-testid="project-loading"]')).not.toBeNull();
+  });
+});

--- a/requel-angular/src/app/shared/loading-state.ts
+++ b/requel-angular/src/app/shared/loading-state.ts
@@ -1,0 +1,97 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import { Component, Input } from '@angular/core';
+
+/**
+ * Shared loading placeholder (issue #131, UI/UX review Finding 2.4). Renders a
+ * skeleton — a set of faint shimmering bars that stand in for content while an
+ * async load is in flight — so editors show the shape of the form instead of a
+ * blank surface or stale data.
+ *
+ * Scope: this is the *editor* loading affordance. List pages keep PrimeNG's own
+ * `p-table [loading]` overlay, which already covers the tabular case.
+ *
+ * Accessibility: the skeleton bars are decorative (`aria-hidden`); the readable
+ * status lives in a visually-hidden `role="status"` region so assistive tech
+ * announces "Loading …" without the bars polluting the accessibility tree
+ * (satisfies the AC "loading states expose readable labels for assistive tech").
+ *
+ * All colour/radius reads from the `--rq-skeleton-*` tokens in `styles.scss`; the
+ * component holds no literals.
+ *
+ * API:
+ * - `label` — the accessible status text (default "Loading…").
+ * - `lines` — number of skeleton bars (default 3). The last bar is rendered
+ *   shorter to suggest a trailing/partial line.
+ * - `testid` — `data-testid` for the wrapper (default "loading-state").
+ */
+@Component({
+  selector: 'app-loading-state',
+  standalone: true,
+  template: `
+    <div class="loading-state" [attr.data-testid]="testid">
+      <span class="rq-visually-hidden" role="status" aria-live="polite">{{ label }}</span>
+      <div class="skeleton" aria-hidden="true">
+        @for (w of barWidths(); track $index) {
+          <div class="skeleton-bar" [style.width]="w"></div>
+        }
+      </div>
+    </div>
+  `,
+  styles: [`
+    :host { display: block; }
+    .skeleton { display: flex; flex-direction: column; gap: var(--rq-space-3); }
+    .skeleton-bar {
+      height: 1rem;
+      border-radius: var(--rq-skeleton-radius);
+      background: linear-gradient(
+        90deg,
+        var(--rq-skeleton-base) 25%,
+        var(--rq-skeleton-sheen) 37%,
+        var(--rq-skeleton-base) 63%
+      );
+      background-size: 400% 100%;
+      animation: rq-skeleton-shimmer 1.4s ease-in-out infinite;
+    }
+    @keyframes rq-skeleton-shimmer {
+      0% { background-position: 100% 50%; }
+      100% { background-position: 0 50%; }
+    }
+    /* Respect users who prefer reduced motion — hold a static placeholder. */
+    @media (prefers-reduced-motion: reduce) {
+      .skeleton-bar { animation: none; }
+    }
+  `]
+})
+export class LoadingStateComponent {
+  /** Accessible status text announced to assistive tech while loading. */
+  @Input() label = 'Loading…';
+  /** Number of skeleton bars to render. */
+  @Input() lines = 3;
+  /** data-testid for the wrapper element. */
+  @Input() testid = 'loading-state';
+
+  /** Bar widths; the final bar is shortened to hint at a trailing line. */
+  barWidths(): string[] {
+    const count = Math.max(1, this.lines);
+    return Array.from({ length: count }, (_, i) => (i === count - 1 ? '60%' : '100%'));
+  }
+}

--- a/requel-angular/src/app/shared/tag-selector.ts
+++ b/requel-angular/src/app/shared/tag-selector.ts
@@ -26,6 +26,7 @@ import { MessageService } from 'primeng/api';
 import { TagCategoryDto, TagDto, tagLabel } from '../models/tag';
 import { TagService } from '../core/tag.service';
 import { AppChipComponent } from './app-chip';
+import { ErrorStateComponent } from './error-state';
 
 /**
  * Reusable tag chip/selector for any taggable entity. Shows the entity's assigned tags as
@@ -35,11 +36,16 @@ import { AppChipComponent } from './app-chip';
 @Component({
   selector: 'app-tag-selector',
   standalone: true,
-  imports: [FormsModule, ButtonModule, InputText, AppChipComponent],
+  imports: [FormsModule, ButtonModule, InputText, AppChipComponent, ErrorStateComponent],
   template: `
     @if (entityId != null) {
       <div class="tags-section" data-testid="tags-section">
         <div class="section-header"><h3>Tags</h3></div>
+
+        @if (loadError()) {
+          <app-error-state severity="warn" [message]="loadError()!" retryLabel="Retry"
+                           testid="tags-load-error" (retry)="reload()" />
+        }
 
         <div class="chips" data-testid="tag-chips">
           @for (t of assigned(); track t.id) {
@@ -100,6 +106,10 @@ export class TagSelectorComponent implements OnChanges {
   private _categories = signal<string[]>([]);
   categories = this._categories.asReadonly();
   private _typedCategories = signal<TagCategoryDto[]>([]);
+  // Non-blocking inline warning when the supplemental tag load fails, instead of
+  // the previous silent swallow (issue #131).
+  private _loadError = signal<string | null>(null);
+  loadError = this._loadError.asReadonly();
 
   newCategory = '';
   newValue = '';
@@ -144,6 +154,11 @@ export class TagSelectorComponent implements OnChanges {
     return tag.color ?? this.categoryFor(tag.category)?.color ?? null;
   }
 
+  /** Re-run the tag load; wired to the inline warning's (retry) output. */
+  reload(): void {
+    void this.load();
+  }
+
   private async load(): Promise<void> {
     if (this.entityId == null) return;
     try {
@@ -157,8 +172,12 @@ export class TagSelectorComponent implements OnChanges {
       this._available.set(available);
       this._categories.set(categories);
       this._typedCategories.set(typedCategories);
+      this._loadError.set(null);
     } catch {
-      // Tags are supplemental — ignore load failures silently.
+      // Tags are supplemental, so a failure must not block the editor — but it is
+      // no longer swallowed silently: surface a non-blocking inline warning so the
+      // lost capability is visible and retryable (issue #131).
+      this._loadError.set('Tags could not be loaded.');
     }
   }
 

--- a/requel-angular/src/styles.scss
+++ b/requel-angular/src/styles.scss
@@ -136,6 +136,15 @@
   --rq-target-min: 24px;
   --rq-target-comfortable: 36px;
 
+  // Loading skeleton (issue #131). Placeholder bars shown while editor content
+  // loads, so users see the shape of the form instead of a blank surface. `base`
+  // is a faint surface fill; `sheen` is a lighter band the shimmer animation
+  // sweeps across. Both read the Slate surface ramp so they theme with the rest
+  // of the app — the component holds no colour literals.
+  --rq-skeleton-base: var(--p-surface-200);
+  --rq-skeleton-sheen: var(--p-surface-100);
+  --rq-skeleton-radius: var(--rq-radius-sm);
+
   // Make PrimeNG components inherit Figtree (font-family is not set by Aura).
   --p-font-family: var(--rq-font-family);
 }
@@ -208,6 +217,21 @@ html, body {
   font-weight: var(--rq-text-caption-weight);
   line-height: var(--rq-text-caption-line);
   color: var(--rq-text-muted-color);
+}
+
+// Visually-hidden text (issue #131). Removes content from the visual layout while
+// keeping it in the accessibility tree, so status/loading regions can carry a
+// readable label for assistive tech without showing it on screen. Standard
+// clip-rect pattern; do not use `display:none`/`visibility:hidden` (those hide
+// from AT too).
+.rq-visually-hidden {
+  position: absolute !important;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 // -------------------------------------------------------------------------


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/131

Add shared loading, empty, and error-state components and wire them into editors, lists, and supplemental sections

Implements UI/UX review Finding 2.4: editors showed blank forms during async
loads, supplemental tag/annotation load failures were swallowed silently, and
empty lists offered only bare "No X found." text with no guidance or call to
action. Adds three shared standalone components and adopts them across the
cited views. Closes #131.

New shared components (requel-angular/src/app/shared/):
- loading-state.ts (`app-loading-state`) — skeleton placeholder for editor
  loads. Decorative shimmer bars (aria-hidden) plus a visually-hidden
  role="status" region so assistive tech announces a readable label. Scoped to
  editors; lists keep PrimeNG `p-table [loading]`.
- error-state.ts (`app-error-state`) — one component for two jobs: a blocking
  page/editor failure (`severity="error"`, role="alert", Retry button) and a
  non-blocking supplemental-section warning (`severity="warn"`, role="status").
  Retry contract: emits `(retry)`; the host re-invokes its own load method. No
  colour literals — reads the `--rq-tag-danger-*` / `--rq-tag-warning-*` tokens.
- empty-state.ts (`app-empty-state`) — titled guidance with an optional CTA
  gated by a host-provided `[showAction]` permission flag. Title is a styled
  paragraph (not a heading) so it can drop into a table body without disturbing
  the page heading outline.
- Each component has a `.spec.ts` and an `.a11y.spec.ts` (axe-core), matching
  the shared/ convention.

styles.scss:
- Added `--rq-skeleton-base|sheen|radius` tokens (Slate surface ramp) and a
  reusable `.rq-visually-hidden` utility (clip-rect pattern).

Editors — loading skeleton + retryable error state, and the missing catch that
caused the silent blank-form bug (project-editor.ts, user-editor.ts,
scenario-editor.ts):
- Added a `loadError` signal distinct from the existing save/inline
  `errorMessage`, so the retryable error state replaces the form only on an
  initial load failure. Added `retryLoad()` wired to `(retry)`.
- project/user editor load methods now `catch` and set `loadError` (previously
  `try/finally` with no catch left a blank form on failure).
- scenario-editor: added `loading`/`loadError` signals; only the user-initiated
  (non-SSE) load drives the skeleton/error state — a background SSE refresh must
  not blank the form, so SSE failures still use the inline `errorMessage`.
  New-scenario path resolves loading synchronously.

Supplemental sections — inline non-blocking warnings instead of silent ignores
(tag-selector.ts, annotations-section.ts):
- Both now set a `loadError` on catch and render `app-error-state severity="warn"`
  with Retry (`reload()`), so a lost tags/annotations capability is visible and
  recoverable rather than hidden.

List empty states with permission-gated CTAs (project-list.ts, goal-list.ts,
stakeholder-list.ts):
- Replaced bare emptymessage text with `app-empty-state`; the CTA is gated by
  the existing permission signal (`canCreateProjects()` / `canEdit()`).
- goal-list distinguishes a genuinely empty project from a tag-filter that
  matched nothing (no misleading "create" CTA in the filtered case).

Tests:
- Added specs + a11y specs for the three new components.
- Updated scenario-editor.spec: the initial-load-failure test now asserts
  `loadError` (retryable state) rather than `errorMessage`, and a new test
  covers `retryLoad()` recovery.
- Full Angular suite green: 404 passed (70 files).
