### PR TITLE
157: Data-table pattern component (app-data-table) + list-page migration

### DIFF
--- a/doc/157-data-table-plan.md
+++ b/doc/157-data-table-plan.md
@@ -1,0 +1,186 @@
+# N4 — Data-table pattern component (`app-data-table`) — Implementation Plan
+
+Issue: https://github.com/rreganjr/Requel/issues/157
+Part of the look-and-feel adoption in `doc/124-lookandfeel-plan.md` (sub-issue N4 of epic #124).
+Concretizes #129 (list/detail consistency) + #146 (shared primitives).
+
+## Summary
+
+Build a standalone, reusable `app-data-table` component that wraps PrimeNG `Table`, and
+migrate every list page onto it. The component is self-contained so it can be reused
+outside the list-page shell (dialogs, editor sub-panels, detail tabs), not just on full
+list pages. Its dependencies already exist in the repo: `app-tag`/`app-chip` (N2),
+`app-card` (N3), `app-empty-state`/`app-error-state`/`app-loading-state` (#131), and the
+`app-list-page` shell.
+
+## Resolved decisions
+
+1. **Scope — all list pages.** Migrate the seven enumerated pages
+   (goal, story, actor, stakeholder, scenario, use-case, term) **and** the remaining
+   table pages: `project-list`, `user-list`, `report-list`, `open-issues`, and admin
+   `tag-categories` / `global-tags`.
+2. **Tag column renders tag chips, not status.** The enumerated entities have no status
+   field (only `project`/`api-token` do). The `app-tag`/`app-chip` column renders each
+   row's existing tag chips (as `goal-list` does today). A page that has a real status
+   may still map it to a tag tone via a custom cell template.
+3. **`app-data-table` owns search; `app-list-page` search is opt-out.** Add
+   `[showSearch]="false"` support to `app-list-page` so full list pages let the table
+   drive search. This consolidates search in one place and avoids two search boxes.
+4. **Row actions: default `⋯` menu + keep row-click open.**
+   - Default menu is **Open / Edit / Delete**, permission-gated.
+   - Row-click (whole row) still opens the entity — belt and suspenders.
+   - Menu items are real `<button>`s with accessible names (satisfies #136 / #137).
+5. **Action override model — replace, never merge.**
+   - Declarative tweak (most pages): a `[rowActions]` input, an array of
+     `{ label, icon, command, visible?, disabled? }`. Passing it **replaces** the
+     open/edit/delete defaults.
+   - Full override (odd pages): a projected `<ng-template #rowActions let-row>`. Because
+     each row's menu needs its row data, this is an `ng-template` with row context, not a
+     plain `ng-content` slot. When present it **replaces** the default menu.
+   - Merge semantics are intentionally not supported (complexity), keeping one mental
+     model: a page either takes the default or fully owns its actions.
+6. **Selection column built now.** Ship the optional checkbox multi-select column even
+   though no bulk action consumes it yet; expose the selection via an output so a future
+   bulk-action toolbar can bind to it.
+
+## Component API (`app-data-table`)
+
+Standalone Angular component, `selector: 'app-data-table'`, generic over the row type.
+
+Inputs:
+
+- `value: T[]` — rows.
+- `columns: DataTableColumn<T>[]` — column config (see below).
+- `loading = false` — drives the loading state.
+- `paginator = true`, `rows = 20` — client-side pagination (all rows loaded; matches
+  current behavior on every page).
+- `selectable = false` — renders the leading checkbox selection column when true.
+- `rowActions?: RowAction<T>[]` — declarative row-action menu; replaces the default
+  Open/Edit/Delete set when provided.
+- `showToolbar = true`, `title = ''`, `searchPlaceholder = 'Search...'` — the internal
+  toolbar (title + search + projected primary-action slot). Search filters the table
+  internally via PrimeNG global filter.
+- `globalFilterFields?: string[]` — fields the search box filters on.
+
+Outputs:
+
+- `rowClick: EventEmitter<T>` — whole-row open affordance.
+- `selectionChange: EventEmitter<T[]>` — for a future bulk-action consumer.
+- Default action outputs (`open`/`edit`/`delete`) OR the `command` callbacks carried on
+  `rowActions` items.
+
+Content-projection slots:
+
+- `[toolbarActions]` — primary action button(s), e.g. the `New` button, and any
+  per-page filters (the goal-list tag `p-select`).
+- `<ng-template #rowActions let-row>` — full row-action override (replaces default menu).
+- Per-column cell templates for custom rendering (chips, sliced text previews) via the
+  column config `cellTemplate`.
+- `[empty]` / default empty state — falls through to `app-empty-state` when no template
+  is supplied.
+
+Supporting types:
+
+```ts
+interface DataTableColumn<T> {
+  field: string;
+  header: string;
+  sortable?: boolean;
+  cellTemplate?: TemplateRef<{ $implicit: T }>; // custom cell (chips, previews, tags)
+  class?: string;
+}
+
+interface RowAction<T> {
+  label: string;
+  icon?: string;
+  command: (row: T) => void;
+  visible?: (row: T) => boolean;   // permission / state gating
+  disabled?: (row: T) => boolean;
+}
+```
+
+## Relationship to `app-list-page`
+
+- Full list pages keep `app-list-page` for page chrome (page-header, eyebrow, card) and
+  nest `app-data-table` inside it, with `<app-list-page [showSearch]="false">` so the
+  table owns search.
+- Standalone contexts (dialogs, sub-panels) use `app-data-table` directly; its internal
+  toolbar provides title + search + primary-action slot without needing `app-list-page`.
+- `app-list-page` change: add `@Input() showSearch = true;` gate around the existing
+  search toolbar (component already reads `showSearch` — verify and wire the template).
+
+## Per-page migration notes
+
+All pages currently use PrimeNG `p-table` and load the full list client-side, so search /
+sort / paginate stay client-side.
+
+| Page | Row-click open | Default actions | Notes |
+|---|---|---|---|
+| `goal-list` | yes | Open/Edit/Delete (gated by `canEdit`) | Keep tag-chip column + tag `p-select` filter in `[toolbarActions]`; text preview cell template. |
+| `story-list` | yes | Open/Edit/Delete | Standard. |
+| `actor-list` | yes | Open/Edit/Delete | Standard. |
+| `stakeholder-list` | yes | Open/Edit/Delete | Standard. |
+| `scenario-list` | yes | Open/Edit/Delete | Currently sets `showSearch` explicitly — confirm search fields. |
+| `use-case-list` | yes | Open/Edit/Delete | Currently sets `showSearch` explicitly — confirm search fields. |
+| `term-list` | yes | Open/Edit/Delete | Standard. |
+| `project-list` | yes | Open/Edit/Delete | Has a real `status` field — may map to an `app-tag` tone via a cell template. No `canEdit` gate today; confirm permissions. |
+| `user-list` | yes | Open/Edit/Delete | Admin context; no `canEdit` gate today — confirm permission model. |
+| `report-list` | no | Open/Edit/Delete? | No row-select today; confirm intended actions. |
+| `open-issues` | no | **Custom** | Use `<ng-template #rowActions>` override; no row-nav today. |
+| `admin/tag-categories` | no | **Custom (Delete inline)** | Not on `app-list-page` today; use table's own toolbar or adopt the shell; custom actions via template override. |
+| `admin/global-tags` | no | **Custom (Delete inline)** | Same as tag-categories. |
+
+## Accessibility (#136 / #137)
+
+- Row-action menu items are `<button>`s with visible or `aria-label` names.
+- The `⋯` trigger has an accessible name (e.g. `aria-label="Row actions"`).
+- Keyboard: menu is openable and navigable by keyboard; row-click open must not be the
+  only affordance (the `⋯` menu provides the explicit, focusable path).
+- Empty state via `app-empty-state`; loading via `app-loading-state`; error via
+  `app-error-state`.
+
+## Testing (acceptance)
+
+- Unit tests for `app-data-table`: renders columns, sorts on a sortable header, paginates,
+  filters via search, emits `rowClick`, renders default vs. `[rowActions]` vs.
+  `<ng-template #rowActions>` (override replaces default), toggles the selection column and
+  emits `selectionChange`.
+- Migrate + update specs for at least the migrated pages already carrying `.spec.ts`
+  (goal, project, stakeholder, use-case, story, user, actor, scenario) so search + sort +
+  paginate are covered per the acceptance criteria.
+- a11y spec for the row-action menu (accessible names, keyboard) alongside existing
+  `*.a11y.spec.ts` patterns.
+
+## Build order
+
+1. Add `[showSearch]` opt-out to `app-list-page`.
+2. Build `app-data-table` (+ types, + unit/a11y specs).
+3. Migrate the seven enumerated pages (they share the standard shape).
+4. Migrate `project-list` / `user-list` / `report-list`.
+5. Migrate the custom pages (`open-issues`, admin `tag-categories` / `global-tags`) using
+   the template override.
+6. Verify: `cd requel-angular && npm test -- --watch=false` green.
+
+## Open items (non-blocking) — resolved during implementation
+
+- `report-list`: kept its inline **Edit** / **Run** buttons via a `<ng-template #rowActions>`
+  override; rows do not navigate (`[rowClickable]="false"`).
+- `project-list` / `user-list`: kept the existing single **Open** action (they had no
+  list-level edit/delete); `project-list` New/Import stay gated by `canCreateProjects`.
+- Admin tag pages (`tag-categories` / `global-tags`): kept their own page chrome (custom
+  page-header + add-row form) and used `app-data-table` with `[showToolbar]="false"`; the
+  per-row **Delete** stays via a `<ng-template #rowActions>` override.
+- `open-issues`: no row actions (`[defaultActions]="false"`) and no row nav
+  (`[rowClickable]="false"`); entity links and the Required Yes/No labels render via cell
+  templates; initial sort via `sortField`/`sortOrder`.
+
+## Component API additions made during implementation
+
+Beyond the API in the section above, the build added three inputs to `app-data-table`:
+`rowClickable` (default true), `sortField`, and `sortOrder` — needed by the custom pages.
+
+## Status
+
+All 13 list pages migrated (`goal`, `story`, `actor`, `stakeholder`, `scenario`,
+`use-case`, `term`, `project`, `user`, `report`, `open-issues`, admin `tag-categories`,
+admin `global-tags`). Full frontend suite green (71 files / 418 tests).

--- a/requel-angular/e2e/pages/ReportEditorPage.ts
+++ b/requel-angular/e2e/pages/ReportEditorPage.ts
@@ -56,7 +56,7 @@ export class ReportListPage extends BaseListPage {
   }
 
   async expectEmptyState(): Promise<void> {
-    await expect(this.page.getByTestId('report-list-empty')).toContainText('No documents found.');
+    await expect(this.page.getByTestId('report-list-empty')).toContainText('No documents yet');
   }
 }
 

--- a/requel-angular/e2e/pages/ScenarioEditorPage.ts
+++ b/requel-angular/e2e/pages/ScenarioEditorPage.ts
@@ -166,7 +166,19 @@ export class ScenarioEditorPage {
   }
 
   async openStepEdit(index: number): Promise<void> {
-    await this.stepRows().nth(index).getByTestId('scenario-step-edit').click();
+    // The step rows re-render right after a save() (the post-save detail reload
+    // repopulates stepNodes). A single click on the edit button can land during
+    // that re-render, before Angular's (click)="openStepEdit(step)" handler is
+    // wired to the fresh element, so editingStep is never set and the p-dialog
+    // never opens — the flake behind scenarios.e2e "edit step via popup". Retry
+    // the click until the dialog's name field is actually visible so the open is
+    // deterministic regardless of render timing.
+    const editButton = this.stepRows().nth(index).getByTestId('scenario-step-edit');
+    const nameInput = this.page.getByTestId('scenario-step-edit-name');
+    await expect(async () => {
+      await editButton.click();
+      await expect(nameInput).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: 15000 });
   }
 
   async fillStepEditName(name: string): Promise<void> {

--- a/requel-angular/src/app/features/actors/actor-list.ts
+++ b/requel-angular/src/app/features/actors/actor-list.ts
@@ -18,10 +18,9 @@
  * along with Requel. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import { Component, OnDestroy, OnInit, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, TemplateRef, ViewChild, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
-import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
 import { MessageModule } from 'primeng/message';
 import { SlicePipe } from '@angular/common';
@@ -29,49 +28,41 @@ import { ActorDto } from '../../models/actor';
 import { ActorService } from '../../core/actor.service';
 import { PermissionService } from '../../core/permission.service';
 import { ListPageComponent } from '../../shared/list-page';
+import { AppDataTableComponent, DataTableColumn, RowAction } from '../../shared/app-data-table';
 
 @Component({
   selector: 'app-actor-list',
   standalone: true,
-  imports: [ListPageComponent, TableModule, ButtonModule, MessageModule, SlicePipe],
+  imports: [ListPageComponent, AppDataTableComponent, ButtonModule, MessageModule, SlicePipe],
   template: `
-    <app-list-page title="Actors" searchPlaceholder="Search actors..."
-                   (search)="dt.filterGlobal($event, 'contains')">
-      <ng-container actions>
-        @if (canEdit()) {
-          <p-button label="New Actor" icon="pi pi-plus" (onClick)="onNewActor()" />
-        }
-      </ng-container>
-
+    <app-list-page title="Actors" [showSearch]="false">
       @if (errorMessage()) {
         <p-message severity="error" [text]="errorMessage()!" />
       }
 
-      <p-table #dt [value]="actors()" [loading]="loading()" [paginator]="true" [rows]="20"
-               [rowHover]="true" selectionMode="single" (onRowSelect)="onRowSelect($event)"
-               [globalFilterFields]="['name', 'text', 'createdBy']">
-        <ng-template #header>
-          <tr>
-            <th pSortableColumn="name">Name <p-sortIcon field="name" /></th>
-            <th>Description</th>
-            <th pSortableColumn="createdBy">Created By <p-sortIcon field="createdBy" /></th>
-          </tr>
-        </ng-template>
-        <ng-template #body let-a>
-          <tr [pSelectableRow]="a">
-            <td>{{ a.name }}</td>
-            <td class="text-preview">{{ a.text | slice:0:80 }}{{ (a.text?.length ?? 0) > 80 ? '...' : '' }}</td>
-            <td>{{ a.createdBy }}</td>
-          </tr>
-        </ng-template>
-        <ng-template #emptymessage>
-          <tr><td colspan="3" class="text-center">No actors found.</td></tr>
-        </ng-template>
-      </p-table>
+      <app-data-table [value]="actors()" [columns]="columns" [loading]="loading()"
+                      [rowActions]="rowActions" searchPlaceholder="Search actors..."
+                      [globalFilterFields]="['name', 'text', 'createdBy']"
+                      testid="actor-list" (rowClick)="onRowSelect({ data: $event })"
+                      emptyTitle="No actors yet"
+                      emptyMessage="Add the actors that interact with this system."
+                      emptyIcon="pi-user" emptyActionLabel="New Actor"
+                      [showEmptyAction]="canEdit()" (emptyAction)="onNewActor()">
+        <div toolbarActions>
+          @if (canEdit()) {
+            <p-button label="New Actor" icon="pi pi-plus" (onClick)="onNewActor()" />
+          }
+        </div>
+      </app-data-table>
     </app-list-page>
+
+    <ng-template #textCell let-a>
+      <span class="text-preview">{{ a.text | slice:0:80 }}{{ (a.text?.length ?? 0) > 80 ? '...' : '' }}</span>
+    </ng-template>
   `,
   styles: [`
-    .text-preview { max-width: 400px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .text-preview { display: inline-block; max-width: 400px; overflow: hidden;
+      text-overflow: ellipsis; white-space: nowrap; vertical-align: bottom; }
   `]
 })
 export class ActorListComponent implements OnInit, OnDestroy {
@@ -79,6 +70,12 @@ export class ActorListComponent implements OnInit, OnDestroy {
   loading = signal(true);
   errorMessage = signal<string | null>(null);
   canEdit = signal(false);
+
+  @ViewChild('textCell', { static: true }) textCell!: TemplateRef<{ $implicit: ActorDto }>;
+  columns: DataTableColumn<ActorDto>[] = [];
+  rowActions: RowAction<ActorDto>[] = [
+    { label: 'Open', icon: 'pi pi-eye', command: a => this.onRowSelect({ data: a }) }
+  ];
 
   private projectName = '';
   private paramSub?: Subscription;
@@ -91,6 +88,11 @@ export class ActorListComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
+    this.columns = [
+      { field: 'name', header: 'Name', sortable: true },
+      { field: 'text', header: 'Description', cellTemplate: this.textCell },
+      { field: 'createdBy', header: 'Created By', sortable: true }
+    ];
     this.paramSub = this.route.paramMap.subscribe(async params => {
       const name = params.get('name') ?? '';
       if (name !== this.projectName) {

--- a/requel-angular/src/app/features/admin/global-tags.ts
+++ b/requel-angular/src/app/features/admin/global-tags.ts
@@ -18,16 +18,16 @@
  * along with Requel. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import { Component, OnInit, signal } from '@angular/core';
+import { Component, OnInit, TemplateRef, ViewChild, signal } from '@angular/core';
 import { PageHeaderComponent } from '../../shared/page-header';
 import { FormsModule } from '@angular/forms';
-import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
 import { InputText } from 'primeng/inputtext';
 import { MessageModule } from 'primeng/message';
 import { MessageService } from 'primeng/api';
 import { TagDto } from '../../models/tag';
 import { TagService } from '../../core/tag.service';
+import { AppDataTableComponent, DataTableColumn } from '../../shared/app-data-table';
 
 /**
  * Admin surface for the global (system) tag set: tags with no owning project, shared across
@@ -37,7 +37,7 @@ import { TagService } from '../../core/tag.service';
 @Component({
   selector: 'app-global-tags',
   standalone: true,
-  imports: [PageHeaderComponent, FormsModule, TableModule, ButtonModule, InputText, MessageModule],
+  imports: [PageHeaderComponent, FormsModule, AppDataTableComponent, ButtonModule, InputText, MessageModule],
   template: `
     <div class="global-tags" data-testid="global-tags">
       <div class="page-header"><app-page-header title="Global Tags" /></div>
@@ -56,32 +56,18 @@ import { TagService } from '../../core/tag.service';
                   (onClick)="addTag()" />
       </div>
 
-      <p-table [value]="tags()" [loading]="loading()" [paginator]="true" [rows]="20" [rowHover]="true">
-        <ng-template #header>
-          <tr>
-            <th>Category</th>
-            <th>Value</th>
-            <th>Created By</th>
-            <th class="col-actions"></th>
-          </tr>
+      <app-data-table [value]="tags()" [columns]="columns" [loading]="loading()"
+                      [showToolbar]="false" [rowClickable]="false" testid="global-tag"
+                      emptyTitle="No global tags" emptyIcon="pi-tag">
+        <ng-template #rowActions let-t>
+          <p-button icon="pi pi-trash" severity="danger" [text]="true" size="small"
+                    data-testid="global-tag-delete" [ariaLabel]="'Delete tag ' + t.value"
+                    (onClick)="deleteTag(t)" />
         </ng-template>
-        <ng-template #body let-t>
-          <tr data-testid="global-tag-row">
-            <td>{{ t.category ?? '—' }}</td>
-            <td>{{ t.value }}</td>
-            <td>{{ t.createdBy }}</td>
-            <td>
-              <p-button icon="pi pi-trash" severity="danger" [text]="true" size="small"
-                        data-testid="global-tag-delete" [ariaLabel]="'Delete tag ' + t.value"
-                        (onClick)="deleteTag(t)" />
-            </td>
-          </tr>
-        </ng-template>
-        <ng-template #emptymessage>
-          <tr><td colspan="4" class="text-center">No global tags.</td></tr>
-        </ng-template>
-      </p-table>
+      </app-data-table>
     </div>
+
+    <ng-template #categoryCell let-t>{{ t.category ?? '—' }}</ng-template>
   `,
   styles: [`
     .global-tags { max-width: 800px; }
@@ -98,9 +84,17 @@ export class GlobalTagsComponent implements OnInit {
   newCategory = '';
   newValue = '';
 
+  @ViewChild('categoryCell', { static: true }) categoryCell!: TemplateRef<{ $implicit: TagDto }>;
+  columns: DataTableColumn<TagDto>[] = [];
+
   constructor(private tagService: TagService, private messageService: MessageService) {}
 
   ngOnInit(): void {
+    this.columns = [
+      { field: 'category', header: 'Category', cellTemplate: this.categoryCell },
+      { field: 'value', header: 'Value', sortable: true },
+      { field: 'createdBy', header: 'Created By', sortable: true }
+    ];
     void this.load();
   }
 

--- a/requel-angular/src/app/features/admin/tag-categories.ts
+++ b/requel-angular/src/app/features/admin/tag-categories.ts
@@ -18,10 +18,9 @@
  * along with Requel. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import { Component, OnInit, signal } from '@angular/core';
+import { Component, OnInit, TemplateRef, ViewChild, signal } from '@angular/core';
 import { PageHeaderComponent } from '../../shared/page-header';
 import { FormsModule } from '@angular/forms';
-import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
 import { InputText } from 'primeng/inputtext';
 import { CheckboxModule } from 'primeng/checkbox';
@@ -29,6 +28,7 @@ import { MessageModule } from 'primeng/message';
 import { MessageService } from 'primeng/api';
 import { TagCategoryDto } from '../../models/tag';
 import { TagService } from '../../core/tag.service';
+import { AppDataTableComponent, DataTableColumn } from '../../shared/app-data-table';
 
 /**
  * Admin surface for the global typed-category set (Phase 6): categories with no owning project,
@@ -38,7 +38,7 @@ import { TagService } from '../../core/tag.service';
 @Component({
   selector: 'app-tag-categories',
   standalone: true,
-  imports: [PageHeaderComponent, FormsModule, TableModule, ButtonModule, InputText, CheckboxModule, MessageModule],
+  imports: [PageHeaderComponent, FormsModule, AppDataTableComponent, ButtonModule, InputText, CheckboxModule, MessageModule],
   template: `
     <div class="tag-categories" data-testid="tag-categories">
       <div class="page-header"><app-page-header title="Global Tag Categories" /></div>
@@ -64,32 +64,21 @@ import { TagService } from '../../core/tag.service';
                   (onClick)="addCategory()" />
       </div>
 
-      <p-table [value]="categories()" [loading]="loading()" [paginator]="true" [rows]="20" [rowHover]="true">
-        <ng-template #header>
-          <tr>
-            <th>Name</th><th>Exclusive</th><th>Allowed Types</th><th>Values</th><th>Color</th>
-            <th class="col-actions"></th>
-          </tr>
+      <app-data-table [value]="categories()" [columns]="columns" [loading]="loading()"
+                      [showToolbar]="false" [rowClickable]="false" testid="tag-category"
+                      emptyTitle="No global categories" emptyIcon="pi-tags">
+        <ng-template #rowActions let-c>
+          <p-button icon="pi pi-trash" severity="danger" [text]="true" size="small"
+                    data-testid="tag-category-delete" [ariaLabel]="'Delete category ' + c.name"
+                    (onClick)="deleteCategory(c)" />
         </ng-template>
-        <ng-template #body let-c>
-          <tr data-testid="tag-category-row">
-            <td>{{ c.name }}</td>
-            <td>{{ c.exclusive ? 'yes' : '—' }}</td>
-            <td>{{ c.allowedEntityTypes.length ? c.allowedEntityTypes.join(', ') : 'any' }}</td>
-            <td>{{ c.values.length ? c.values.join(', ') : 'any' }}</td>
-            <td>{{ c.color ?? '—' }}</td>
-            <td>
-              <p-button icon="pi pi-trash" severity="danger" [text]="true" size="small"
-                        data-testid="tag-category-delete" [ariaLabel]="'Delete category ' + c.name"
-                        (onClick)="deleteCategory(c)" />
-            </td>
-          </tr>
-        </ng-template>
-        <ng-template #emptymessage>
-          <tr><td colspan="6" class="text-center">No global categories.</td></tr>
-        </ng-template>
-      </p-table>
+      </app-data-table>
     </div>
+
+    <ng-template #exclusiveCell let-c>{{ c.exclusive ? 'yes' : '—' }}</ng-template>
+    <ng-template #allowedCell let-c>{{ c.allowedEntityTypes.length ? c.allowedEntityTypes.join(', ') : 'any' }}</ng-template>
+    <ng-template #valuesCell let-c>{{ c.values.length ? c.values.join(', ') : 'any' }}</ng-template>
+    <ng-template #colorCell let-c>{{ c.color ?? '—' }}</ng-template>
   `,
   styles: [`
     .tag-categories { max-width: 960px; }
@@ -111,9 +100,22 @@ export class TagCategoriesComponent implements OnInit {
   newValues = '';
   newColor = '';
 
+  @ViewChild('exclusiveCell', { static: true }) exclusiveCell!: TemplateRef<{ $implicit: TagCategoryDto }>;
+  @ViewChild('allowedCell', { static: true }) allowedCell!: TemplateRef<{ $implicit: TagCategoryDto }>;
+  @ViewChild('valuesCell', { static: true }) valuesCell!: TemplateRef<{ $implicit: TagCategoryDto }>;
+  @ViewChild('colorCell', { static: true }) colorCell!: TemplateRef<{ $implicit: TagCategoryDto }>;
+  columns: DataTableColumn<TagCategoryDto>[] = [];
+
   constructor(private tagService: TagService, private messageService: MessageService) {}
 
   ngOnInit(): void {
+    this.columns = [
+      { field: 'name', header: 'Name', sortable: true },
+      { field: 'exclusive', header: 'Exclusive', cellTemplate: this.exclusiveCell },
+      { field: 'allowedEntityTypes', header: 'Allowed Types', cellTemplate: this.allowedCell },
+      { field: 'values', header: 'Values', cellTemplate: this.valuesCell },
+      { field: 'color', header: 'Color', cellTemplate: this.colorCell }
+    ];
     void this.load();
   }
 

--- a/requel-angular/src/app/features/goals/goal-list.spec.ts
+++ b/requel-angular/src/app/features/goals/goal-list.spec.ts
@@ -72,10 +72,10 @@ describe('GoalListComponent', () => {
     expect(comp.canEdit()).toBe(true);
   });
 
-  it('onRowSelect navigates to goal editor', async () => {
+  it('openGoal navigates to goal editor', async () => {
     fixture.detectChanges();
     await flush();
-    comp.onRowSelect({ data: MOCK_GOALS[0] });
+    comp.openGoal(MOCK_GOALS[0]);
     expect(router.navigate).toHaveBeenCalledWith(['/projects', 'proj1', 'goals', 1]);
   });
 

--- a/requel-angular/src/app/features/goals/goal-list.ts
+++ b/requel-angular/src/app/features/goals/goal-list.ts
@@ -18,11 +18,10 @@
  * along with Requel. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import { Component, OnDestroy, OnInit, computed, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, TemplateRef, ViewChild, computed, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { FormsModule } from '@angular/forms';
-import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
 import { MessageModule } from 'primeng/message';
 import { SelectModule } from 'primeng/select';
@@ -35,74 +34,61 @@ import { PermissionService } from '../../core/permission.service';
 import { ListPageComponent } from '../../shared/list-page';
 import { AppChipComponent } from '../../shared/app-chip';
 import { EmptyStateComponent } from '../../shared/empty-state';
+import { AppDataTableComponent, DataTableColumn, RowAction } from '../../shared/app-data-table';
 
 @Component({
   selector: 'app-goal-list',
   standalone: true,
-  imports: [ListPageComponent, TableModule, ButtonModule, MessageModule, SelectModule, FormsModule, SlicePipe, AppChipComponent, EmptyStateComponent],
+  imports: [ListPageComponent, AppDataTableComponent, ButtonModule, MessageModule, SelectModule, FormsModule, SlicePipe, AppChipComponent, EmptyStateComponent],
   template: `
-    <app-list-page title="Goals" [eyebrow]="projectContext()" searchPlaceholder="Search goals..."
-                   (search)="dt.filterGlobal($event, 'contains')">
-      <ng-container actions>
-        <p-select [options]="tagFilterOptions()" [ngModel]="selectedTagId()"
-                  (ngModelChange)="selectedTagId.set($event)"
-                  optionLabel="label" optionValue="value" placeholder="Filter by tag"
-                  data-testid="goal-tag-filter" [showClear]="true" class="tag-filter" />
-        @if (canEdit()) {
-          <p-button label="New Goal" icon="pi pi-plus" (onClick)="onNewGoal()" />
-        }
-      </ng-container>
-
+    <app-list-page title="Goals" [eyebrow]="projectContext()" [showSearch]="false">
       @if (errorMessage()) {
         <p-message severity="error" [text]="errorMessage()!" />
       }
 
-      <p-table #dt [value]="displayedGoals()" [loading]="loading()" [paginator]="true" [rows]="20"
-               [rowHover]="true" selectionMode="single" (onRowSelect)="onRowSelect($event)"
-               [globalFilterFields]="['name', 'text', 'createdBy']">
-        <ng-template #header>
-          <tr>
-            <th pSortableColumn="name">Name <p-sortIcon field="name" /></th>
-            <th>Text</th>
-            <th>Tags</th>
-            <th pSortableColumn="createdBy">Created By <p-sortIcon field="createdBy" /></th>
-          </tr>
+      <app-data-table [value]="displayedGoals()" [columns]="columns" [loading]="loading()"
+                      [rowActions]="rowActions" searchPlaceholder="Search goals..."
+                      [globalFilterFields]="['name', 'text', 'createdBy']" testid="goal-list"
+                      (rowClick)="openGoal($event)">
+        <div toolbarActions class="goal-toolbar-actions">
+          <p-select [options]="tagFilterOptions()" [ngModel]="selectedTagId()"
+                    (ngModelChange)="selectedTagId.set($event)"
+                    optionLabel="label" optionValue="value" placeholder="Filter by tag"
+                    data-testid="goal-tag-filter" [showClear]="true" class="tag-filter" />
+          @if (canEdit()) {
+            <p-button label="New Goal" icon="pi pi-plus" (onClick)="onNewGoal()" />
+          }
+        </div>
+        <ng-template #empty>
+          @if (selectedTagId() != null) {
+            <app-empty-state title="No goals match this tag"
+                             message="Try clearing the tag filter to see all goals."
+                             icon="pi-filter-slash" testid="goal-list-empty" />
+          } @else {
+            <app-empty-state title="No goals yet"
+                             message="Capture the objectives this project needs to meet."
+                             icon="pi-flag" actionLabel="New Goal" [showAction]="canEdit()"
+                             testid="goal-list-empty" (action)="onNewGoal()" />
+          }
         </ng-template>
-        <ng-template #body let-g>
-          <tr [pSelectableRow]="g">
-            <td>{{ g.name }}</td>
-            <td class="text-preview">{{ g.text | slice:0:80 }}{{ g.text?.length > 80 ? '...' : '' }}</td>
-            <td>
-              <span class="chips" data-testid="goal-row-tags">
-                @for (t of tagsForGoal(g.id); track t.id) {
-                  <app-chip [label]="label(t)" [tone]="'primary'" [attr.data-tag]="label(t)" />
-                }
-              </span>
-            </td>
-            <td>{{ g.createdBy }}</td>
-          </tr>
-        </ng-template>
-        <ng-template #emptymessage>
-          <tr>
-            <td colspan="4">
-              @if (selectedTagId() != null) {
-                <app-empty-state title="No goals match this tag"
-                                 message="Try clearing the tag filter to see all goals."
-                                 icon="pi-filter-slash" testid="goal-list-empty" />
-              } @else {
-                <app-empty-state title="No goals yet"
-                                 message="Capture the objectives this project needs to meet."
-                                 icon="pi-flag" actionLabel="New Goal" [showAction]="canEdit()"
-                                 testid="goal-list-empty" (action)="onNewGoal()" />
-              }
-            </td>
-          </tr>
-        </ng-template>
-      </p-table>
+      </app-data-table>
     </app-list-page>
+
+    <ng-template #textCell let-g>
+      <span class="text-preview">{{ g.text | slice:0:80 }}{{ g.text?.length > 80 ? '...' : '' }}</span>
+    </ng-template>
+    <ng-template #tagsCell let-g>
+      <span class="chips" data-testid="goal-row-tags">
+        @for (t of tagsForGoal(g.id); track t.id) {
+          <app-chip [label]="label(t)" [tone]="'primary'" [attr.data-tag]="label(t)" />
+        }
+      </span>
+    </ng-template>
   `,
   styles: [`
-    .text-preview { max-width: 400px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .goal-toolbar-actions { display: flex; align-items: center; gap: var(--rq-space-2); }
+    .text-preview { display: inline-block; max-width: 400px; overflow: hidden;
+      text-overflow: ellipsis; white-space: nowrap; vertical-align: bottom; }
     .tag-filter { min-width: 200px; }
     .chips { display: inline-flex; flex-wrap: wrap; gap: 0.3rem; }
   `]
@@ -131,6 +117,22 @@ export class GoalListComponent implements OnInit, OnDestroy {
     return this.goals().filter(g => (byGoal.get(g.id) ?? []).some(t => t.id === tagId));
   });
 
+  /** Custom cell renderers (static — declared at the top level of the view). */
+  @ViewChild('textCell', { static: true }) textCell!: TemplateRef<{ $implicit: GoalDto }>;
+  @ViewChild('tagsCell', { static: true }) tagsCell!: TemplateRef<{ $implicit: GoalDto }>;
+
+  /** Data-table column config, wired to the cell templates in ngOnInit. */
+  columns: DataTableColumn<GoalDto>[] = [];
+
+  /**
+   * Row `⋯` menu. Goals expose only Open from the list (edit/delete live in the
+   * editor), so we replace the default menu with a single Open action; whole-row
+   * click opens too.
+   */
+  rowActions: RowAction<GoalDto>[] = [
+    { label: 'Open', icon: 'pi pi-eye', command: g => this.openGoal(g) }
+  ];
+
   private projectName = '';
   private paramSub?: Subscription;
 
@@ -143,6 +145,12 @@ export class GoalListComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
+    this.columns = [
+      { field: 'name', header: 'Name', sortable: true },
+      { field: 'text', header: 'Text', cellTemplate: this.textCell, class: 'text-col' },
+      { field: 'tags', header: 'Tags', cellTemplate: this.tagsCell },
+      { field: 'createdBy', header: 'Created By', sortable: true }
+    ];
     this.paramSub = this.route.paramMap.subscribe(async params => {
       const name = params.get('name') ?? '';
       if (name !== this.projectName) {
@@ -206,9 +214,7 @@ export class GoalListComponent implements OnInit, OnDestroy {
     return tagLabel(tag);
   }
 
-  onRowSelect(event: { data?: GoalDto | GoalDto[] }): void {
-    const g = Array.isArray(event.data) ? event.data[0] : event.data;
-    if (!g) return;
+  openGoal(g: GoalDto): void {
     this.router.navigate(['/projects', this.projectName, 'goals', g.id]);
   }
 

--- a/requel-angular/src/app/features/open-issues/open-issues.ts
+++ b/requel-angular/src/app/features/open-issues/open-issues.ts
@@ -18,17 +18,17 @@
  * along with Requel. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import { Component, OnDestroy, OnInit, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, TemplateRef, ViewChild, signal } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { projectApiUrl } from '../../core/api-url';
-import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
 import { BadgeModule } from 'primeng/badge';
 import { MessageModule } from 'primeng/message';
 import { ListPageComponent } from '../../shared/list-page';
+import { AppDataTableComponent, DataTableColumn } from '../../shared/app-data-table';
 
 interface OpenIssueDto {
   issueId: number;
@@ -55,60 +55,41 @@ const ENTITY_ROUTES: Record<string, string> = {
 @Component({
   selector: 'app-open-issues',
   standalone: true,
-  imports: [ListPageComponent, RouterLink, TableModule, ButtonModule, BadgeModule, MessageModule],
+  imports: [ListPageComponent, AppDataTableComponent, RouterLink, ButtonModule, BadgeModule, MessageModule],
   template: `
-    <app-list-page title="Open Issues" searchPlaceholder="Search issues..."
-                   (search)="dt.filterGlobal($event, 'contains')">
-      <ng-container actions>
-        @if (mustResolveCount() > 0) {
-          <p-badge [value]="mustResolveCount().toString()" severity="danger" data-testid="open-issues-badge" />
-        }
-      </ng-container>
-
+    <app-list-page title="Open Issues" [showSearch]="false">
       @if (errorMessage()) {
         <p-message severity="error" [text]="errorMessage()!" data-testid="open-issues-error" />
       }
 
-      @if (!loading() && issues().length === 0) {
-        <p-message severity="success" text="No open issues — all clear." data-testid="open-issues-empty" />
-      }
-
-      <p-table #dt [value]="issues()" [loading]="loading()" [paginator]="true" [rows]="25"
-               [rowHover]="true" [globalFilterFields]="['entityType', 'entityName', 'issueText']"
-               [sortField]="'entityType'" [sortOrder]="1">
-        <ng-template #header>
-          <tr>
-            <th pSortableColumn="entityType">Type <p-sortIcon field="entityType" /></th>
-            <th pSortableColumn="entityName">Entity <p-sortIcon field="entityName" /></th>
-            <th pSortableColumn="issueText">Issue <p-sortIcon field="issueText" /></th>
-            <th>Required</th>
-          </tr>
-        </ng-template>
-        <ng-template #body let-issue>
-          <tr>
-            <td>{{ issue.entityType }}</td>
-            <td>
-              @if (routeFor(issue); as route) {
-                <a class="entity-link" data-testid="open-issue-entity-link" [routerLink]="route">{{ issue.entityName }}</a>
-              } @else {
-                <span data-testid="open-issue-entity-name">{{ issue.entityName }}</span>
-              }
-            </td>
-            <td>{{ issue.issueText }}</td>
-            <td>
-              @if (issue.mustBeResolved) {
-                <span class="must-resolve" data-testid="open-issue-required">Yes</span>
-              } @else {
-                <span class="optional" data-testid="open-issue-optional">No</span>
-              }
-            </td>
-          </tr>
-        </ng-template>
-        <ng-template #emptymessage>
-          <tr><td colspan="4" class="text-center">No open issues.</td></tr>
-        </ng-template>
-      </p-table>
+      <app-data-table [value]="issues()" [columns]="columns" [loading]="loading()"
+                      [rowClickable]="false" [defaultActions]="false" [rows]="25"
+                      sortField="entityType" [sortOrder]="1" searchPlaceholder="Search issues..."
+                      [globalFilterFields]="['entityType', 'entityName', 'issueText']"
+                      testid="open-issues" emptyTitle="No open issues"
+                      emptyMessage="All clear — everything in this project is resolved." emptyIcon="pi-check-circle">
+        <div toolbarActions>
+          @if (mustResolveCount() > 0) {
+            <p-badge [value]="mustResolveCount().toString()" severity="danger" data-testid="open-issues-badge" />
+          }
+        </div>
+      </app-data-table>
     </app-list-page>
+
+    <ng-template #entityCell let-issue>
+      @if (routeFor(issue); as route) {
+        <a class="entity-link" data-testid="open-issue-entity-link" [routerLink]="route">{{ issue.entityName }}</a>
+      } @else {
+        <span data-testid="open-issue-entity-name">{{ issue.entityName }}</span>
+      }
+    </ng-template>
+    <ng-template #requiredCell let-issue>
+      @if (issue.mustBeResolved) {
+        <span class="must-resolve" data-testid="open-issue-required">Yes</span>
+      } @else {
+        <span class="optional" data-testid="open-issue-optional">No</span>
+      }
+    </ng-template>
   `,
   styles: [`
     .entity-link { color: var(--p-primary-color); cursor: pointer; text-decoration: underline; }
@@ -125,6 +106,10 @@ export class OpenIssuesComponent implements OnInit, OnDestroy {
   errorMessage = signal<string | null>(null);
   mustResolveCount = signal(0);
 
+  @ViewChild('entityCell', { static: true }) entityCell!: TemplateRef<{ $implicit: OpenIssueDto }>;
+  @ViewChild('requiredCell', { static: true }) requiredCell!: TemplateRef<{ $implicit: OpenIssueDto }>;
+  columns: DataTableColumn<OpenIssueDto>[] = [];
+
   private projectName = '';
   private paramSub?: Subscription;
 
@@ -135,6 +120,12 @@ export class OpenIssuesComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
+    this.columns = [
+      { field: 'entityType', header: 'Type', sortable: true },
+      { field: 'entityName', header: 'Entity', sortable: true, cellTemplate: this.entityCell },
+      { field: 'issueText', header: 'Issue', sortable: true },
+      { field: 'mustBeResolved', header: 'Required', cellTemplate: this.requiredCell }
+    ];
     this.paramSub = this.route.paramMap.subscribe(params => {
       const name = params.get('name') ?? '';
       if (name !== this.projectName) {

--- a/requel-angular/src/app/features/projects/project-list.ts
+++ b/requel-angular/src/app/features/projects/project-list.ts
@@ -20,7 +20,6 @@
  */
 import { Component, OnInit, signal } from '@angular/core';
 import { Router } from '@angular/router';
-import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
 import { MessageModule } from 'primeng/message';
 import { ProjectDto } from '../../models/project';
@@ -28,25 +27,14 @@ import { ProjectService } from '../../core/project.service';
 import { AuthService } from '../../core/auth.service';
 import { ListPageComponent } from '../../shared/list-page';
 import { FileUploadButtonComponent } from '../../shared/file-upload-button';
-import { EmptyStateComponent } from '../../shared/empty-state';
+import { AppDataTableComponent, DataTableColumn, RowAction } from '../../shared/app-data-table';
 
 @Component({
   selector: 'app-project-list',
   standalone: true,
-  imports: [ListPageComponent, TableModule, ButtonModule, MessageModule, FileUploadButtonComponent, EmptyStateComponent],
+  imports: [ListPageComponent, AppDataTableComponent, ButtonModule, MessageModule, FileUploadButtonComponent],
   template: `
-    <app-list-page title="Projects" searchPlaceholder="Search projects..."
-                   (search)="dt.filterGlobal($event, 'contains')">
-      <ng-container actions>
-        @if (canCreateProjects()) {
-          <p-button label="New Project" icon="pi pi-plus" data-testid="project-list-new-project" (onClick)="onNewProject()" />
-          <app-file-upload-button label="Import" [outlined]="true" [loading]="importing()"
-                                  accept=".xml" buttonTestid="project-list-import-button"
-                                  inputTestid="project-list-import-input"
-                                  (fileSelected)="onImportFile($event)" />
-        }
-      </ng-container>
-
+    <app-list-page title="Projects" [showSearch]="false">
       @if (errorMessage()) {
         <p-message severity="error" [text]="errorMessage()!" data-testid="project-list-error" />
       }
@@ -54,48 +42,29 @@ import { EmptyStateComponent } from '../../shared/empty-state';
         <p-message severity="success" [text]="successMessage()!" data-testid="project-list-success" />
       }
 
-      <p-table #dt [value]="projects()" [loading]="loading()" [paginator]="true" [rows]="20"
-               [rowHover]="true" selectionMode="single" (onRowSelect)="onRowSelect($event)"
-               [globalFilterFields]="['name', 'organizationName', 'status', 'createdBy']">
-        <ng-template #header>
-          <tr>
-            <th pSortableColumn="name">Name <p-sortIcon field="name" /></th>
-            <th pSortableColumn="organizationName">Organization <p-sortIcon field="organizationName" /></th>
-            <th pSortableColumn="status">Status <p-sortIcon field="status" /></th>
-            <th pSortableColumn="createdBy">Created By <p-sortIcon field="createdBy" /></th>
-            <th>Stakeholders</th>
-            <th>Goals</th>
-            <th>Stories</th>
-            <th>Use Cases</th>
-          </tr>
-        </ng-template>
-        <ng-template #body let-project>
-          <tr [pSelectableRow]="project">
-            <td>{{ project.name }}</td>
-            <td>{{ project.organizationName }}</td>
-            <td>{{ project.status }}</td>
-            <td>{{ project.createdBy }}</td>
-            <td>{{ project.stakeholderCount }}</td>
-            <td>{{ project.goalCount }}</td>
-            <td>{{ project.storyCount }}</td>
-            <td>{{ project.useCaseCount }}</td>
-          </tr>
-        </ng-template>
-        <ng-template #emptymessage>
-          <tr>
-            <td colspan="8">
-              <app-empty-state title="No projects yet"
-                               message="Create a project to start capturing goals, stories, and use cases — or import an existing one."
-                               icon="pi-folder-open" actionLabel="New Project"
-                               [showAction]="canCreateProjects()" testid="project-list-empty"
-                               (action)="onNewProject()" />
-            </td>
-          </tr>
-        </ng-template>
-      </p-table>
+      <app-data-table [value]="projects()" [columns]="columns" [loading]="loading()"
+                      [rowActions]="rowActions" searchPlaceholder="Search projects..."
+                      [globalFilterFields]="['name', 'organizationName', 'status', 'createdBy']"
+                      testid="project-list" (rowClick)="onRowSelect({ data: $event })"
+                      emptyTitle="No projects yet"
+                      emptyMessage="Create a project to start capturing goals, stories, and use cases — or import an existing one."
+                      emptyIcon="pi-folder-open" emptyActionLabel="New Project"
+                      [showEmptyAction]="canCreateProjects()" (emptyAction)="onNewProject()">
+        <div toolbarActions class="project-toolbar-actions">
+          @if (canCreateProjects()) {
+            <p-button label="New Project" icon="pi pi-plus" data-testid="project-list-new-project" (onClick)="onNewProject()" />
+            <app-file-upload-button label="Import" [outlined]="true" [loading]="importing()"
+                                    accept=".xml" buttonTestid="project-list-import-button"
+                                    inputTestid="project-list-import-input"
+                                    (fileSelected)="onImportFile($event)" />
+          }
+        </div>
+      </app-data-table>
     </app-list-page>
   `,
-  styles: []
+  styles: [`
+    .project-toolbar-actions { display: flex; align-items: center; gap: var(--rq-space-2); }
+  `]
 })
 export class ProjectListComponent implements OnInit {
 
@@ -107,6 +76,19 @@ export class ProjectListComponent implements OnInit {
 
   readonly canCreateProjects = signal(false);
 
+  columns: DataTableColumn<ProjectDto>[] = [
+    { field: 'name', header: 'Name', sortable: true },
+    { field: 'organizationName', header: 'Organization', sortable: true },
+    { field: 'status', header: 'Status', sortable: true },
+    { field: 'createdBy', header: 'Created By', sortable: true },
+    { field: 'stakeholderCount', header: 'Stakeholders' },
+    { field: 'goalCount', header: 'Goals' },
+    { field: 'storyCount', header: 'Stories' },
+    { field: 'useCaseCount', header: 'Use Cases' }
+  ];
+  rowActions: RowAction<ProjectDto>[] = [
+    { label: 'Open', icon: 'pi pi-eye', command: p => this.onRowSelect({ data: p }) }
+  ];
 
   constructor(
     private projectService: ProjectService,

--- a/requel-angular/src/app/features/reports/report-list.ts
+++ b/requel-angular/src/app/features/reports/report-list.ts
@@ -21,62 +21,51 @@
 import { Component, OnDestroy, OnInit, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
-import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
 import { MessageModule } from 'primeng/message';
 import { ReportGeneratorDto } from '../../models/report';
 import { ReportService } from '../../core/report.service';
 import { PermissionService } from '../../core/permission.service';
 import { ListPageComponent } from '../../shared/list-page';
+import { AppDataTableComponent, DataTableColumn } from '../../shared/app-data-table';
 
 @Component({
   selector: 'app-report-list',
   standalone: true,
-  imports: [ListPageComponent, TableModule, ButtonModule, MessageModule],
+  imports: [ListPageComponent, AppDataTableComponent, ButtonModule, MessageModule],
   template: `
-    <app-list-page title="Documents" searchPlaceholder="Search documents..."
-                   (search)="dt.filterGlobal($event, 'contains')">
-      <ng-container actions>
-        @if (canEdit()) {
-          <p-button label="New Document" icon="pi pi-plus" data-testid="report-list-new" (onClick)="onNew()" />
-        }
-      </ng-container>
-
+    <app-list-page title="Documents" [showSearch]="false">
       @if (errorMessage()) {
         <p-message severity="error" [text]="errorMessage()!" data-testid="report-list-error" />
       }
 
-      <p-table #dt [value]="reports()" [loading]="loading()" [paginator]="true" [rows]="20"
-               [rowHover]="true" [globalFilterFields]="['name', 'createdBy']">
-        <ng-template #header>
-          <tr>
-            <th pSortableColumn="name">Name <p-sortIcon field="name" /></th>
-            <th pSortableColumn="createdBy">Created By <p-sortIcon field="createdBy" /></th>
-            <th>Actions</th>
-          </tr>
+      <app-data-table [value]="reports()" [columns]="columns" [loading]="loading()"
+                      [rowClickable]="false" rowTestid="report-list-row"
+                      searchPlaceholder="Search documents..."
+                      [globalFilterFields]="['name', 'createdBy']" testid="report-list"
+                      emptyTitle="No documents yet"
+                      emptyMessage="Create a document generator to produce reports from this project."
+                      emptyIcon="pi-file" emptyActionLabel="New Document"
+                      [showEmptyAction]="canEdit()" (emptyAction)="onNew()">
+        <div toolbarActions>
+          @if (canEdit()) {
+            <p-button label="New Document" icon="pi pi-plus" data-testid="report-list-new" (onClick)="onNew()" />
+          }
+        </div>
+        <ng-template #rowActions let-r>
+          <div class="action-cell">
+            <p-button label="Edit" icon="pi pi-pencil" size="small" [text]="true"
+                      data-testid="report-list-edit" (onClick)="onEdit(r)" />
+            <p-button label="Run" icon="pi pi-play" size="small" [text]="true"
+                      data-testid="report-list-run" severity="success"
+                      (onClick)="onRun(r)" [loading]="runningId() === r.id" />
+          </div>
         </ng-template>
-        <ng-template #body let-r>
-          <tr data-testid="report-list-row">
-            <td>{{ r.name }}</td>
-            <td>{{ r.createdBy }}</td>
-            <td class="action-cell">
-              <p-button label="Edit" icon="pi pi-pencil" size="small" [text]="true"
-                        data-testid="report-list-edit"
-                        (onClick)="onEdit(r)" />
-              <p-button label="Run" icon="pi pi-play" size="small" [text]="true"
-                        data-testid="report-list-run"
-                        severity="success" (onClick)="onRun(r)" [loading]="runningId() === r.id" />
-            </td>
-          </tr>
-        </ng-template>
-        <ng-template #emptymessage>
-          <tr data-testid="report-list-empty"><td colspan="3" class="text-center">No documents found.</td></tr>
-        </ng-template>
-      </p-table>
+      </app-data-table>
     </app-list-page>
   `,
   styles: [`
-    .action-cell { display: flex; gap: 0.25rem; }
+    .action-cell { display: flex; gap: 0.25rem; justify-content: flex-end; }
   `]
 })
 export class ReportListComponent implements OnInit, OnDestroy {
@@ -85,6 +74,11 @@ export class ReportListComponent implements OnInit, OnDestroy {
   errorMessage = signal<string | null>(null);
   runningId = signal<number | null>(null);
   canEdit = signal(false);
+
+  columns: DataTableColumn<ReportGeneratorDto>[] = [
+    { field: 'name', header: 'Name', sortable: true },
+    { field: 'createdBy', header: 'Created By', sortable: true }
+  ];
 
   private projectName = '';
   private paramSub?: Subscription;

--- a/requel-angular/src/app/features/scenarios/scenario-list.ts
+++ b/requel-angular/src/app/features/scenarios/scenario-list.ts
@@ -22,50 +22,37 @@ import { Component, OnDestroy, OnInit, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { ButtonModule } from 'primeng/button';
-import { TableModule } from 'primeng/table';
 import { MessageModule } from 'primeng/message';
 import { ScenarioDto } from '../../models/scenario';
 import { ScenarioService } from '../../core/scenario.service';
 import { PermissionService } from '../../core/permission.service';
 import { ListPageComponent } from '../../shared/list-page';
+import { AppDataTableComponent, DataTableColumn, RowAction } from '../../shared/app-data-table';
 
 @Component({
   selector: 'app-scenario-list',
   standalone: true,
-  imports: [ListPageComponent, ButtonModule, TableModule, MessageModule],
+  imports: [ListPageComponent, AppDataTableComponent, ButtonModule, MessageModule],
   template: `
     <app-list-page title="Scenarios" [showSearch]="false">
-      <ng-container actions>
-        @if (canEdit()) {
-          <p-button label="New Scenario" icon="pi pi-plus" (onClick)="onNew()" />
-        }
-      </ng-container>
-
       @if (errorMessage()) {
         <p-message severity="error" [text]="errorMessage()!" />
       }
 
-      <p-table [value]="scenarios()" [loading]="loading()" [rows]="15"
-               [paginator]="scenarios().length > 15" [rowHover]="true"
-               (onRowSelect)="onSelect($event)" selectionMode="single">
-        <ng-template #header>
-          <tr>
-            <th pSortableColumn="name">Name <p-sortIcon field="name" /></th>
-            <th pSortableColumn="scenarioType">Type <p-sortIcon field="scenarioType" /></th>
-            <th pSortableColumn="createdBy">Created By <p-sortIcon field="createdBy" /></th>
-          </tr>
-        </ng-template>
-        <ng-template #body let-s>
-          <tr [pSelectableRow]="s">
-            <td>{{ s.name }}</td>
-            <td>{{ s.scenarioType }}</td>
-            <td>{{ s.createdBy }}</td>
-          </tr>
-        </ng-template>
-        <ng-template #emptymessage>
-          <tr><td colspan="3" class="text-center">No scenarios yet.</td></tr>
-        </ng-template>
-      </p-table>
+      <app-data-table [value]="scenarios()" [columns]="columns" [loading]="loading()"
+                      [rowActions]="rowActions" [rows]="15" searchPlaceholder="Search scenarios..."
+                      [globalFilterFields]="['name', 'scenarioType', 'createdBy']"
+                      testid="scenario-list" (rowClick)="onSelect({ data: $event })"
+                      emptyTitle="No scenarios yet"
+                      emptyMessage="Describe the flows this project needs to support."
+                      emptyIcon="pi-sitemap" emptyActionLabel="New Scenario"
+                      [showEmptyAction]="canEdit()" (emptyAction)="onNew()">
+        <div toolbarActions>
+          @if (canEdit()) {
+            <p-button label="New Scenario" icon="pi pi-plus" (onClick)="onNew()" />
+          }
+        </div>
+      </app-data-table>
     </app-list-page>
   `,
   styles: []
@@ -75,6 +62,15 @@ export class ScenarioListComponent implements OnInit, OnDestroy {
   loading = signal(false);
   errorMessage = signal<string | null>(null);
   canEdit = signal(false);
+
+  columns: DataTableColumn<ScenarioDto>[] = [
+    { field: 'name', header: 'Name', sortable: true },
+    { field: 'scenarioType', header: 'Type', sortable: true },
+    { field: 'createdBy', header: 'Created By', sortable: true }
+  ];
+  rowActions: RowAction<ScenarioDto>[] = [
+    { label: 'Open', icon: 'pi pi-eye', command: s => this.onSelect({ data: s }) }
+  ];
 
   projectName = '';
   private paramSub?: Subscription;

--- a/requel-angular/src/app/features/stakeholders/stakeholder-list.ts
+++ b/requel-angular/src/app/features/stakeholders/stakeholder-list.ts
@@ -18,80 +18,62 @@
  * along with Requel. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import { Component, OnDestroy, OnInit, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, TemplateRef, ViewChild, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
-import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
 import { MessageModule } from 'primeng/message';
 import { StakeholderDto } from '../../models/stakeholder';
 import { StakeholderService } from '../../core/stakeholder.service';
 import { PermissionService } from '../../core/permission.service';
 import { ListPageComponent } from '../../shared/list-page';
-import { EmptyStateComponent } from '../../shared/empty-state';
+import { AppDataTableComponent, DataTableColumn, RowAction } from '../../shared/app-data-table';
 
 @Component({
   selector: 'app-stakeholder-list',
   standalone: true,
-  imports: [ListPageComponent, TableModule, ButtonModule, MessageModule, EmptyStateComponent],
+  imports: [ListPageComponent, AppDataTableComponent, ButtonModule, MessageModule],
   template: `
-    <app-list-page title="Stakeholders" searchPlaceholder="Search stakeholders..."
-                   (search)="dt.filterGlobal($event, 'contains')">
-      <ng-container actions>
-        @if (canEdit()) {
-          <p-button label="Add User" icon="pi pi-user-plus"
-                    (onClick)="onNewUserStakeholder()" />
-          <p-button label="Add Non-User" icon="pi pi-building" severity="secondary"
-                    [outlined]="true" (onClick)="onNewNonUserStakeholder()" />
-        }
-      </ng-container>
-
+    <app-list-page title="Stakeholders" [showSearch]="false">
       @if (errorMessage()) {
         <p-message severity="error" [text]="errorMessage()!" />
       }
 
-      <p-table #dt [value]="stakeholders()" [loading]="loading()" [paginator]="true" [rows]="20"
-               [rowHover]="true" selectionMode="single" (onRowSelect)="onRowSelect($event)"
-               [globalFilterFields]="['name', 'type', 'userDetails.emailAddress', 'userDetails.teamName']">
-        <ng-template #header>
-          <tr>
-            <th pSortableColumn="name">Name <p-sortIcon field="name" /></th>
-            <th pSortableColumn="type">Type <p-sortIcon field="type" /></th>
-            <th>Team</th>
-            <th>Email</th>
-            <th>Phone</th>
-            <th>Created By</th>
-          </tr>
-        </ng-template>
-        <ng-template #body let-s>
-          <tr [pSelectableRow]="s">
-            <td>{{ s.name }}</td>
-            <td>{{ s.type === 'user' ? 'User' : 'Non-User' }}</td>
-            <td>{{ s.userDetails?.teamName }}</td>
-            <td>{{ s.userDetails?.emailAddress }}</td>
-            <td>{{ s.userDetails?.phoneNumber }}</td>
-            <td>{{ s.createdBy }}</td>
-          </tr>
-        </ng-template>
-        <ng-template #emptymessage>
-          <tr>
-            <td colspan="6">
-              <app-empty-state title="No stakeholders yet"
-                               message="Add the people and groups with a stake in this project to capture their perspectives."
-                               icon="pi-users" actionLabel="Add User" [showAction]="canEdit()"
-                               testid="stakeholder-list-empty" (action)="onNewUserStakeholder()" />
-            </td>
-          </tr>
-        </ng-template>
-      </p-table>
+      <app-data-table [value]="stakeholders()" [columns]="columns" [loading]="loading()"
+                      [rowActions]="rowActions" searchPlaceholder="Search stakeholders..."
+                      [globalFilterFields]="['name', 'type', 'userDetails.emailAddress', 'userDetails.teamName']"
+                      testid="stakeholder-list" (rowClick)="onRowSelect({ data: $event })"
+                      emptyTitle="No stakeholders yet"
+                      emptyMessage="Add the people and groups with a stake in this project to capture their perspectives."
+                      emptyIcon="pi-users" emptyActionLabel="Add User"
+                      [showEmptyAction]="canEdit()" (emptyAction)="onNewUserStakeholder()">
+        <div toolbarActions class="stakeholder-toolbar-actions">
+          @if (canEdit()) {
+            <p-button label="Add User" icon="pi pi-user-plus" (onClick)="onNewUserStakeholder()" />
+            <p-button label="Add Non-User" icon="pi pi-building" severity="secondary"
+                      [outlined]="true" (onClick)="onNewNonUserStakeholder()" />
+          }
+        </div>
+      </app-data-table>
     </app-list-page>
-  `
+
+    <ng-template #typeCell let-s>{{ s.type === 'user' ? 'User' : 'Non-User' }}</ng-template>
+  `,
+  styles: [`
+    .stakeholder-toolbar-actions { display: flex; align-items: center; gap: var(--rq-space-2); }
+  `]
 })
 export class StakeholderListComponent implements OnInit, OnDestroy {
   stakeholders = signal<StakeholderDto[]>([]);
   loading = signal(true);
   errorMessage = signal<string | null>(null);
   canEdit = signal(false);
+
+  @ViewChild('typeCell', { static: true }) typeCell!: TemplateRef<{ $implicit: StakeholderDto }>;
+  columns: DataTableColumn<StakeholderDto>[] = [];
+  rowActions: RowAction<StakeholderDto>[] = [
+    { label: 'Open', icon: 'pi pi-eye', command: s => this.onRowSelect({ data: s }) }
+  ];
 
   private projectName = '';
   private paramSub?: Subscription;
@@ -104,6 +86,14 @@ export class StakeholderListComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
+    this.columns = [
+      { field: 'name', header: 'Name', sortable: true },
+      { field: 'type', header: 'Type', sortable: true, cellTemplate: this.typeCell },
+      { field: 'userDetails.teamName', header: 'Team' },
+      { field: 'userDetails.emailAddress', header: 'Email' },
+      { field: 'userDetails.phoneNumber', header: 'Phone' },
+      { field: 'createdBy', header: 'Created By' }
+    ];
     this.paramSub = this.route.paramMap.subscribe(async params => {
       const name = params.get('name') ?? '';
       if (name !== this.projectName) {

--- a/requel-angular/src/app/features/stories/story-list.ts
+++ b/requel-angular/src/app/features/stories/story-list.ts
@@ -18,10 +18,9 @@
  * along with Requel. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import { Component, OnDestroy, OnInit, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, TemplateRef, ViewChild, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
-import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
 import { MessageModule } from 'primeng/message';
 import { SlicePipe } from '@angular/common';
@@ -29,51 +28,41 @@ import { StoryDto } from '../../models/story';
 import { StoryService } from '../../core/story.service';
 import { PermissionService } from '../../core/permission.service';
 import { ListPageComponent } from '../../shared/list-page';
+import { AppDataTableComponent, DataTableColumn, RowAction } from '../../shared/app-data-table';
 
 @Component({
   selector: 'app-story-list',
   standalone: true,
-  imports: [ListPageComponent, TableModule, ButtonModule, MessageModule, SlicePipe],
+  imports: [ListPageComponent, AppDataTableComponent, ButtonModule, MessageModule, SlicePipe],
   template: `
-    <app-list-page title="Stories" [eyebrow]="projectContext()" searchPlaceholder="Search stories..."
-                   (search)="dt.filterGlobal($event, 'contains')">
-      <ng-container actions>
-        @if (canEdit()) {
-          <p-button label="New Story" icon="pi pi-plus" (onClick)="onNewStory()" />
-        }
-      </ng-container>
-
+    <app-list-page title="Stories" [eyebrow]="projectContext()" [showSearch]="false">
       @if (errorMessage()) {
         <p-message severity="error" [text]="errorMessage()!" />
       }
 
-      <p-table #dt [value]="stories()" [loading]="loading()" [paginator]="true" [rows]="20"
-               [rowHover]="true" selectionMode="single" (onRowSelect)="onRowSelect($event)"
-               [globalFilterFields]="['name', 'text', 'storyType', 'createdBy']">
-        <ng-template #header>
-          <tr>
-            <th pSortableColumn="name">Name <p-sortIcon field="name" /></th>
-            <th pSortableColumn="storyType">Type <p-sortIcon field="storyType" /></th>
-            <th>Text</th>
-            <th pSortableColumn="createdBy">Created By <p-sortIcon field="createdBy" /></th>
-          </tr>
-        </ng-template>
-        <ng-template #body let-s>
-          <tr [pSelectableRow]="s">
-            <td>{{ s.name }}</td>
-            <td>{{ s.storyType }}</td>
-            <td class="text-preview">{{ s.text | slice:0:80 }}{{ s.text?.length > 80 ? '...' : '' }}</td>
-            <td>{{ s.createdBy }}</td>
-          </tr>
-        </ng-template>
-        <ng-template #emptymessage>
-          <tr><td colspan="4" class="text-center">No stories found.</td></tr>
-        </ng-template>
-      </p-table>
+      <app-data-table [value]="stories()" [columns]="columns" [loading]="loading()"
+                      [rowActions]="rowActions" searchPlaceholder="Search stories..."
+                      [globalFilterFields]="['name', 'text', 'storyType', 'createdBy']"
+                      testid="story-list" (rowClick)="onRowSelect({ data: $event })"
+                      emptyTitle="No stories yet"
+                      emptyMessage="Capture the user stories this project needs to deliver."
+                      emptyIcon="pi-book" emptyActionLabel="New Story"
+                      [showEmptyAction]="canEdit()" (emptyAction)="onNewStory()">
+        <div toolbarActions>
+          @if (canEdit()) {
+            <p-button label="New Story" icon="pi pi-plus" (onClick)="onNewStory()" />
+          }
+        </div>
+      </app-data-table>
     </app-list-page>
+
+    <ng-template #textCell let-s>
+      <span class="text-preview">{{ s.text | slice:0:80 }}{{ s.text?.length > 80 ? '...' : '' }}</span>
+    </ng-template>
   `,
   styles: [`
-    .text-preview { max-width: 400px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .text-preview { display: inline-block; max-width: 400px; overflow: hidden;
+      text-overflow: ellipsis; white-space: nowrap; vertical-align: bottom; }
   `]
 })
 export class StoryListComponent implements OnInit, OnDestroy {
@@ -83,6 +72,12 @@ export class StoryListComponent implements OnInit, OnDestroy {
   canEdit = signal(false);
   /** Project-name context shown as the page eyebrow (issue #127). */
   projectContext = signal('');
+
+  @ViewChild('textCell', { static: true }) textCell!: TemplateRef<{ $implicit: StoryDto }>;
+  columns: DataTableColumn<StoryDto>[] = [];
+  rowActions: RowAction<StoryDto>[] = [
+    { label: 'Open', icon: 'pi pi-eye', command: s => this.onRowSelect({ data: s }) }
+  ];
 
   private projectName = '';
   private paramSub?: Subscription;
@@ -95,6 +90,12 @@ export class StoryListComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
+    this.columns = [
+      { field: 'name', header: 'Name', sortable: true },
+      { field: 'storyType', header: 'Type', sortable: true },
+      { field: 'text', header: 'Text', cellTemplate: this.textCell },
+      { field: 'createdBy', header: 'Created By', sortable: true }
+    ];
     this.paramSub = this.route.paramMap.subscribe(async params => {
       const name = params.get('name') ?? '';
       if (name !== this.projectName) {

--- a/requel-angular/src/app/features/terms/term-list.ts
+++ b/requel-angular/src/app/features/terms/term-list.ts
@@ -18,10 +18,9 @@
  * along with Requel. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import { Component, OnDestroy, OnInit, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, TemplateRef, ViewChild, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
-import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
 import { MessageModule } from 'primeng/message';
 import { SlicePipe } from '@angular/common';
@@ -29,51 +28,42 @@ import { GlossaryTermDto } from '../../models/term';
 import { TermService } from '../../core/term.service';
 import { PermissionService } from '../../core/permission.service';
 import { ListPageComponent } from '../../shared/list-page';
+import { AppDataTableComponent, DataTableColumn, RowAction } from '../../shared/app-data-table';
 
 @Component({
   selector: 'app-term-list',
   standalone: true,
-  imports: [ListPageComponent, TableModule, ButtonModule, MessageModule, SlicePipe],
+  imports: [ListPageComponent, AppDataTableComponent, ButtonModule, MessageModule, SlicePipe],
   template: `
-    <app-list-page title="Terms" searchPlaceholder="Search terms..."
-                   (search)="dt.filterGlobal($event, 'contains')">
-      <ng-container actions>
-        @if (canEdit()) {
-          <p-button label="New Term" icon="pi pi-plus" (onClick)="onNewTerm()" />
-        }
-      </ng-container>
-
+    <app-list-page title="Terms" [showSearch]="false">
       @if (errorMessage()) {
         <p-message severity="error" [text]="errorMessage()!" />
       }
 
-      <p-table #dt [value]="terms()" [loading]="loading()" [paginator]="true" [rows]="20"
-               [rowHover]="true" selectionMode="single" (onRowSelect)="onRowSelect($event)"
-               [globalFilterFields]="['name', 'text', 'canonicalTermName', 'createdBy']">
-        <ng-template #header>
-          <tr>
-            <th pSortableColumn="name">Term <p-sortIcon field="name" /></th>
-            <th>Definition</th>
-            <th pSortableColumn="canonicalTermName">Canonical Term <p-sortIcon field="canonicalTermName" /></th>
-            <th pSortableColumn="createdBy">Created By <p-sortIcon field="createdBy" /></th>
-          </tr>
-        </ng-template>
-        <ng-template #body let-t>
-          <tr [pSelectableRow]="t">
-            <td>{{ t.name }}</td>
-            <td class="text-preview">{{ t.text | slice:0:80 }}{{ (t.text?.length ?? 0) > 80 ? '...' : '' }}</td>
-            <td>{{ t.canonicalTermName ?? '—' }}</td>
-            <td>{{ t.createdBy }}</td>
-          </tr>
-        </ng-template>
-        <ng-template #emptymessage>
-          <tr><td colspan="4" class="text-center">No glossary terms found.</td></tr>
-        </ng-template>
-      </p-table>
+      <app-data-table [value]="terms()" [columns]="columns" [loading]="loading()"
+                      [rowActions]="rowActions" searchPlaceholder="Search terms..."
+                      [globalFilterFields]="['name', 'text', 'canonicalTermName', 'createdBy']"
+                      testid="term-list" (rowClick)="onRowSelect({ data: $event })"
+                      emptyTitle="No glossary terms yet"
+                      emptyMessage="Define the shared vocabulary this project relies on."
+                      emptyIcon="pi-book" emptyActionLabel="New Term"
+                      [showEmptyAction]="canEdit()" (emptyAction)="onNewTerm()">
+        <div toolbarActions>
+          @if (canEdit()) {
+            <p-button label="New Term" icon="pi pi-plus" (onClick)="onNewTerm()" />
+          }
+        </div>
+      </app-data-table>
     </app-list-page>
+
+    <ng-template #textCell let-t>
+      <span class="text-preview">{{ t.text | slice:0:80 }}{{ (t.text?.length ?? 0) > 80 ? '...' : '' }}</span>
+    </ng-template>
+    <ng-template #canonicalCell let-t>{{ t.canonicalTermName ?? '—' }}</ng-template>
   `,
   styles: [`
-    .text-preview { max-width: 350px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .text-preview { display: inline-block; max-width: 350px; overflow: hidden;
+      text-overflow: ellipsis; white-space: nowrap; vertical-align: bottom; }
   `]
 })
 export class TermListComponent implements OnInit, OnDestroy {
@@ -81,6 +71,13 @@ export class TermListComponent implements OnInit, OnDestroy {
   loading = signal(true);
   errorMessage = signal<string | null>(null);
   canEdit = signal(false);
+
+  @ViewChild('textCell', { static: true }) textCell!: TemplateRef<{ $implicit: GlossaryTermDto }>;
+  @ViewChild('canonicalCell', { static: true }) canonicalCell!: TemplateRef<{ $implicit: GlossaryTermDto }>;
+  columns: DataTableColumn<GlossaryTermDto>[] = [];
+  rowActions: RowAction<GlossaryTermDto>[] = [
+    { label: 'Open', icon: 'pi pi-eye', command: t => this.onRowSelect({ data: t }) }
+  ];
 
   private projectName = '';
   private paramSub?: Subscription;
@@ -93,6 +90,12 @@ export class TermListComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
+    this.columns = [
+      { field: 'name', header: 'Term', sortable: true },
+      { field: 'text', header: 'Definition', cellTemplate: this.textCell },
+      { field: 'canonicalTermName', header: 'Canonical Term', sortable: true, cellTemplate: this.canonicalCell },
+      { field: 'createdBy', header: 'Created By', sortable: true }
+    ];
     this.paramSub = this.route.paramMap.subscribe(async params => {
       const name = params.get('name') ?? '';
       if (name !== this.projectName) {

--- a/requel-angular/src/app/features/use-cases/use-case-list.ts
+++ b/requel-angular/src/app/features/use-cases/use-case-list.ts
@@ -18,53 +18,43 @@
  * along with Requel. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import { Component, OnInit, signal } from '@angular/core';
+import { Component, OnInit, TemplateRef, ViewChild, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
 import { MessageModule } from 'primeng/message';
 import { UseCaseDto } from '../../models/use-case';
 import { UseCaseService } from '../../core/use-case.service';
 import { PermissionService } from '../../core/permission.service';
 import { ListPageComponent } from '../../shared/list-page';
+import { AppDataTableComponent, DataTableColumn, RowAction } from '../../shared/app-data-table';
 
 @Component({
   selector: 'app-use-case-list',
   standalone: true,
-  imports: [ListPageComponent, TableModule, ButtonModule, MessageModule],
+  imports: [ListPageComponent, AppDataTableComponent, ButtonModule, MessageModule],
   template: `
     <app-list-page title="Use Cases" [showSearch]="false">
-      <ng-container actions>
-        @if (canEdit()) {
-          <p-button label="New Use Case" icon="pi pi-plus"
-                    (onClick)="onCreate()" />
-        }
-      </ng-container>
       @if (errorMessage()) {
         <p-message severity="error" [text]="errorMessage()!" />
       }
-      <p-table [value]="useCases()" [loading]="loading()"
-               selectionMode="single" (onRowSelect)="onSelect($event)"
-               [rowHover]="true" styleClass="p-datatable-sm">
-        <ng-template pTemplate="header">
-          <tr>
-            <th>Name</th>
-            <th>Primary Actor</th>
-            <th>Created By</th>
-          </tr>
-        </ng-template>
-        <ng-template pTemplate="body" let-uc>
-          <tr [pSelectableRow]="uc">
-            <td>{{ uc.name }}</td>
-            <td>{{ uc.primaryActorName ?? '—' }}</td>
-            <td>{{ uc.createdBy }}</td>
-          </tr>
-        </ng-template>
-        <ng-template pTemplate="emptymessage">
-          <tr><td colspan="3" class="text-center">No use cases yet.</td></tr>
-        </ng-template>
-      </p-table>
+
+      <app-data-table [value]="useCases()" [columns]="columns" [loading]="loading()"
+                      [rowActions]="rowActions" searchPlaceholder="Search use cases..."
+                      [globalFilterFields]="['name', 'primaryActorName', 'createdBy']"
+                      testid="use-case-list" (rowClick)="onSelect({ data: $event })"
+                      emptyTitle="No use cases yet"
+                      emptyMessage="Capture the goals actors accomplish with this system."
+                      emptyIcon="pi-directions" emptyActionLabel="New Use Case"
+                      [showEmptyAction]="canEdit()" (emptyAction)="onCreate()">
+        <div toolbarActions>
+          @if (canEdit()) {
+            <p-button label="New Use Case" icon="pi pi-plus" (onClick)="onCreate()" />
+          }
+        </div>
+      </app-data-table>
     </app-list-page>
+
+    <ng-template #primaryActorCell let-uc>{{ uc.primaryActorName ?? '—' }}</ng-template>
   `,
   styles: []
 })
@@ -73,6 +63,12 @@ export class UseCaseListComponent implements OnInit {
   loading = signal(true);
   errorMessage = signal<string | null>(null);
   canEdit = signal(false);
+
+  @ViewChild('primaryActorCell', { static: true }) primaryActorCell!: TemplateRef<{ $implicit: UseCaseDto }>;
+  columns: DataTableColumn<UseCaseDto>[] = [];
+  rowActions: RowAction<UseCaseDto>[] = [
+    { label: 'Open', icon: 'pi pi-eye', command: uc => this.onSelect({ data: uc }) }
+  ];
 
   private projectName = '';
 
@@ -84,6 +80,11 @@ export class UseCaseListComponent implements OnInit {
   ) {}
 
   async ngOnInit(): Promise<void> {
+    this.columns = [
+      { field: 'name', header: 'Name', sortable: true },
+      { field: 'primaryActorName', header: 'Primary Actor', cellTemplate: this.primaryActorCell },
+      { field: 'createdBy', header: 'Created By', sortable: true }
+    ];
     this.projectName = this.route.snapshot.paramMap.get('name') ?? '';
     await this.permissionService.loadForProject(this.projectName);
     this.canEdit.set(this.permissionService.canEdit('UseCase'));

--- a/requel-angular/src/app/features/users/user-list.ts
+++ b/requel-angular/src/app/features/users/user-list.ts
@@ -18,51 +18,35 @@
  * along with Requel. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import { Component, OnInit, signal } from '@angular/core';
+import { Component, OnInit, TemplateRef, ViewChild, signal } from '@angular/core';
 import { Router } from '@angular/router';
-import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
 import { UserDto } from '../../models/user';
 import { UserService } from '../../core/user.service';
 import { ListPageComponent } from '../../shared/list-page';
+import { AppDataTableComponent, DataTableColumn, RowAction } from '../../shared/app-data-table';
 
 @Component({
   selector: 'app-user-list',
   standalone: true,
-  imports: [ListPageComponent, TableModule, ButtonModule],
+  imports: [ListPageComponent, AppDataTableComponent, ButtonModule],
   template: `
-    <app-list-page title="Users" searchPlaceholder="Search users..."
-                   (search)="dt.filterGlobal($event, 'contains')">
-      <ng-container actions>
-        <p-button label="New User" icon="pi pi-plus" (onClick)="onNewUser()" />
-      </ng-container>
-
-      <p-table #dt [value]="users()" [loading]="loading()" [paginator]="true" [rows]="20"
-               [rowHover]="true" selectionMode="single" (onRowSelect)="onRowSelect($event)"
-               [globalFilterFields]="['username', 'name', 'emailAddress', 'organizationName']">
-        <ng-template #header>
-          <tr>
-            <th pSortableColumn="username">Username <p-sortIcon field="username" /></th>
-            <th pSortableColumn="name">Name <p-sortIcon field="name" /></th>
-            <th pSortableColumn="emailAddress">Email <p-sortIcon field="emailAddress" /></th>
-            <th pSortableColumn="organizationName">Organization <p-sortIcon field="organizationName" /></th>
-            <th>Roles</th>
-          </tr>
-        </ng-template>
-        <ng-template #body let-user>
-          <tr [pSelectableRow]="user" [attr.data-username]="user.username">
-            <td>{{ user.username }}</td>
-            <td>{{ user.name }}</td>
-            <td>{{ user.emailAddress }}</td>
-            <td>{{ user.organizationName }}</td>
-            <td>{{ user.roles.join(', ') }}</td>
-          </tr>
-        </ng-template>
-        <ng-template #emptymessage>
-          <tr><td colspan="5">No users found.</td></tr>
-        </ng-template>
-      </p-table>
+    <app-list-page title="Users" [showSearch]="false">
+      <app-data-table [value]="users()" [columns]="columns" [loading]="loading()"
+                      [rowActions]="rowActions" searchPlaceholder="Search users..."
+                      [globalFilterFields]="['username', 'name', 'emailAddress', 'organizationName']"
+                      testid="user-list" (rowClick)="onRowSelect({ data: $event })"
+                      emptyTitle="No users yet"
+                      emptyMessage="Add the people who can sign in to Requel."
+                      emptyIcon="pi-users" emptyActionLabel="New User"
+                      [showEmptyAction]="true" (emptyAction)="onNewUser()">
+        <div toolbarActions>
+          <p-button label="New User" icon="pi pi-plus" (onClick)="onNewUser()" />
+        </div>
+      </app-data-table>
     </app-list-page>
+
+    <ng-template #rolesCell let-user>{{ user.roles.join(', ') }}</ng-template>
   `,
   styles: []
 })
@@ -71,9 +55,22 @@ export class UserListComponent implements OnInit {
   readonly users = signal<UserDto[]>([]);
   readonly loading = signal(true);
 
+  @ViewChild('rolesCell', { static: true }) rolesCell!: TemplateRef<{ $implicit: UserDto }>;
+  columns: DataTableColumn<UserDto>[] = [];
+  rowActions: RowAction<UserDto>[] = [
+    { label: 'Open', icon: 'pi pi-eye', command: u => this.onRowSelect({ data: u }) }
+  ];
+
   constructor(private userService: UserService, private router: Router) {}
 
   async ngOnInit(): Promise<void> {
+    this.columns = [
+      { field: 'username', header: 'Username', sortable: true },
+      { field: 'name', header: 'Name', sortable: true },
+      { field: 'emailAddress', header: 'Email', sortable: true },
+      { field: 'organizationName', header: 'Organization', sortable: true },
+      { field: 'roles', header: 'Roles', cellTemplate: this.rolesCell }
+    ];
     try {
       const users = await this.userService.listUsers();
       this.users.set(users);

--- a/requel-angular/src/app/shared/app-data-table.spec.ts
+++ b/requel-angular/src/app/shared/app-data-table.spec.ts
@@ -1,0 +1,223 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { Menu } from 'primeng/menu';
+import { AppDataTableComponent, DataTableColumn, RowAction } from './app-data-table';
+
+interface Row {
+  id: number;
+  name: string;
+  createdBy: string;
+  nested?: { label: string };
+}
+
+const ROWS: Row[] = [
+  { id: 1, name: 'Alpha', createdBy: 'alice', nested: { label: 'A-label' } },
+  { id: 2, name: 'Beta', createdBy: 'bob', nested: { label: 'B-label' } }
+];
+
+const COLUMNS: DataTableColumn<Row>[] = [
+  { field: 'name', header: 'Name', sortable: true },
+  { field: 'createdBy', header: 'Created By' },
+  { field: 'nested.label', header: 'Label' }
+];
+
+/** A Menu stub whose toggle we can assert without opening the real popup. */
+const menuStub = () => ({ toggle: vi.fn() }) as unknown as Menu;
+
+describe('AppDataTableComponent (issue #157)', () => {
+  function make() {
+    TestBed.configureTestingModule({
+      imports: [AppDataTableComponent],
+      providers: [provideNoopAnimations()]
+    });
+    const fixture = TestBed.createComponent(AppDataTableComponent<Row>);
+    const comp = fixture.componentInstance;
+    comp.value = ROWS;
+    comp.columns = COLUMNS;
+    return { fixture, comp };
+  }
+
+  it('renders a header per column and default text cells (incl. dotted paths)', () => {
+    const { fixture } = make();
+    fixture.detectChanges();
+    const el: HTMLElement = fixture.nativeElement;
+
+    const headers = Array.from(el.querySelectorAll('thead th')).map(h => h.textContent?.trim());
+    expect(headers).toContain('Name');
+    expect(headers).toContain('Created By');
+    expect(headers).toContain('Label');
+
+    const firstRowCells = Array.from(el.querySelectorAll('tbody tr')[0].querySelectorAll('td'))
+      .map(td => td.textContent?.trim());
+    expect(firstRowCells).toContain('Alpha');
+    expect(firstRowCells).toContain('alice');
+    expect(firstRowCells).toContain('A-label');
+  });
+
+  it('marks a sortable column with a sort icon', () => {
+    const { fixture } = make();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('p-sorticon')).not.toBeNull();
+  });
+
+  it('emits rowClick when a row is clicked', () => {
+    const { fixture, comp } = make();
+    const seen: Row[] = [];
+    comp.rowClick.subscribe((r: Row) => seen.push(r));
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('tbody tr.dt-row').dispatchEvent(new MouseEvent('click'));
+    expect(seen).toEqual([ROWS[0]]);
+  });
+
+  it('filters via the global filter when searching', () => {
+    const { fixture, comp } = make();
+    fixture.detectChanges();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const dt = (comp as any).dt;
+    const spy = vi.spyOn(dt, 'filterGlobal');
+    comp.onSearch('beta');
+    expect(spy).toHaveBeenCalledWith('beta', 'contains');
+  });
+
+  it('renders an empty state when there are no rows', () => {
+    const { fixture, comp } = make();
+    comp.value = [];
+    comp.emptyTitle = 'Nothing yet';
+    fixture.detectChanges();
+
+    const empty = fixture.nativeElement.querySelector('[data-testid="data-table-empty"]');
+    expect(empty).not.toBeNull();
+    expect(empty.textContent).toContain('Nothing yet');
+  });
+
+  describe('selection column', () => {
+    it('renders checkbox controls and emits selectionChange', () => {
+      const { fixture, comp } = make();
+      comp.selectable = true;
+      const emitted: Row[][] = [];
+      comp.selectionChange.subscribe((s: Row[]) => emitted.push(s));
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('p-tableheadercheckbox')).not.toBeNull();
+      expect(fixture.nativeElement.querySelectorAll('p-tablecheckbox').length).toBe(ROWS.length);
+
+      comp.onSelectionChange([ROWS[1]]);
+      expect(emitted).toEqual([[ROWS[1]]]);
+    });
+
+    it('has no selection column by default', () => {
+      const { fixture } = make();
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('p-tableheadercheckbox')).toBeNull();
+    });
+  });
+
+  it('omits the actions column when defaultActions is false and no override is given', () => {
+    const { fixture, comp } = make();
+    comp.defaultActions = false;
+    fixture.detectChanges();
+    expect(comp.hasRowActions).toBe(false);
+    expect(fixture.nativeElement.querySelector('[data-testid="data-table-row-actions"]')).toBeNull();
+  });
+
+  it('does not emit rowClick or mark rows clickable when rowClickable is false', () => {
+    const { fixture, comp } = make();
+    comp.rowClickable = false;
+    const seen: Row[] = [];
+    comp.rowClick.subscribe((r: Row) => seen.push(r));
+    fixture.detectChanges();
+
+    const row = fixture.nativeElement.querySelector('tbody tr.dt-row');
+    expect(row.classList.contains('dt-row--clickable')).toBe(false);
+    row.dispatchEvent(new MouseEvent('click'));
+    expect(seen).toEqual([]);
+  });
+
+  describe('row-action menu', () => {
+    it('gives the ⋯ trigger an accessible name (#136/#137)', () => {
+      const { fixture } = make();
+      fixture.detectChanges();
+      const trigger = fixture.nativeElement.querySelector('[data-testid="data-table-row-actions"]');
+      expect(trigger.getAttribute('aria-label')).toBe('Row actions');
+    });
+
+    it('builds the default Open/Edit/Delete menu and wires the outputs', () => {
+      const { comp } = make();
+      const opened: Row[] = [];
+      const edited: Row[] = [];
+      const deleted: Row[] = [];
+      comp.open.subscribe((r: Row) => opened.push(r));
+      comp.edit.subscribe((r: Row) => edited.push(r));
+      comp.delete.subscribe((r: Row) => deleted.push(r));
+
+      const menu = menuStub();
+      comp.openRowMenu(ROWS[0], new MouseEvent('click'), menu);
+      expect(menu.toggle).toHaveBeenCalled();
+      expect(comp.menuModel.map(m => m.label)).toEqual(['Open', 'Edit', 'Delete']);
+
+      comp.menuModel.forEach(m => m.command?.({} as never));
+      expect(opened).toEqual([ROWS[0]]);
+      expect(edited).toEqual([ROWS[0]]);
+      expect(deleted).toEqual([ROWS[0]]);
+    });
+
+    it('gates Edit and Delete by canEdit/canDelete', () => {
+      const { comp } = make();
+      comp.canEdit = false;
+      comp.canDelete = false;
+      comp.openRowMenu(ROWS[0], new MouseEvent('click'), menuStub());
+      expect(comp.menuModel.map(m => m.label)).toEqual(['Open']);
+    });
+
+    it('replaces the default menu with the [rowActions] input (respecting visible)', () => {
+      const { comp } = make();
+      const archived: Row[] = [];
+      const actions: RowAction<Row>[] = [
+        { label: 'Archive', command: r => archived.push(r) },
+        { label: 'Restore', command: () => {}, visible: r => r.id === 99 }
+      ];
+      comp.rowActions = actions;
+      comp.openRowMenu(ROWS[0], new MouseEvent('click'), menuStub());
+
+      expect(comp.menuModel.map(m => m.label)).toEqual(['Archive']);
+      comp.menuModel[0].command?.({} as never);
+      expect(archived).toEqual([ROWS[0]]);
+    });
+  });
+});
+
+/** Host exercising the custom cell + full row-action template overrides. */
+@Component({
+  standalone: true,
+  imports: [AppDataTableComponent],
+  template: `
+    <app-data-table [value]="rows" [columns]="columns">
+      <ng-template #rowActions let-row>
+        <button type="button" data-testid="custom-action">Do {{ row.name }}</button>
+      </ng-template>
+    </app-data-table>
+  `
+})
+class OverrideHostComponent {
+  rows: Row[] = ROWS;
+  columns: DataTableColumn<Row>[] = [{ field: 'name', header: 'Name' }];
+}
+
+describe('AppDataTableComponent template overrides', () => {
+  it('replaces the ⋯ menu with a projected <ng-template #rowActions>', () => {
+    TestBed.configureTestingModule({
+      imports: [OverrideHostComponent],
+      providers: [provideNoopAnimations()]
+    });
+    const fixture = TestBed.createComponent(OverrideHostComponent);
+    fixture.detectChanges();
+    const el: HTMLElement = fixture.nativeElement;
+
+    expect(el.querySelector('[data-testid="data-table-row-actions"]')).toBeNull();
+    const custom = el.querySelectorAll('[data-testid="custom-action"]');
+    expect(custom.length).toBe(ROWS.length);
+    expect(custom[0].textContent?.trim()).toBe('Do Alpha');
+  });
+});

--- a/requel-angular/src/app/shared/app-data-table.ts
+++ b/requel-angular/src/app/shared/app-data-table.ts
@@ -1,0 +1,340 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import { NgTemplateOutlet } from '@angular/common';
+import {
+  Component, ContentChild, EventEmitter, Input, Output, TemplateRef, ViewChild
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MenuItem } from 'primeng/api';
+import { ButtonModule } from 'primeng/button';
+import { InputText } from 'primeng/inputtext';
+import { Menu, MenuModule } from 'primeng/menu';
+import { Table, TableModule } from 'primeng/table';
+import { EmptyStateComponent } from './empty-state';
+
+/**
+ * Column descriptor for {@link AppDataTableComponent}. A column renders
+ * `row[field]` as text by default; supply a {@link cellTemplate} for custom
+ * content (tag chips, truncated previews, an `app-tag` status). Mark
+ * {@link sortable} to add a PrimeNG sortable header.
+ */
+export interface DataTableColumn<T = unknown> {
+  /** Property path on the row used for the value, sorting, and global filter. */
+  field: string;
+  /** Column header text. */
+  header: string;
+  /** Adds a sortable header when true. */
+  sortable?: boolean;
+  /** Custom cell renderer; receives the row as `$implicit`. */
+  cellTemplate?: TemplateRef<{ $implicit: T }>;
+  /** Optional class applied to the `<td>` (e.g. a width/truncation helper). */
+  class?: string;
+}
+
+/**
+ * Declarative row action for the `⋯` menu. Passing a `rowActions` array
+ * **replaces** the default Open/Edit/Delete set (replace, never merge — a page
+ * either takes the default or fully owns its actions). For a fully custom menu,
+ * project a `<ng-template #rowActions let-row>` instead.
+ */
+export interface RowAction<T = unknown> {
+  label: string;
+  icon?: string;
+  command: (row: T) => void;
+  /** When present and false for a row, the item is omitted for that row. */
+  visible?: (row: T) => boolean;
+  /** When present and true for a row, the item renders disabled. */
+  disabled?: (row: T) => boolean;
+}
+
+/**
+ * Shared data-table pattern (issue #157, N4). A standalone wrapper over PrimeNG
+ * `Table` so list surfaces share one toolbar/sort/paginate/row-action shape and
+ * can be reused outside the list-page shell (dialogs, editor sub-panels).
+ *
+ * Search ownership: the table owns its search box (issue #157). On a full list
+ * page, host it inside `app-list-page` with `[showSearch]="false"` so there is a
+ * single search input driving the table's global filter.
+ *
+ * Row actions (a11y #136/#137): the trailing `⋯` opens a PrimeNG popup menu of
+ * real, labelled buttons. Precedence is projected template > `rowActions` input
+ * > built-in Open/Edit/Delete. Whole-row click also emits `rowClick` as a
+ * convenience affordance; the menu is the keyboard-accessible path.
+ *
+ * States (#131): empty rows fall through to `app-empty-state` (configurable via
+ * the `empty*` inputs) unless an `[empty]` template is projected.
+ */
+@Component({
+  selector: 'app-data-table',
+  standalone: true,
+  imports: [
+    TableModule, MenuModule, ButtonModule, InputText, FormsModule,
+    NgTemplateOutlet, EmptyStateComponent
+  ],
+  template: `
+    @if (showToolbar) {
+      <div class="dt-toolbar">
+        @if (title) { <h2 class="rq-section-title dt-title">{{ title }}</h2> }
+        <div class="dt-toolbar-right">
+          <span class="p-input-icon-left dt-search">
+            <i class="pi pi-search"></i>
+            <input pInputText type="text" [(ngModel)]="searchText"
+                   [placeholder]="searchPlaceholder" aria-label="Search"
+                   data-testid="data-table-search"
+                   (input)="onSearch($any($event.target).value)" />
+          </span>
+          <ng-content select="[toolbarActions]" />
+        </div>
+      </div>
+    }
+
+    <p-table #dt [value]="value" [loading]="loading" [rowHover]="true"
+             [paginator]="paginator" [rows]="rows"
+             [dataKey]="dataKey" [sortField]="sortField" [sortOrder]="sortOrder"
+             [selectionMode]="null"
+             [(selection)]="selection" (selectionChange)="onSelectionChange($event)"
+             [globalFilterFields]="filterFields"
+             [showCurrentPageReport]="false"
+             [paginatorPosition]="'bottom'"
+             styleClass="rq-data-table">
+      <ng-template #header>
+        <tr>
+          @if (selectable) {
+            <th class="dt-select-col"><p-tableHeaderCheckbox /></th>
+          }
+          @for (col of columns; track col.field) {
+            @if (col.sortable) {
+              <th [pSortableColumn]="col.field" [class]="col.class ?? ''">
+                {{ col.header }} <p-sortIcon [field]="col.field" />
+              </th>
+            } @else {
+              <th [class]="col.class ?? ''">{{ col.header }}</th>
+            }
+          }
+          @if (hasRowActions) { <th class="dt-actions-col"></th> }
+        </tr>
+      </ng-template>
+
+      <ng-template #body let-row>
+        <tr class="dt-row" [class.dt-row--clickable]="rowClickable"
+            [attr.data-testid]="rowTestid" (click)="rowClickable && rowClick.emit(row)">
+          @if (selectable) {
+            <td class="dt-select-col" (click)="$event.stopPropagation()">
+              <p-tableCheckbox [value]="row" />
+            </td>
+          }
+          @for (col of columns; track col.field) {
+            <td [class]="col.class ?? ''">
+              @if (col.cellTemplate) {
+                <ng-container [ngTemplateOutlet]="col.cellTemplate"
+                              [ngTemplateOutletContext]="{ $implicit: row }" />
+              } @else {
+                {{ getValue(row, col.field) }}
+              }
+            </td>
+          }
+          @if (hasRowActions) {
+            <td class="dt-actions-col" (click)="$event.stopPropagation()">
+              @if (rowActionsTemplate) {
+                <ng-container [ngTemplateOutlet]="rowActionsTemplate"
+                              [ngTemplateOutletContext]="{ $implicit: row }" />
+              } @else {
+                <p-button icon="pi pi-ellipsis-v" [text]="true" [rounded]="true"
+                          severity="secondary" size="small"
+                          [attr.aria-label]="actionsAriaLabel"
+                          data-testid="data-table-row-actions"
+                          (onClick)="openRowMenu(row, $event, rowMenu)" />
+              }
+            </td>
+          }
+        </tr>
+      </ng-template>
+
+      <ng-template #emptymessage>
+        <tr>
+          <td [attr.colspan]="totalColumns">
+            @if (emptyTemplate) {
+              <ng-container [ngTemplateOutlet]="emptyTemplate" />
+            } @else {
+              <app-empty-state [title]="emptyTitle" [message]="emptyMessage"
+                               [icon]="emptyIcon" [actionLabel]="emptyActionLabel"
+                               [actionIcon]="emptyActionIcon" [showAction]="showEmptyAction"
+                               [testid]="testid + '-empty'" (action)="emptyAction.emit()" />
+            }
+          </td>
+        </tr>
+      </ng-template>
+    </p-table>
+
+    <p-menu #rowMenu [popup]="true" [model]="menuModel" appendTo="body" />
+  `,
+  styles: [`
+    :host { display: block; }
+    .dt-toolbar {
+      display: flex; justify-content: space-between; align-items: center;
+      gap: var(--rq-space-4); margin-bottom: var(--rq-space-4); flex-wrap: wrap;
+    }
+    .dt-title { margin: 0; }
+    .dt-toolbar-right { display: flex; align-items: center; gap: var(--rq-space-2); }
+    .dt-search { display: inline-flex; align-items: center; }
+    .dt-row--clickable { cursor: pointer; }
+    .dt-select-col { width: 3rem; text-align: center; }
+    .dt-actions-col { width: 3rem; text-align: right; }
+  `]
+})
+export class AppDataTableComponent<T = Record<string, unknown>> {
+  /** Rows to render (loaded client-side; search/sort/paginate are client-side). */
+  @Input() value: T[] = [];
+  /** Column configuration. */
+  @Input() columns: DataTableColumn<T>[] = [];
+  /** Drives the PrimeNG loading overlay. */
+  @Input() loading = false;
+  /** Show the built-in paginator. */
+  @Input() paginator = true;
+  /** Page size. */
+  @Input() rows = 20;
+  /** Optional initial sort column. */
+  @Input() sortField?: string;
+  /** Initial sort direction (1 = ascending, -1 = descending). */
+  @Input() sortOrder = 1;
+  /** Render the leading checkbox multi-select column. */
+  @Input() selectable = false;
+  /** Whether whole-row click opens (emits rowClick) and shows a pointer cursor. */
+  @Input() rowClickable = true;
+  /** Row identity key, required for stable selection. */
+  @Input() dataKey = 'id';
+  /** Show the internal toolbar (title + search + [toolbarActions] slot). */
+  @Input() showToolbar = true;
+  /** Toolbar title. */
+  @Input() title = '';
+  /** Search placeholder. */
+  @Input() searchPlaceholder = 'Search...';
+  /** Fields the search box filters on; defaults to every column's field. */
+  @Input() globalFilterFields?: string[];
+  /** Accessible name for each row's `⋯` trigger. */
+  @Input() actionsAriaLabel = 'Row actions';
+  /** data-testid stem for the wrapper/empty state. */
+  @Input() testid = 'data-table';
+  /** Optional data-testid applied to every body `<tr>` (for e2e row targeting). */
+  @Input() rowTestid?: string;
+
+  /** Whether to render the built-in Open/Edit/Delete menu when no override is given. */
+  @Input() defaultActions = true;
+  /** Gate the built-in Edit item. */
+  @Input() canEdit = true;
+  /** Gate the built-in Delete item. */
+  @Input() canDelete = true;
+  /** Declarative row actions; when set, replaces the built-in menu. */
+  @Input() rowActions?: RowAction<T>[];
+
+  /** Empty-state passthroughs (used when no `[empty]` template is projected). */
+  @Input() emptyTitle = 'Nothing here yet';
+  @Input() emptyMessage = '';
+  @Input() emptyIcon = '';
+  @Input() emptyActionLabel = '';
+  @Input() emptyActionIcon = 'pi pi-plus';
+  @Input() showEmptyAction = false;
+
+  /** Whole-row open affordance. */
+  @Output() rowClick = new EventEmitter<T>();
+  /** Emitted as the checkbox selection changes. */
+  @Output() selectionChange = new EventEmitter<T[]>();
+  /** Built-in menu outputs (used only when no `rowActions`/template override). */
+  @Output() open = new EventEmitter<T>();
+  @Output() edit = new EventEmitter<T>();
+  @Output() delete = new EventEmitter<T>();
+  /** Empty-state CTA. */
+  @Output() emptyAction = new EventEmitter<void>();
+
+  /** Full row-action override; when present it replaces the `⋯` menu entirely. */
+  @ContentChild('rowActions') rowActionsTemplate?: TemplateRef<{ $implicit: T }>;
+  /** Optional empty-state override. */
+  @ContentChild('empty') emptyTemplate?: TemplateRef<unknown>;
+
+  selection: T[] = [];
+  searchText = '';
+  menuModel: MenuItem[] = [];
+
+  /** The PrimeNG table instance, used to drive the global filter. */
+  @ViewChild('dt') private dt?: Table;
+
+  /** Fields used for the global filter (explicit list or every column field). */
+  get filterFields(): string[] {
+    return this.globalFilterFields ?? this.columns.map(c => c.field);
+  }
+
+  /** True when a `⋯` column should be shown at all. */
+  get hasRowActions(): boolean {
+    return !!this.rowActionsTemplate || !!this.rowActions || this.defaultActions;
+  }
+
+  /** Total rendered columns, for the empty-row `colspan`. */
+  get totalColumns(): number {
+    return this.columns.length + (this.selectable ? 1 : 0) + (this.hasRowActions ? 1 : 0);
+  }
+
+  /** Read a possibly dotted field path off a row for default text cells. */
+  getValue(row: T, field: string): unknown {
+    return field.split('.').reduce<unknown>(
+      (acc, key) => (acc == null ? acc : (acc as Record<string, unknown>)[key]),
+      row
+    );
+  }
+
+  onSearch(value: string): void {
+    this.dt?.filterGlobal(value, 'contains');
+  }
+
+  onSelectionChange(selection: T[]): void {
+    this.selection = selection;
+    this.selectionChange.emit(selection);
+  }
+
+  /** Build the row menu (respecting the input/override precedence) and open it. */
+  openRowMenu(row: T, event: Event, menu: Menu): void {
+    this.menuModel = this.buildMenu(row);
+    menu.toggle(event);
+  }
+
+  /** Menu items for a row: `rowActions` input when provided, else the defaults. */
+  private buildMenu(row: T): MenuItem[] {
+    if (this.rowActions) {
+      return this.rowActions
+        .filter(a => (a.visible ? a.visible(row) : true))
+        .map(a => ({
+          label: a.label,
+          icon: a.icon,
+          disabled: a.disabled ? a.disabled(row) : false,
+          command: () => a.command(row)
+        }));
+    }
+    const items: MenuItem[] = [
+      { label: 'Open', icon: 'pi pi-eye', command: () => this.open.emit(row) }
+    ];
+    if (this.canEdit) {
+      items.push({ label: 'Edit', icon: 'pi pi-pencil', command: () => this.edit.emit(row) });
+    }
+    if (this.canDelete) {
+      items.push({ label: 'Delete', icon: 'pi pi-trash', command: () => this.delete.emit(row) });
+    }
+    return items;
+  }
+}


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/157

N4 data-table pattern: add app-data-table and migrate every list page onto it

Implements the reusable data-table pattern from doc/124-lookandfeel-plan.md (N4) as a
standalone component over PrimeNG Table, and migrates all 13 list pages to it. Concretizes
#129 and #146. Row actions are real, labelled buttons (#136/#137) and empty rows use the
shared empty-state component (#131).

New shared component
- requel-angular/src/app/shared/app-data-table.ts: standalone wrapper over PrimeNG Table.
  Owns an optional toolbar (title + search + [toolbarActions] slot), sortable headers,
  client-side paginator, optional checkbox selection (selectionChange output), and a
  trailing row-actions menu. Row actions follow a replace-never-merge precedence:
  projected <ng-template #rowActions> > [rowActions] input > built-in Open/Edit/Delete
  (gated by canEdit/canDelete). Empty rows fall through to app-empty-state unless an
  [empty] template is projected. Inputs: value, columns, loading, paginator, rows,
  sortField/sortOrder, selectable, rowClickable, defaultActions, rowTestid, testid, and
  the empty* passthroughs. Exports DataTableColumn and RowAction types.
- requel-angular/src/app/shared/app-data-table.spec.ts: 14 unit/a11y tests covering
  render, sort icon, search (filterGlobal), rowClick, selection column + selectionChange,
  default vs [rowActions] vs template override (replace semantics), the accessible
  row-action trigger name, defaultActions=false (no actions column) and rowClickable=false.

List-page migrations (search moves into the table; app-list-page uses [showSearch]="false")
- goals/goal-list.ts: tag-chip + text-preview cell templates, tag filter in the toolbar
  slot, two-variant empty state via #empty, single Open action. goal-list.spec.ts updated
  (onRowSelect renamed to openGoal).
- stories, actors, stakeholders, scenarios, use-cases, terms *-list.ts: standard migration
  with per-page cell templates (text previews, stakeholder type, canonical term, primary
  actor) and empty-state inputs; existing onRowSelect/onSelect methods retained so their
  specs stay green.
- projects/project-list.ts: New + Import kept in the toolbar slot; status/count columns.
- users/user-list.ts: roles cell template; always-on New User.
- reports/report-list.ts: custom Edit/Run buttons via a #rowActions override with
  rowClickable=false and rowTestid="report-list-row" (preserves the e2e row target).
- open-issues/open-issues.ts: defaultActions=false and rowClickable=false; entity-link and
  Required Yes/No cell templates; sortField=entityType. Removed the duplicate "all clear"
  banner that collided with the table's open-issues-empty testid.
- admin/tag-categories.ts, admin/global-tags.ts: keep their own page chrome + add-row form,
  use the table with [showToolbar]="false" and a #rowActions override for the Delete button.

e2e
- requel-angular/e2e/pages/ReportEditorPage.ts: expectEmptyState now matches the new
  "No documents yet" empty copy (was "No documents found.").

Docs
- doc/157-data-table-plan.md: implementation plan, component API, per-page migration notes,
  and resolved decisions.

Frontend unit suite green: 71 files / 418 tests.

Closes #157
