### PR TITLE
158: Entity-create form wizard (app-form-wizard + app-field) + Goal & Story migration

### DIFF
--- a/doc/158-form-wizard-field.md
+++ b/doc/158-form-wizard-field.md
@@ -1,0 +1,564 @@
+# Implementation Plan — #158 N5 Multi-step entity-create wizard (`app-form-wizard` + `app-field`)
+
+Part of the look-and-feel adoption epic #124 (see `doc/124-lookandfeel-plan.md`, item N5),
+and §1.2 "Form wizard" of `doc/UI_UX_REVIEW.md`. Phase 3. Concretizes #132 + #146.
+
+Build the two primitives the app's create/edit forms compose from — `app-field` (the form
+row) and `app-form-wizard` (the multi-step shell) — plus the shared `form-errors` message
+map, and prove all three on the **Goal** and **Story** create/edit flows.
+
+This plan supersedes the N5 wording in `doc/124-lookandfeel-plan.md` §4 and the current
+body of issue #158, both of which were written without looking at the actual editors.
+Grounded in `requel-angular` at `909cc49` (Angular 21.2, PrimeNG 21.1.3, `@angular/cdk`
+21.2.3 with `/a11y`, **Vitest** via `@angular/build:unit-test` + Playwright 1.59).
+
+## Decisions (locked)
+
+1. **Commit on step 1, not one submit at the end.** Tags, Relations, Goals and Actors are
+   separate `CommandService` commands that need a real entity `id`, so step 1 commits
+   `EditGoal` / `EditStory` on **Continue** and the later steps enrich the saved entity.
+   The cost — abandoning the wizard at step 2 leaves a saved, valid, named entity — is
+   accepted. See §2 for the version-handling this forces.
+2. **Version is server-owned from the moment of the step-1 commit.** The wizard never
+   reuses a version it has already spent. See §2 — this is the main correctness risk in
+   the whole ticket.
+3. **Both Goal and Story pilot the wizard**, not Goal alone. They exercise different step
+   shapes (Goal: Tags + Relations; Story: Goals + Additional Actors) and different control
+   types (Story adds a `p-select` and an actor picker), which is what proves `app-field` is
+   actually control-agnostic.
+4. **The `form-errors` helper lands here, not in #132.** N5 owns the helper and the first
+   two migrations; #132 extends the helper (cross-field, password confirmation) and rolls
+   the pattern out to the remaining editors.
+5. **Edit mode is not a wizard.** The Goal and Story editors keep their single-card layout
+   and swap `div.form-grid` for `app-field` rows. Same components, no wizard chrome.
+6. **Story's Primary Actor stays on step 1.** It's a scalar property of the story, not an
+   association, so it belongs with Name / Type / Text rather than with the Additional
+   Actors step. This makes the actor picker a **step-1 `app-field` requirement**, and it is
+   the control most likely to fight the row contract — build `app-field` against it early
+   rather than discovering the friction late.
+7. **The step nav is hand-rolled, not a `p-stepper` wrapper.** This replaces the
+   original "wrap PrimeNG the way `app-data-table` wraps `p-table`" decision, whose
+   justification was inheriting the library's keyboard nav and ARIA — and the ARIA is
+   exactly what is broken (§2a). It is also the better semantic: tabs are peer views
+   you browse, wizard steps are a linear process with progress state, so the nav is a
+   `<nav>` + `<ol>` of buttons with `aria-current="step"`, which carries no tablist
+   child requirements. Keyboard behaviour was already an acceptance criterion, so it
+   was owned here either way; native buttons give Enter/Space, leaving roving
+   tabindex as the only real work. No points change — a small hand-rolled nav for a
+   wrapper is a wash.
+8. **Points: 8 → 13** for #158, with #132 repointed to 8. See §7.
+
+## 1. Ordering — the plan is right, the acceptance wording is wrong
+
+`scripts/epic-rollup-comment.sh` puts `3.1` (#132) and `N5` (#158) both in **Phase 3** as
+peers; nothing in it orders them. What *reads* as a dependency is one line in the N5
+acceptance:
+
+> Built on reactive forms (#132).
+
+Combined with #158's out-of-scope bullet ("comprehensive reactive forms migration belongs
+to #132"), N5 depends on a thing it declares out of scope. That's the circularity — not the
+phasing.
+
+Ground truth from the tree: **there are zero reactive forms in the app today.**
+`ReactiveFormsModule` / `FormBuilder` / `FormGroup` appear in no file; 22 files under
+`src/app` use `[(ngModel)]`. Somebody has to introduce reactive forms, and doing it inside
+N5 — where the two components that consume them are being built — is the cheaper order.
+`scripts/update-ui-ux-subissues.sh` already encodes exactly this (`add_blocked_by 132 158`,
+and line 142: "#132 is blocked by #158"), so the tooling and this plan now agree.
+
+Fix: N5's acceptance line becomes "Introduces reactive forms; #132 rolls the pattern out."
+Phase 3 grouping stays as-is.
+
+**Also stale:** #158 says "Blocked by #125, #126, #127." All three are merged (#126 → PR
+#162, #127 → `bac80b1`, rollup → `06795d4`). Delete that line. The real upstream is
+**N3 / #156 (`app-card`)**, which is already in.
+
+## 2. The version contract (why commit-on-step-1 needs care)
+
+Committing on step 1 means the wizard holds a persisted entity across steps 2–3 while
+issuing *further* commands against it. #108 wired caller-supplied optimistic-lock
+`version` through every `Edit*` command: on an update the command reloads the entity,
+compares the caller's `version` to the persisted one, and throws
+`EntityLockException.staleEntity(...)` on mismatch, which `CommandController` maps to
+**HTTP 409**. Creates are never version-checked.
+
+Today that never bites, because `goal-editor.onSave()` navigates away immediately after a
+create:
+
+```ts
+if (this.version != null) input['version'] = this.version;
+const result = await this.commandService.execute('EditGoal', input);
+if (result.success) {
+  if (this.isNew()) { /* ... */ this.router.navigate([...,'goals', saved.id]); }
+  else { await this.loadGoal(); }   // reload refreshes this.version
+}
+```
+
+A wizard stays on the page. So the failure mode is real and easy to hit: capture `version`
+on step 1, add a relation on step 3, go back to step 1 to fix a typo, hit Continue → the
+held version is stale → 409, and the user loses the edit for a reason the UI can't explain.
+
+**Requirements.**
+
+- `result.entity` from `EditGoal` / `EditStory` is a `GoalDto` / `StoryDto`, both of which
+  carry `id` **and** `version`. The step-1 commit captures **both** from `result.entity` —
+  never just the id.
+- Treat the held version as **spent on use**. After *every* `EditGoal` / `EditStory`,
+  refresh the held version from that command's returned entity. Never carry a version
+  across two mutations of the same entity.
+- **The enrichment steps do not bump the parent's version — verified, so no refetch is
+  needed after steps 2–3.** Checked against the command impls:
+  - `AssignTagCommandImpl.execute()` (`modules/tagging-jpa`) mutates the **Tag**, not the
+    entity: `tagImpl.getTaggables().add(managedTaggable); merge(tagImpl)`. The Goal/Story
+    is loaded as a `Taggable` and never modified, so its `@Version` is untouched.
+  - `EditGoalRelationCommandImpl.execute()` (`modules/project-jpa`) persists or merges a
+    standalone `GoalRelationImpl` and version-checks the **relation's** own version. It
+    never touches the `Goal`.
+
+  So the parent's version changes on `EditGoal` / `EditStory` and nowhere else. The bug
+  surface is narrower than it first looked: it is confined to a *second* step-1 commit.
+  That is exactly the back-navigate case below, and it is still a real defect — the
+  simplification removes the belt-and-braces refetch, not the requirement.
+- The editors already subscribe to the SSE event stream and reload on notification, with an
+  explicit `if (fromSSE && this.hasUnsavedChanges()) return;` guard. Keep that guard intact
+  inside the wizard: an SSE reload must refresh `version` without clobbering fields the
+  user is editing in the active step.
+- A 409 on a step commit is **not** a generic error. The wizard keeps the step, refetches
+  the entity, and renders "This <entity> was changed elsewhere — your version has been
+  refreshed, please review and continue" in the `role="alert"` region. It must not silently
+  overwrite and must not dead-end.
+
+**Required test (this is the one that would have caught it):** create through the wizard,
+advance to step 3, add a relation, navigate **back** to step 1, edit the name, Continue —
+asserts success, not 409.
+
+## 2a. Verified platform facts
+
+Checked against the installed tree so the spec above isn't written against a
+remembered API:
+
+| Assumption | Reality |
+|---|---|
+| `p-stepper` exists | ✅ PrimeNG **21.1.3**, exported at `primeng/stepper`; `StepperModule`, `Stepper`, `Step`, `StepItem`, `StepList`, `StepPanel`, `StepPanels`, `StepperSeparator` |
+| `orientation="vertical"` input | ❌ **Does not exist.** Inputs are `value`, `linear`, `transitionOptions`, `motionOptions`. Vertical is a composition (`StepItem` + `StepperSeparator`), horizontal is `StepList` + `StepPanels` |
+| Step selection is keyed | ❌ `value` is `ModelSignal<number \| undefined>` — numeric. Wizard maps key ↔ index |
+| `[linear]` gating available | ✅ `InputSignalWithTransform<any, boolean>` |
+| Reactive forms available | ✅ `@angular/forms` **21.2.2**; and confirmed **zero** current usages of `ReactiveFormsModule` / `FormBuilder` / `FormGroup`, against 22 files using `ngModel` |
+| `DirtyCheckable` / `dirtyCheckGuard` | ✅ `app/core/dirty-check.guard.ts`, already implemented by both target editors |
+| `expectNoAxeViolations` | ✅ `app/shared/testing/a11y.ts`; `empty-state.a11y.spec.ts` is the pattern to copy |
+| `app-card`, `app-data-table` | ✅ both in `app/shared/` — N3 and N4 have landed |
+| `--rq-editor-max` | ✅ `styles.scss:76`, but it is a **max-width (48rem)**, not a media-query breakpoint |
+| `p-stepper` is axe-clean | ❌ **No — and this killed the wrapper approach.** `p-stepper` hard-codes `role="tablist"` on itself while its children are `role="presentation"` (`p-step`) and `role="tabpanel"` (`p-step-panel`), never `role="tab"`. axe reports a **critical** `aria-required-children`. Verified against **both** compositions — vertical (`p-step-item`) and horizontal (`p-step-list` + `p-step-panels`) — and `p-step-list` carries no role at all, so the tablist is on the wrong element. A component's host binding cannot be overridden from outside. See locked decision 7 |
+| `p-button` carries our `data-testid` | ❌ It lands on the `p-button` **host**; the real `<button>` is inside. Specs must query `[data-testid="x"] button` (as `empty-state.spec.ts` / `error-state.spec.ts` already do) |
+| `app-field` can host `p-select` | ✅ **Confirmed on Story's Type and Primary Actor rows.** Pass `app-field`'s `controlId` matching the select's own `inputId`; the `<label for>` then resolves to the input PrimeNG renders *inside* the wrapper, verified by asserting the target is a descendant of the wrapper and not the wrapper itself. Do not rely on the directive's DOM probe for wrappers that render their input asynchronously |
+| `story-editor` guarded SSE reloads | ❌ It had **no** `fromSSE` guard at all (unlike `goal-editor`), so an SSE notification silently overwrote whatever the user was typing. Fixed as part of the migration; both editors now keep local edits *and* adopt the incoming version |
+| `formControlName` works in a projected step body | ❌ It resolves its parent `formGroup` from the injector at the **insertion** point, where there is none. Step templates must use `[formControl]` |
+| Unit tests are Karma/Jasmine | ❌ **Vitest.** `angular.json` uses `@angular/build:unit-test` with `setupFiles: src/test-setup.ts`; `tsconfig.spec.json` types are `vitest/globals` + `@testing-library/jest-dom`. No karma/jasmine dependency exists. Specs use global `describe`/`it`/`expect` and `TestBed` — copy `app-card.spec.ts` |
+| `@angular/cdk` for step-nav keyboard | ✅ 21.2.3, `@angular/cdk/a11y` exported — `FocusKeyManager` available if `p-stepper`'s own nav proves insufficient |
+
+## 3. What the pilot actually looks like
+
+Both the issue ("project editor") and the plan ("e.g. new Goal or Story") were written
+without looking at the forms.
+
+### Goal — `goal-editor.ts`
+
+The form is **two fields**:
+
+```html
+<div class="form-grid">
+  <label for="name">Name</label>
+  <input id="name" pInputText [(ngModel)]="name" />
+  <label for="text">Description</label>
+  <textarea id="text" pTextarea [(ngModel)]="text" rows="6"></textarea>
+</div>
+```
+
+You cannot split two fields across a multi-step wizard. But the editor already has three
+more sections **gated behind `@if (!isNew())`** — Tags, Relations, Annotations — because
+they need a persisted `goalId`. *That gate* is the create-flow problem worth solving, and
+it's what makes the Goal create flow genuinely multi-step:
+
+| Step | Content | Required | Commits |
+|---|---|---|---|
+| 1 · Details | Name, Description | yes | `EditGoal` on **Continue** — creates the goal, captures `id` + `version` |
+| 2 · Tags | existing `app-tag-selector`, now reachable pre-first-save | no (skippable) | per-tag `TagService` call, as today |
+| 3 · Relations | existing `app-entity-selector-dialog` + relation-type flow | no (skippable) | `EditGoalRelation`, as today |
+
+Done navigates to `/projects/:name/goals/:id`.
+
+### Story — `story-editor.ts`
+
+Story has a richer step 1 (four controls, two of them not plain inputs) and two gated
+sections — Goals and Additional Actors:
+
+| Step | Content | Required | Commits |
+|---|---|---|---|
+| 1 · Details | Name, Type (`p-select`), Primary Actor (picker — locked to step 1), Text | yes (Name, Type) | `EditStory` on **Continue** — captures `id` + `version` |
+| 2 · Goals | existing `app-entity-selector-dialog` (`entityType="Goal"`, `excludeIds`) | no (skippable) | as today |
+| 3 · Additional Actors | existing `app-entity-selector-dialog` (`entityType="Actor"`) | no (skippable) | as today |
+
+Story has no tag-selector; don't add one here. `app-annotations-section` stays outside the
+wizard in both editors (it renders against a persisted `entityId`).
+
+Story's step 1 is what makes `app-field` honest: it must host `pInputText`, `pTextarea`,
+`p-select` and the actor picker without per-control special-casing. Since Primary Actor is
+locked to step 1 (decision 6), the actor picker is a step-1 requirement — so build
+`app-field` against Story's four controls, not Goal's two, or the row contract will look
+finished while still being input-only.
+
+### Edit mode
+
+`/projects/:name/goals/:goalId` and `/projects/:name/stories/:storyId` keep their single
+`app-card` and swap `div.form-grid` for `app-field` rows. No wizard chrome. Both editors
+currently redefine the identical `.form-grid { grid-template-columns: 120px 1fr; ... }`
+block locally — both copies get deleted.
+
+## 4. Replacement for `doc/124-lookandfeel-plan.md` §4, N5
+
+> ### N5 — Entity-create form wizard (`app-form-wizard` + `app-field`) · priority:medium
+>
+> Build the two primitives the app's create/edit forms compose from, and prove them on the
+> Goal and Story create/edit flows.
+>
+> **`app-field`** — one form row: label + helper text on the left, control on the right,
+> hairline divider below, inline error under the control. Replaces the per-editor
+> `div.form-grid { grid-template-columns: 120px 1fr }` that #126's descope left in place
+> (nine editors currently redefine it at varying widths). The row owns
+> label↔control↔error association, so #138 is satisfied structurally rather than
+> per-caller.
+>
+> **`app-form-wizard`** — two-column card: left = vertical step nav with per-step
+> completion state, right = the active step's fields, footer = subtle **Cancel** +
+> primary **Continue** (**Done** on the last step). The nav is a `<nav>` + `<ol>` of
+> buttons with `aria-current="step"` and a roving tabindex, *not* a `p-stepper` wrapper —
+> `p-stepper` fails axe's `aria-required-children` in every composition (§2a).
+>
+> Introduces reactive forms and a shared `form-errors` message map, and migrates the Goal
+> and Story flows; #132 rolls both out to the remaining editors.
+>
+> **Acceptance.**
+> - Goal create and Story create migrated end-to-end as 3-step wizards, replacing the
+>   `@if (!isNew())` gate on their enrichment sections.
+> - Goal edit and Story edit use `app-field` rows (no wizard chrome); `div.form-grid`
+>   deleted from both editors.
+> - Reactive forms; wizard Continue disabled while `form.invalid || saving()`, edit-form
+>   Save additionally disabled while `form.pristine`.
+> - Entity `version` refreshed after every step commit; a stale-version 409 keeps the step
+>   and refetches rather than failing opaquely.
+> - Labels and errors associated via `aria-describedby` / `aria-invalid` (#138); step nav
+>   keyboard-operable; `axe` clean.
+> - All styling from `--rq-*` tokens; no literals.
+>
+> *Concretizes #132 + #146. Points: 13.*
+
+## 5. Replacement body for issue #158
+
+> ## N5 — Entity-create form wizard (`app-form-wizard` + `app-field`)
+>
+> Part of the design-system adoption in `doc/124-lookandfeel-plan.md` §4 (N5) and §1.2
+> "Form wizard". Full plan: `doc/158-form-wizard-field.md`. Phase 3. Concretizes #132 +
+> #146.
+>
+> ### Why
+>
+> Nine editors each redefine their own `div.form-grid` with a different label column width,
+> none associate errors with fields, and create flows hide enrichment sections behind
+> `@if (!isNew())` — so a user must save a half-configured entity before they can finish
+> configuring it. #126 was descoped to the mechanical `::ng-deep`/inline-style pass and did
+> **not** ship a shared form layout, so this issue is the first real answer to that
+> finding.
+>
+> ### In scope
+>
+> **1. `app-field` — `src/app/shared/app-field.ts`**
+>
+> One form row. Label + helper on the left, control on the right, hairline divider below,
+> inline error beneath the control.
+>
+> ```ts
+> @Input({ required: true }) label!: string;
+> @Input() helper = '';
+> @Input() control?: AbstractControl;   // drives error / required / aria state
+> @Input() divider = true;
+> @Input() errorMessages?: Record<string, string>;  // per-field override
+> ```
+>
+> - The control is content-projected and carries an `appFieldControl` directive.
+>   `app-field` queries it with `contentChild` and sets `id`, `aria-describedby` (helper id
+>   + error id), and `aria-invalid` on the host element. Callers never wire ARIA by hand —
+>   this is what makes #138 structural.
+> - Must host `pInputText`, `pTextarea`, `p-select` and the actor picker with no
+>   per-control special-casing (Story's step 1 is the proof).
+> - Ids are generated (`rq-field-{n}`) unless the caller supplies one.
+> - Required marker derives from the control's validators, not a separate input.
+> - Errors render only when `control.invalid && (control.touched || submitted)`.
+> - Label column width is a single token, not a per-editor literal.
+> - Layout collapses to stacked label-above-control on narrow viewports. Note
+>   `--rq-editor-max` (`styles.scss:76`) is a **max-width token (48rem)**, not a breakpoint
+>   — the collapse needs a container query or a new `--rq-bp-*` token rather than reusing
+>   it.
+>
+> **2. `form-errors` helper — `src/app/shared/form-errors.ts`**
+>
+> Maps `required | minlength | maxlength | email | pattern` to messages, with per-field
+> override. Owned by this ticket; #132 extends it (password confirmation, cross-field)
+> during rollout.
+>
+> **3. `app-form-wizard` — `src/app/shared/app-form-wizard.ts`**
+>
+> Two-column card. Left: vertical step nav with completion state. Right: the active
+> step's `app-field` rows. Footer: subtle **Cancel** + primary **Continue** / **Done**.
+>
+> The nav is hand-rolled — a `<nav aria-label="Steps">` wrapping an `<ol>` of buttons
+> carrying `aria-current="step"`, `aria-disabled` on locked steps, and a roving tabindex.
+> It does **not** wrap `p-stepper`, which hard-codes `role="tablist"` on itself and so
+> fails axe's `aria-required-children` in both its vertical and horizontal compositions
+> (§2a). Locked steps use `aria-disabled` rather than the `disabled` attribute, so screen
+> reader users can still reach a step and hear that it is not yet available.
+>
+> Steps are declared as child elements rather than passed as an array, so each step's
+> body can be an `<ng-template>` the caller owns:
+>
+> ```html
+> <app-form-wizard [(activeKey)]="step" (stepCommit)="onCommit($event)"
+>                  (cancelled)="onCancel()" (finished)="onFinish()">
+>   <app-wizard-step key="details" label="Details" [form]="detailsForm">
+>     <ng-template>
+>       <app-field label="Name" [control]="detailsForm.controls.name">
+>         <input appFieldControl [formControl]="detailsForm.controls.name" />
+>       </app-field>
+>     </ng-template>
+>   </app-wizard-step>
+>   <app-wizard-step key="tags" label="Tags" [optional]="true"> ... </app-wizard-step>
+> </app-form-wizard>
+> ```
+>
+> `app-wizard-step` inputs: `key`, `label`, `helper?`, `form?` (omitted for
+> association-only steps), `optional`. Inside the template use `[formControl]`, **not**
+> `formControlName` — the body is projected, and `formControlName` looks for its parent
+> `formGroup` at the insertion point, where there is none.
+>
+> Keys are the only step identity in the public API and the route fragment; indexes never
+> leak into caller code or URLs.
+>
+> The commit handshake is a request object, so the wizard owns the busy state rather than
+> the host having to mirror it back:
+>
+> ```ts
+> interface WizardCommitRequest {
+>   readonly step: AppWizardStepComponent;
+>   complete(): void;              // advance, or emit finished on the last step
+>   fail(message: string): void;   // stay on the step, show message in role="alert"
+> }
+> ```
+>
+> The wizard stays busy until one of the two fires, so a host that forgets to respond
+> visibly hangs on its own step instead of silently advancing past a failed save. A
+> second response after the first is ignored.
+>
+> Behavior:
+> - **Linear forward, free backward.** Continue is disabled while `form.invalid` or a
+>   commit is in flight; completed steps stay clickable. Deliberately **not** gated on
+>   `pristine`: with commit-on-step-1 the user can return to a step whose values are
+>   already saved and valid, and a pristine guard would trap them there with no way
+>   forward. (The plan's original `form.pristine` clause survives for the *edit* forms,
+>   where Save-on-unchanged is the thing worth preventing.)
+> - **Step state**: incomplete / complete / invalid / active, derived from the step's
+>   `FormGroup`. Optional steps can be skipped without blocking.
+> - **Commit model**: `stepCommit` fires on Continue; the host decides whether that hits
+>   the API. Wizard shows a busy state until the host resolves.
+> - **Version handling**: the host reports the entity's current `version` back after each
+>   commit (from `result.entity`) and the wizard never reuses a spent version. A 409
+>   (`EntityLockException.staleEntity` → HTTP 409 via `CommandController`) keeps the step,
+>   refetches the entity, and explains that it was changed elsewhere. Never a silent
+>   overwrite.
+> - **Failure**: on any rejected commit the wizard stays on the step and renders the
+>   host-supplied message in a `role="alert"` region above the fields. Mapping backend
+>   constraint violations to specific fields stays with #133.
+> - **Routing**: active step reflected as a route fragment so back/refresh land on the
+>   right step.
+> - **Unsaved changes**: implements `DirtyCheckable` and composes with the existing
+>   `dirtyCheckGuard`.
+>
+> **4. Pilots — Goal and Story create/edit**
+>
+> - `/projects/:name/goals/new` becomes a 3-step wizard: **Details** (Name, Description —
+>   required, commits `EditGoal` on Continue) → **Tags** (optional) → **Relations**
+>   (optional). Done navigates to the saved goal.
+> - `/projects/:name/stories/new` becomes a 3-step wizard: **Details** (Name, Type,
+>   Primary Actor, Text — commits `EditStory`) → **Goals** (optional) → **Additional
+>   Actors** (optional). Primary Actor stays on Details: it is a scalar property of the
+>   story, not an association, and the Additional Actors step covers only the association.
+> - Both edit routes keep their single card and swap `div.form-grid` for `app-field` rows.
+>   No wizard chrome.
+> - `@if (!isNew())` gates removed from the migrated enrichment sections.
+> - `app-annotations-section` stays outside the wizard in both editors.
+>
+> ### Out of scope
+>
+> - Migrating the *remaining* editors (project, actor, stakeholder ×2, scenario, use-case,
+>   term, user, auth) to reactive forms / `app-field` — **#132**.
+> - Mapping backend constraint violations to field-level errors — **#133**.
+> - The broader form-labelling sweep — **#138**.
+> - Dark-mode variants — **N6**.
+>
+> ### Acceptance criteria
+>
+> - [ ] Goal create runs end-to-end as a 3-step wizard; a goal created through it is
+>       identical to one created by the current form.
+> - [ ] Story create runs end-to-end as a 3-step wizard; same equivalence check.
+> - [ ] Enrichment sections reachable during create (no `isNew()` gate).
+> - [ ] Goal edit and Story edit render via `app-field`; `div.form-grid` gone from both.
+> - [ ] All four flows use reactive forms; wizard Continue disabled while
+>       `form.invalid || saving()`, edit-form Save also disabled while `form.pristine`.
+> - [ ] Step nav is a `<nav>`/`<ol>` of buttons with `aria-current="step"`; locked steps
+>       are `aria-disabled` and still focusable.
+> - [ ] `version` is captured from `result.entity` on the step-1 commit and refreshed after
+>       every subsequent mutation; no held version is reused.
+> - [ ] Back-navigate-and-re-Continue after a later-step commit succeeds (no 409).
+> - [ ] A stale-version 409 keeps the step, refetches, and surfaces an explanatory message;
+>       no silent overwrite.
+> - [ ] The SSE reload guard (`fromSSE && hasUnsavedChanges()`) still prevents clobbering
+>       in-flight step edits.
+> - [ ] Every `app-field` control has an associated `<label>`, and `aria-describedby` /
+>       `aria-invalid` update with validation state.
+> - [ ] `app-field` hosts `pInputText`, `pTextarea`, `p-select` and the actor picker with no
+>       per-control special-casing.
+> - [ ] Step nav is keyboard-operable (Up/Down/Home/End, Enter/Space); focus moves to the
+>       step panel heading on change.
+> - [ ] No color, radius, spacing, or type literals — all `--rq-*` tokens.
+> - [ ] `app-field.spec.ts` and `app-form-wizard.spec.ts` cover required/error states,
+>       disable policy, linear gating, keyboard nav, and version refresh + 409 handling.
+> - [ ] `app-field.a11y.spec.ts` and `app-form-wizard.a11y.spec.ts` pass
+>       `expectNoAxeViolations` (matching `empty-state.a11y.spec.ts`).
+> - [ ] Playwright: create a goal and a story through the wizard, each including one
+>       skipped optional step, plus the back-navigate-and-re-Continue case.
+>
+> ### Notes
+>
+> - Depends on **#156** (`app-card`) — merged. The #125/#126/#127 block is cleared; that
+>   line has been removed.
+> - New `data-testid`s follow the existing convention (`goal-wizard-step-tags`,
+>   `story-wizard-step-goals`, `wizard-continue`, `wizard-cancel`).
+> - Points: **13**.
+
+## 6. What this moves out of #132
+
+#132 (3.1 "Forms are mostly template-driven and lack consistent validation") keeps the
+rollout and loses the foundations:
+
+| Moves to #158 | Stays in #132 |
+|---|---|
+| `form-errors` helper (base message map) | Helper extensions: cross-field, password confirmation |
+| Reactive forms for Goal + Story | Reactive forms for the remaining 8 editors |
+| `app-field` adoption in Goal + Story | `app-field` adoption everywhere else |
+| — | Save-button disable policy applied app-wide |
+| — | Deleting the remaining 7 copies of `.form-grid` |
+
+`scripts/update-ui-ux-subissues.sh` already records `add_blocked_by 132 158`, so no
+dependency edit is needed — only the scope/acceptance text on #132 and the two point
+values.
+
+## 7. Story points
+
+| Issue | Was | Now | Why |
+|---|---|---|---|
+| **#158** (N5) | 8 | **13** | Two pilots instead of one, plus the `form-errors` helper, plus the version/409 contract |
+| **#132** (3.1) | unset | **8** | Loses the helper and two editors; still 8 editors + the app-wide disable policy |
+
+Nothing in `scripts/` currently points #132 — `set-lookandfeel-points.sh` only covers
+#154–#159 and `backfill-points.sh` only touches closed issues. Verify with
+`bash scripts/probe-project.sh` before writing.
+
+The repo already has the tooling; **prefer it over raw `gh`**, because it resolves the
+project by title, adds the item if missing, and refuses to set a Retro value on an open
+issue:
+
+```bash
+bash scripts/set-points.sh 158 13
+bash scripts/set-points.sh 132 8
+```
+
+Also update the here-doc in `scripts/set-lookandfeel-points.sh` so a re-run doesn't
+reset #158 to 8:
+
+```
+158 13  # N5 Form wizard + app-field + form-errors helper + Goal & Story migrations
+```
+
+<details>
+<summary>Raw <code>gh</code> equivalent (project #2, <code>rreganjr</code>)</summary>
+
+```bash
+OWNER=rreganjr
+NUM=2                     # github.com/users/rreganjr/projects/2
+REPO=rreganjr/Requel
+
+PROJECT_ID=$(gh project view "$NUM" --owner "$OWNER" --format json | jq -r '.id')
+SP_ID=$(gh project field-list "$NUM" --owner "$OWNER" --format json \
+        | jq -r '.fields[] | select(.name=="Story Points") | .id')
+
+set_points() {   # set_points <issue#> <points>
+  ITEM_ID=$(gh project item-add "$NUM" --owner "$OWNER" \
+              --url "https://github.com/$REPO/issues/$1" --format json | jq -r '.id')
+  gh project item-edit --project-id "$PROJECT_ID" --id "$ITEM_ID" \
+                       --field-id "$SP_ID" --number "$2"
+}
+
+set_points 158 13
+set_points 132 8
+```
+
+Notes: `--project-id` wants the project's **node ID** (`PVT_…`), not the number `2`;
+`item-add` is idempotent and returns the existing item id if the issue is already on the
+board. Needs a token with `project` scope — `gh auth refresh -s project` if
+`gh project field-list` 403s.
+
+</details>
+
+## 8. Applying the rest
+
+- Update `doc/124-lookandfeel-plan.md` §4 N5 with §4 above, and the §7 points line
+  (`N5 = 8` → `N5 = 13`).
+- Replace the body of #158 with §5 (`gh issue edit 158 --body-file …`).
+- Update #132's scope/acceptance per §6.
+- Regenerate the epic rollup comment in place:
+
+  ```bash
+  DRY_RUN=1 bash scripts/epic-rollup-comment.sh                  # preview
+  COMMENT_ID=5113771759 bash scripts/epic-rollup-comment.sh       # edit in place
+  ```
+
+Per `CLAUDE.md`, none of the GitHub-state steps run without an explicit go-ahead.
+
+## 8a. Carried out of scope, filed elsewhere
+
+Both raised as comments on their owning issues rather than absorbed here:
+
+- **#139** — `p-confirmDialog` marks its *host* `role="alertdialog"` even while idle, so
+  axe reports an unnamed dialog (**serious**) on every page that mounts one. Not specific
+  to these forms. `expectNoAxeViolations` gained an `exclude` parameter and the pilots pass
+  `['p-confirmdialog']`; grep that string to find the exclusions to remove once fixed.
+- **#132** — `goal-editor`'s relation-type `p-select` still binds with `ngModel`. It is a
+  transient dialog control rather than part of the goal form, so it stays for #132's sweep,
+  which also inherits `form-errors` (to extend) and `app-field` (to roll out). Verified
+  counts at hand-off: `.form-grid` still defined locally in **8** editors (actor, project,
+  report, scenario, stakeholder, term, use-case, user — goal's and story's are deleted).
+
+## 9. Still open
+
+- ~~Whether the tag and relation commands bump the **parent** entity's `@Version`.~~
+  **Closed** — they don't; see §2. Neither `AssignTagCommandImpl` nor
+  `EditGoalRelationCommandImpl` touches the parent entity.
+- ~~Whether `p-stepper` supports `orientation="vertical"`.~~ **Closed** — it doesn't; the
+  spec now uses the vertical composition. See §2a.
+- ~~Whether Story's **Primary Actor** should stay on step 1 or move to the Actors step.~~
+  **Closed — step 1.** See locked decision 6.
+- The narrow-viewport collapse needs either a container query or a new `--rq-bp-*` token,
+  since `--rq-editor-max` is a width not a breakpoint (§2a). Decide when styling
+  `app-field`; adding one token is in scope.
+
+Nothing above blocks starting. The remaining item is a styling choice made while writing
+`app-field`'s CSS.

--- a/requel-angular/e2e/actors.e2e.ts
+++ b/requel-angular/e2e/actors.e2e.ts
@@ -182,8 +182,10 @@ test.describe('Actor management', () => {
     const ucEditorPage = new UseCaseEditorPage(page);
 
     // Story editor — open new-story form and verify the actor is offered as a primary-actor option.
+    // Since #158 /stories/new is the wizard; Primary Actor lives on its first (Details) step,
+    // so the dropdown is reachable without advancing, and ids are generated — locate by testid.
     await page.goto(`/projects/${encodeURIComponent(PROJECT_NAME)}/stories/new`);
-    await expect(page.locator('#name')).toBeVisible();
+    await expect(page.getByTestId('story-name')).toBeVisible();
     await storyEditorPage.expectActorInPrimaryActorDropdown(actorName);
 
     // Use-case editor — same verification on the use-case form.

--- a/requel-angular/e2e/annotations.e2e.ts
+++ b/requel-angular/e2e/annotations.e2e.ts
@@ -169,7 +169,8 @@ test.describe('Annotations (IBIS)', () => {
     await issueRow.getByTestId('open-issue-entity-link').click();
 
     await page.waitForURL(new RegExp(`/goals/${goalFixture.id}$`));
-    await expect(page.locator('#name')).not.toHaveValue('');
+    // Since #158 the goal form is app-field rows with generated ids — locate by testid.
+    await expect(page.getByTestId('goal-name')).not.toHaveValue('');
 
     await page.close();
   });

--- a/requel-angular/e2e/form-wizard.e2e.ts
+++ b/requel-angular/e2e/form-wizard.e2e.ts
@@ -1,0 +1,464 @@
+import { test, expect } from './fixtures/auth';
+import {
+  createProject,
+  deleteProject,
+  createGoal,
+  deleteGoal,
+  createActor,
+  deleteActor,
+  deleteStory,
+  GoalFixture,
+  ActorFixture,
+  StoryFixture,
+} from './fixtures/api-helper';
+import { GoalListPage, GoalEditorPage } from './pages/GoalEditorPage';
+import { StoryListPage, StoryEditorPage } from './pages/StoryEditorPage';
+
+/**
+ * End-to-end coverage for the entity-create wizard (issue #158).
+ *
+ * The unit suite covers `app-form-wizard` and `app-field` in isolation; this file is
+ * about the two migrated flows against a live backend — in particular the things only
+ * a real server can prove:
+ *
+ *  - Tags / Relations / Goals / Actors are reachable *during* create, which before
+ *    #158 required saving a half-configured entity first.
+ *  - Optional steps can be skipped and the entity is still complete and valid.
+ *  - The optimistic-lock contract: stepping back to Details and committing a second
+ *    time must send the refreshed version, not the one captured at create. Re-sending
+ *    the create-time version is a guaranteed HTTP 409 from
+ *    `EntityLockException.staleEntity`, so this is the regression test the whole
+ *    version contract exists for.
+ */
+
+const PROJECT_NAME = `e2e-wizard-${Date.now()}`;
+
+let relationTargetGoal: GoalFixture | null = null;
+let actorFixture: ActorFixture | null = null;
+let goalToCleanup: GoalFixture | null = null;
+let storyToCleanup: StoryFixture | null = null;
+
+test.beforeAll(async ({ request }) => {
+  await createProject(request, PROJECT_NAME, 'Form wizard E2E test project');
+  relationTargetGoal = await createGoal(
+    request,
+    PROJECT_NAME,
+    `e2e-wizard-target-${Date.now()}`,
+    'Relation target'
+  );
+  actorFixture = await createActor(request, PROJECT_NAME, `e2e-wizard-actor-${Date.now()}`);
+});
+
+test.afterAll(async ({ request }) => {
+  if (relationTargetGoal) {
+    try {
+      await deleteGoal(request, relationTargetGoal);
+    } catch {
+      // project delete below will take it
+    }
+  }
+  if (actorFixture) {
+    try {
+      await deleteActor(request, actorFixture);
+    } catch {
+      // project delete below will take it
+    }
+  }
+  await deleteProject(request, PROJECT_NAME);
+});
+
+test.afterEach(async ({ request }) => {
+  if (goalToCleanup) {
+    try {
+      await deleteGoal(request, goalToCleanup);
+    } catch {
+      // may already be deleted by the test
+    }
+    goalToCleanup = null;
+  }
+  if (storyToCleanup) {
+    try {
+      await deleteStory(request, storyToCleanup);
+    } catch {
+      // may already be deleted by the test
+    }
+    storyToCleanup = null;
+  }
+});
+
+/** Pull the created entity's id out of the URL after the wizard finishes. */
+function idFromUrl(url: string, segment: string): number {
+  const match = url.match(new RegExp(`/${segment}/(\\d+)`));
+  if (!match) {
+    throw new Error(`No ${segment} id in URL: ${url}`);
+  }
+  return parseInt(match[1], 10);
+}
+
+test.describe('Goal create wizard', () => {
+  test('walks all three steps, adding a tag-free relation before the first manual save', async ({
+    adminContext,
+  }) => {
+    const goalName = `e2e-wizard-goal-${Date.now()}`;
+    const page = await adminContext.newPage();
+    const listPage = new GoalListPage(page);
+    const editor = new GoalEditorPage(page);
+    const wizard = editor.wizard;
+
+    await listPage.goto(PROJECT_NAME);
+    await listPage.clickNewGoal();
+
+    // Step 1 — Details. The later steps are not reachable yet.
+    await wizard.expectActiveStep('details');
+    await wizard.expectStepLocked('tags');
+    await wizard.expectStepLocked('relations');
+
+    // Required-field gating: Continue stays disabled until Name has a value.
+    await wizard.expectContinueDisabled();
+    await editor.fillName(goalName);
+    await editor.fillDescription('Created through the wizard');
+    await editor.expectNameAccessiblyLabelled();
+    await wizard.expectContinueEnabled();
+
+    await editor.commitDetails();
+
+    // Step 2 — Tags, now reachable because the goal exists. This is the behaviour the
+    // old `@if (!isNew())` gate made impossible.
+    await wizard.expectActiveStep('tags');
+    await wizard.expectStepComplete('details');
+    await wizard.expectStepUnlocked('relations');
+
+    // Skip Tags entirely — an optional step must not block progress.
+    await wizard.skipToStep('relations');
+
+    // Step 3 — Relations, also reachable pre-first-manual-save.
+    await editor.addRelation(relationTargetGoal!.name);
+    await editor.expectRelationInTable(relationTargetGoal!.name);
+
+    await wizard.expectContinueLabel('Done');
+    await wizard.finish(/\/goals\/\d+/);
+
+    goalToCleanup = {
+      id: idFromUrl(page.url(), 'goals'),
+      version: 0,
+      name: goalName,
+      projectName: PROJECT_NAME,
+    };
+
+    // The finished goal matches what the old single-form create produced, plus the
+    // relation that used to require a second visit.
+    await editor.expectNameValue(goalName);
+    await editor.expectDescriptionValue('Created through the wizard');
+    await editor.expectRelationInTable(relationTargetGoal!.name);
+
+    await listPage.goto(PROJECT_NAME);
+    await listPage.expectGoalInTable(goalName);
+
+    await page.close();
+  });
+
+  test('stepping back to Details and committing again does not 409', async ({ adminContext }) => {
+    // The regression the version contract exists for: the create-time version is spent
+    // once the goal is saved, so a second commit must send the refreshed one.
+    const goalName = `e2e-wizard-goal-revisit-${Date.now()}`;
+    const revisedName = `${goalName}-revised`;
+    const page = await adminContext.newPage();
+    const listPage = new GoalListPage(page);
+    const editor = new GoalEditorPage(page);
+    const wizard = editor.wizard;
+
+    await listPage.goto(PROJECT_NAME);
+    await listPage.clickNewGoal();
+
+    await editor.fillName(goalName);
+    await editor.commitDetails();
+    await wizard.expectActiveStep('tags');
+
+    // Walk forward, then come back to fix the name.
+    await wizard.skipToStep('relations');
+    await wizard.gotoStep('details');
+
+    await editor.fillName(revisedName);
+
+    // Capture the raw response so a 409 fails loudly rather than as a stuck wizard.
+    const [response] = await Promise.all([
+      page.waitForResponse(r => r.url().includes('/api/commands/EditGoal')),
+      wizard.continueButton().click(),
+    ]);
+    expect(
+      response.status(),
+      'second EditGoal should not be an optimistic-lock conflict'
+    ).not.toBe(409);
+    expect(response.ok()).toBe(true);
+
+    // No stale-version alert, and the wizard advanced.
+    await expect(wizard.error()).toHaveCount(0);
+    await wizard.expectActiveStep('tags');
+
+    await wizard.skipToStep('relations');
+    await wizard.finish(/\/goals\/\d+/);
+
+    goalToCleanup = {
+      id: idFromUrl(page.url(), 'goals'),
+      version: 0,
+      name: revisedName,
+      projectName: PROJECT_NAME,
+    };
+
+    await editor.expectNameValue(revisedName);
+
+    await page.close();
+  });
+
+  test('cancel on an optional step leaves the already-created goal intact', async ({
+    adminContext,
+  }) => {
+    // Documented consequence of commit-on-step-1: abandoning the wizard after Details
+    // leaves a saved, valid, named goal rather than nothing.
+    const goalName = `e2e-wizard-goal-abandon-${Date.now()}`;
+    const page = await adminContext.newPage();
+    const listPage = new GoalListPage(page);
+    const editor = new GoalEditorPage(page);
+
+    await listPage.goto(PROJECT_NAME);
+    await listPage.clickNewGoal();
+
+    await editor.fillName(goalName);
+    await editor.commitDetails();
+    await editor.wizard.expectActiveStep('tags');
+
+    await editor.wizard.cancel(`**/projects/${encodeURIComponent(PROJECT_NAME)}/goals`);
+
+    await listPage.expectGoalInTable(goalName);
+    await listPage.clickGoal(goalName);
+    goalToCleanup = {
+      id: idFromUrl(page.url(), 'goals'),
+      version: 0,
+      name: goalName,
+      projectName: PROJECT_NAME,
+    };
+    await editor.expectNameValue(goalName);
+
+    await page.close();
+  });
+
+  test('the step nav is keyboard operable', async ({ adminContext }) => {
+    const page = await adminContext.newPage();
+    const listPage = new GoalListPage(page);
+    const editor = new GoalEditorPage(page);
+    const wizard = editor.wizard;
+
+    await listPage.goto(PROJECT_NAME);
+    await listPage.clickNewGoal();
+
+    await wizard.focusStep('details');
+    await expect(wizard.stepButton('details')).toBeFocused();
+
+    // Arrow keys move focus only — the active step must not change.
+    await wizard.pressInNav('ArrowDown');
+    await expect(wizard.stepButton('tags')).toBeFocused();
+    await wizard.expectActiveStep('details');
+
+    await wizard.pressInNav('End');
+    await expect(wizard.stepButton('relations')).toBeFocused();
+
+    await wizard.pressInNav('Home');
+    await expect(wizard.stepButton('details')).toBeFocused();
+    await wizard.expectActiveStep('details');
+
+    await page.close();
+  });
+});
+
+test.describe('Story create wizard', () => {
+  test('walks all three steps, attaching a goal and skipping the actors step', async ({
+    adminContext,
+  }) => {
+    const storyName = `e2e-wizard-story-${Date.now()}`;
+    const page = await adminContext.newPage();
+    const listPage = new StoryListPage(page);
+    const editor = new StoryEditorPage(page);
+    const wizard = editor.wizard;
+
+    await listPage.goto(PROJECT_NAME);
+    await listPage.clickNewStory();
+
+    await wizard.expectActiveStep('details');
+    await wizard.expectStepLocked('goals');
+    await wizard.expectStepLocked('actors');
+
+    await wizard.expectContinueDisabled();
+
+    // All four controls live on step 1, including the two p-selects — the reason Story
+    // is a pilot at all. Primary Actor stays here because it is a scalar property of
+    // the story, not an association.
+    await editor.fillName(storyName);
+    await editor.fillText('Created through the wizard');
+    await editor.selectStoryType('Exception');
+    await editor.selectPrimaryActor(actorFixture!.name);
+    await editor.expectSelectsAccessiblyLabelled();
+
+    await wizard.expectContinueEnabled();
+    await editor.commitDetails();
+
+    // Step 2 — Goals, reachable during create.
+    await wizard.expectActiveStep('goals');
+    await wizard.expectStepComplete('details');
+    await editor.addGoal(relationTargetGoal!.name);
+    await editor.expectGoalInTable(relationTargetGoal!.name);
+
+    // Step 3 — skip Additional Actors entirely.
+    await wizard.skipToStep('actors');
+    await wizard.expectContinueLabel('Done');
+    await wizard.finish(/\/stories\/\d+/);
+
+    storyToCleanup = {
+      id: idFromUrl(page.url(), 'stories'),
+      version: 0,
+      name: storyName,
+      projectName: PROJECT_NAME,
+    };
+
+    // Everything set through the wizard survived, including the two select values.
+    await editor.expectNameValue(storyName);
+    await editor.expectTextValue('Created through the wizard');
+    await editor.expectStoryTypeValue('Exception');
+    await editor.expectPrimaryActorValue(actorFixture!.name);
+    await editor.expectGoalInTable(relationTargetGoal!.name);
+    await editor.expectAdditionalActorNotInTable(actorFixture!.name);
+
+    await listPage.goto(PROJECT_NAME);
+    await listPage.expectStoryInTable(storyName);
+
+    await page.close();
+  });
+
+  test('stepping back to Details and committing again does not 409', async ({ adminContext }) => {
+    const storyName = `e2e-wizard-story-revisit-${Date.now()}`;
+    const revisedName = `${storyName}-revised`;
+    const page = await adminContext.newPage();
+    const listPage = new StoryListPage(page);
+    const editor = new StoryEditorPage(page);
+    const wizard = editor.wizard;
+
+    await listPage.goto(PROJECT_NAME);
+    await listPage.clickNewStory();
+
+    await editor.fillName(storyName);
+    await editor.commitDetails();
+    await wizard.expectActiveStep('goals');
+
+    await wizard.skipToStep('actors');
+    await wizard.gotoStep('details');
+    await editor.fillName(revisedName);
+
+    const [response] = await Promise.all([
+      page.waitForResponse(r => r.url().includes('/api/commands/EditStory')),
+      wizard.continueButton().click(),
+    ]);
+    expect(
+      response.status(),
+      'second EditStory should not be an optimistic-lock conflict'
+    ).not.toBe(409);
+    expect(response.ok()).toBe(true);
+
+    await expect(wizard.error()).toHaveCount(0);
+    await wizard.expectActiveStep('goals');
+
+    await wizard.skipToStep('actors');
+    await wizard.finish(/\/stories\/\d+/);
+
+    storyToCleanup = {
+      id: idFromUrl(page.url(), 'stories'),
+      version: 0,
+      name: revisedName,
+      projectName: PROJECT_NAME,
+    };
+
+    await editor.expectNameValue(revisedName);
+
+    await page.close();
+  });
+});
+
+test.describe('Edit forms after the migration', () => {
+  test('goal edit renders app-field rows and gates Save on a real change', async ({
+    adminContext,
+    request,
+  }) => {
+    const goal = await createGoal(
+      request,
+      PROJECT_NAME,
+      `e2e-wizard-edit-goal-${Date.now()}`,
+      'Edit me'
+    );
+    goalToCleanup = goal;
+
+    const page = await adminContext.newPage();
+    const editor = new GoalEditorPage(page);
+    await page.goto(`/projects/${encodeURIComponent(PROJECT_NAME)}/goals/${goal.id}`);
+
+    // No wizard chrome on the edit route.
+    await expect(editor.wizard.root()).toHaveCount(0);
+    await expect(page.locator('app-field')).toHaveCount(2);
+
+    // Save is disabled until something actually changes, and again after saving.
+    await expect(editor.saveButton()).toBeDisabled();
+    await editor.fillName(`${goal.name}-renamed`);
+    await expect(editor.saveButton()).toBeEnabled();
+
+    await editor.save();
+    await expect(editor.saveButton()).toBeDisabled();
+    goalToCleanup = { ...goal, name: `${goal.name}-renamed` };
+
+    // Clearing a required field surfaces the shared form-errors message and blocks Save.
+    await editor.fillName('');
+    await editor.nameBlur();
+    await expect(editor.fieldError()).toContainText('A goal needs a name.');
+    await expect(editor.saveButton()).toBeDisabled();
+
+    await page.close();
+  });
+
+  test('story edit renders all four rows with labelled selects', async ({
+    adminContext,
+    request,
+  }) => {
+    const goal = await createGoal(
+      request,
+      PROJECT_NAME,
+      `e2e-wizard-edit-story-goal-${Date.now()}`,
+      'x'
+    );
+    goalToCleanup = goal;
+
+    const page = await adminContext.newPage();
+    const listPage = new StoryListPage(page);
+    const editor = new StoryEditorPage(page);
+
+    // Create through the wizard's fast path, then reopen on the edit route.
+    const storyName = `e2e-wizard-edit-story-${Date.now()}`;
+    await listPage.goto(PROJECT_NAME);
+    await listPage.clickNewStory();
+    await editor.fillName(storyName);
+    await editor.save();
+    storyToCleanup = {
+      id: idFromUrl(page.url(), 'stories'),
+      version: 0,
+      name: storyName,
+      projectName: PROJECT_NAME,
+    };
+
+    await expect(editor.wizard.root()).toHaveCount(0);
+    await expect(page.locator('app-field')).toHaveCount(4);
+    await editor.expectSelectsAccessiblyLabelled();
+
+    await expect(editor.saveButton()).toBeDisabled();
+    await editor.fillText('Now with text');
+    await expect(editor.saveButton()).toBeEnabled();
+    await editor.save();
+    await editor.expectTextValue('Now with text');
+
+    await page.close();
+  });
+});

--- a/requel-angular/e2e/open-issues.e2e.ts
+++ b/requel-angular/e2e/open-issues.e2e.ts
@@ -127,7 +127,8 @@ test.describe('Open Issues', () => {
     const storyRow = page.getByRole('row', { name: new RegExp(storyIssueText) });
     await storyRow.getByTestId('open-issue-entity-link').click();
     await page.waitForURL(new RegExp(`/projects/${encodeURIComponent(PROJECT_NAME)}/stories/${storyToCleanup.id}$`));
-    await expect(page.locator('#name')).not.toHaveValue('');
+    // Since #158 the story form is app-field rows with generated ids — locate by testid.
+    await expect(page.getByTestId('story-name')).not.toHaveValue('');
 
     await page.close();
   });

--- a/requel-angular/e2e/pages/BaseListPage.ts
+++ b/requel-angular/e2e/pages/BaseListPage.ts
@@ -37,6 +37,14 @@ export abstract class BaseListPage {
     return this.page.locator('p-table tbody tr', { hasText: text });
   }
 
+  /**
+   * Click a row and wait for the target editor to be populated.
+   *
+   * `readySelector` defaults to `#name`, which is the static id the not-yet-migrated
+   * editors still render. Editors migrated to `app-field` (goal, story — issue #158) have
+   * generated ids instead, so their list pages must pass their own testid, e.g.
+   * `'[data-testid="goal-name"]'`. #132 will move the rest over the same way.
+   */
   protected async clickTableRow(text: string, targetUrl: string | RegExp, readySelector = '#name'): Promise<void> {
     const row = this.tableRowsWithText(text).first();
     await expect(row).toBeVisible();

--- a/requel-angular/e2e/pages/FormWizardPage.ts
+++ b/requel-angular/e2e/pages/FormWizardPage.ts
@@ -1,0 +1,126 @@
+import { Page, expect } from '@playwright/test';
+
+/**
+ * Page object for the shared `app-form-wizard` (issue #158).
+ *
+ * Used by the create flows of the migrated editors (Goal, Story). The wizard's own
+ * `data-testid`s are stable: `wizard-step-<key>` on each nav button,
+ * `wizard-panel-<key>` on the active panel heading, plus `wizard-continue`,
+ * `wizard-cancel` and `wizard-error`.
+ *
+ * Note the nav buttons carry their testid directly (the nav is hand-rolled), while
+ * Continue/Cancel are PrimeNG `p-button`s whose testid lands on the host — hence the
+ * extra `button` descendant for those two.
+ */
+export class FormWizardPage {
+  constructor(private page: Page) {}
+
+  root() {
+    return this.page.locator('app-form-wizard');
+  }
+
+  /** Whether the wizard is on screen at all — i.e. we are on a create route. */
+  async isPresent(): Promise<boolean> {
+    return (await this.root().count()) > 0;
+  }
+
+  stepButton(key: string) {
+    return this.page.getByTestId(`wizard-step-${key}`);
+  }
+
+  panelHeading(key: string) {
+    return this.page.getByTestId(`wizard-panel-${key}`);
+  }
+
+  continueButton() {
+    return this.page.getByTestId('wizard-continue').locator('button');
+  }
+
+  cancelButton() {
+    return this.page.getByTestId('wizard-cancel').locator('button');
+  }
+
+  error() {
+    return this.page.getByTestId('wizard-error');
+  }
+
+  async expectActiveStep(key: string): Promise<void> {
+    await expect(this.panelHeading(key)).toBeVisible();
+    await expect(this.stepButton(key)).toHaveAttribute('aria-current', 'step');
+  }
+
+  /** A step that cannot be reached yet: marked aria-disabled, but still focusable. */
+  async expectStepLocked(key: string): Promise<void> {
+    await expect(this.stepButton(key)).toHaveAttribute('aria-disabled', 'true');
+  }
+
+  async expectStepUnlocked(key: string): Promise<void> {
+    await expect(this.stepButton(key)).not.toHaveAttribute('aria-disabled', 'true');
+  }
+
+  async expectStepComplete(key: string): Promise<void> {
+    await expect(this.stepButton(key)).toHaveClass(/is-complete/);
+  }
+
+  async expectContinueEnabled(): Promise<void> {
+    await expect(this.continueButton()).toBeEnabled();
+  }
+
+  async expectContinueDisabled(): Promise<void> {
+    await expect(this.continueButton()).toBeDisabled();
+  }
+
+  /** The Continue button reads "Done" on the last step. */
+  async expectContinueLabel(label: 'Continue' | 'Done'): Promise<void> {
+    await expect(this.continueButton()).toContainText(label);
+  }
+
+  /**
+   * Press Continue on a step that commits to the API, and assert the command
+   * succeeded. `commandName` is the command type, e.g. `EditGoal`.
+   */
+  async commitStep(commandName: string): Promise<void> {
+    const [response] = await Promise.all([
+      this.page.waitForResponse(r => r.url().includes(`/api/commands/${commandName}`)),
+      this.continueButton().click(),
+    ]);
+    if (!response.ok()) {
+      throw new Error(`${commandName} failed: ${response.status()} ${await response.text()}`);
+    }
+  }
+
+  /**
+   * Press Continue on a step that commits nothing (the optional enrichment steps),
+   * and wait for the next step's panel to take over.
+   */
+  async skipToStep(nextKey: string): Promise<void> {
+    await this.continueButton().click();
+    await this.expectActiveStep(nextKey);
+  }
+
+  /** Press Done on the last step and wait for the resulting navigation. */
+  async finish(urlPattern: RegExp): Promise<void> {
+    await this.continueButton().click();
+    await this.page.waitForURL(urlPattern);
+  }
+
+  /** Click a step in the nav (only works for reachable steps). */
+  async gotoStep(key: string): Promise<void> {
+    await this.stepButton(key).click();
+    await this.expectActiveStep(key);
+  }
+
+  async cancel(urlPattern: string | RegExp): Promise<void> {
+    await this.cancelButton().click();
+    await this.page.waitForURL(urlPattern);
+  }
+
+  /** Keyboard nav: focus a step button and arrow to the next/previous one. */
+  async focusStep(key: string): Promise<void> {
+    await this.stepButton(key).focus();
+  }
+
+  async pressInNav(key: string): Promise<void> {
+    await this.page.keyboard.press(key);
+  }
+}

--- a/requel-angular/e2e/pages/GoalEditorPage.ts
+++ b/requel-angular/e2e/pages/GoalEditorPage.ts
@@ -1,5 +1,6 @@
 import { Page, expect } from '@playwright/test';
 import { BaseListPage } from './BaseListPage';
+import { FormWizardPage } from './FormWizardPage';
 
 export class GoalListPage extends BaseListPage {
   constructor(page: Page) {
@@ -34,28 +35,80 @@ export class GoalListPage extends BaseListPage {
   }
 }
 
+/**
+ * Page object for the goal editor.
+ *
+ * Since #158 the create route (`/goals/new`) renders a 3-step `app-form-wizard`
+ * (Details → Tags → Relations) while the edit route keeps a single card. The form
+ * controls are `app-field` rows whose ids are generated, so everything here locates
+ * by `data-testid` rather than the old static `#name` / `#text`.
+ */
 export class GoalEditorPage {
-  constructor(private page: Page) {}
+  readonly wizard: FormWizardPage;
+
+  constructor(private page: Page) {
+    this.wizard = new FormWizardPage(page);
+  }
 
   private relationRows(name: string) {
     return this.page.getByTestId('goal-relation-row').filter({ hasText: name });
   }
 
+  private nameInput() {
+    return this.page.getByTestId('goal-name');
+  }
+
+  private descriptionInput() {
+    return this.page.getByTestId('goal-text');
+  }
+
   async fillName(name: string): Promise<void> {
-    const input = this.page.locator('#name');
+    const input = this.nameInput();
     await input.clear();
     await input.fill(name);
   }
 
   async fillDescription(text: string): Promise<void> {
-    const ta = this.page.locator('#text');
+    const ta = this.descriptionInput();
     await ta.clear();
     await ta.fill(text);
   }
 
+  /**
+   * Persist the goal and land on it.
+   *
+   * On the edit route this is the Save button. On the create route there is no Save —
+   * the wizard commits Details on Continue, so this commits, skips the two optional
+   * steps and presses Done, which navigates to the saved goal. That reproduces the
+   * pre-#158 contract of "fill the fields, call save(), end up on /goals/<id>", so
+   * existing specs keep working unchanged.
+   *
+   * Use `commitDetails()` / `wizard` directly when a test needs the individual steps.
+   */
   async save(): Promise<void> {
-    await this.page.getByTestId('goal-save').click();
-    await this.page.waitForLoadState('domcontentloaded');
+    if (await this.wizard.isPresent()) {
+      await this.commitDetails();
+      await this.wizard.skipToStep('relations');
+      await this.wizard.finish(/\/goals\/\d+/);
+      return;
+    }
+    const [response] = await Promise.all([
+      this.page.waitForResponse(r => r.url().includes('/api/commands/EditGoal')),
+      this.page.getByTestId('goal-save').click(),
+    ]);
+    if (!response.ok()) {
+      throw new Error(`EditGoal failed: ${response.status()} ${await response.text()}`);
+    }
+  }
+
+  /** Commit the wizard's Details step, which creates (or updates) the goal. */
+  async commitDetails(): Promise<void> {
+    await this.wizard.commitStep('EditGoal');
+  }
+
+  /** The edit-route Save button, for asserting the disable policy. */
+  saveButton() {
+    return this.page.getByTestId('goal-save').locator('button');
   }
 
   async delete(): Promise<void> {
@@ -83,11 +136,37 @@ export class GoalEditorPage {
   }
 
   async expectNameValue(name: string): Promise<void> {
-    await expect(this.page.locator('#name')).toHaveValue(name);
+    await expect(this.nameInput()).toHaveValue(name);
   }
 
   async expectDescriptionValue(text: string): Promise<void> {
-    await expect(this.page.locator('#text')).toHaveValue(text);
+    await expect(this.descriptionInput()).toHaveValue(text);
+  }
+
+  /** The inline error rendered by `app-field` under an invalid control. */
+  fieldError() {
+    return this.page.getByTestId('field-error');
+  }
+
+  /**
+   * Blur the Name input. `app-field` only shows an error once the control is touched
+   * (or a save has been attempted), so a test that clears the field has to leave it
+   * before asserting on the message.
+   */
+  async nameBlur(): Promise<void> {
+    await this.nameInput().blur();
+  }
+
+  /**
+   * Assert the Name row wires label, error and required state to the input, which is
+   * what makes the label/error association structural rather than per-editor (#138).
+   */
+  async expectNameAccessiblyLabelled(): Promise<void> {
+    const input = this.nameInput();
+    const id = await input.getAttribute('id');
+    expect(id).toBeTruthy();
+    await expect(this.page.locator(`label[for="${id}"]`)).toContainText('Name');
+    await expect(input).toHaveAttribute('aria-required', 'true');
   }
 
   /**

--- a/requel-angular/e2e/pages/GoalEditorPage.ts
+++ b/requel-angular/e2e/pages/GoalEditorPage.ts
@@ -21,7 +21,9 @@ export class GoalListPage extends BaseListPage {
 
   async clickGoal(name: string): Promise<void> {
     await this.searchFor(name);
-    await this.clickTableRow(name, /\/goals\/\d+/);
+    // BaseListPage's readySelector defaults to '#name', which the goal editor no longer
+    // has — since #158 its form is app-field rows with generated ids.
+    await this.clickTableRow(name, /\/goals\/\d+/, '[data-testid="goal-name"]');
   }
 
   async expectGoalInTable(name: string): Promise<void> {

--- a/requel-angular/e2e/pages/StoryEditorPage.ts
+++ b/requel-angular/e2e/pages/StoryEditorPage.ts
@@ -1,5 +1,6 @@
 import { Page, expect } from '@playwright/test';
 import { BaseListPage } from './BaseListPage';
+import { FormWizardPage } from './FormWizardPage';
 
 export class StoryListPage extends BaseListPage {
   constructor(page: Page) {
@@ -43,8 +44,22 @@ export class StoryListPage extends BaseListPage {
   }
 }
 
+/**
+ * Page object for the story editor.
+ *
+ * Since #158 the create route (`/stories/new`) renders a 3-step `app-form-wizard`
+ * (Details → Goals → Additional Actors) while the edit route keeps a single card.
+ * The form controls are `app-field` rows whose ids are generated for plain inputs,
+ * so those are located by `data-testid` rather than the old static `#name` / `#text`.
+ * The two `p-select`s keep their explicit `inputId`s (`storyTypeInput`,
+ * `storyPrimaryActorInput`), which is what `app-field`'s `controlId` binds the label to.
+ */
 export class StoryEditorPage {
-  constructor(private page: Page) {}
+  readonly wizard: FormWizardPage;
+
+  constructor(private page: Page) {
+    this.wizard = new FormWizardPage(page);
+  }
 
   private goalRows(name: string) {
     return this.page.getByTestId('story-goal-row').filter({ hasText: name });
@@ -58,14 +73,22 @@ export class StoryEditorPage {
     return this.page.getByTestId('story-primary-actor');
   }
 
+  private nameInput() {
+    return this.page.getByTestId('story-name');
+  }
+
+  private textInput() {
+    return this.page.getByTestId('story-text');
+  }
+
   async fillName(name: string): Promise<void> {
-    const input = this.page.locator('#name');
+    const input = this.nameInput();
     await input.clear();
     await input.fill(name);
   }
 
   async fillText(text: string): Promise<void> {
-    const ta = this.page.locator('#text');
+    const ta = this.textInput();
     await ta.clear();
     await ta.fill(text);
   }
@@ -87,7 +110,24 @@ export class StoryEditorPage {
     await this.page.getByRole('option', { name: actorName }).click();
   }
 
+  /**
+   * Persist the story and land on it.
+   *
+   * On the edit route this is the Save button. On the create route there is no Save —
+   * the wizard commits Details on Continue, so this commits, skips the two optional
+   * steps and presses Done, which navigates to the saved story. That reproduces the
+   * pre-#158 contract of "fill the fields, call save(), end up on /stories/<id>", so
+   * existing specs keep working unchanged.
+   *
+   * Use `commitDetails()` / `wizard` directly when a test needs the individual steps.
+   */
   async save(): Promise<void> {
+    if (await this.wizard.isPresent()) {
+      await this.commitDetails();
+      await this.wizard.skipToStep('actors');
+      await this.wizard.finish(/\/stories\/\d+/);
+      return;
+    }
     const [response] = await Promise.all([
       this.page.waitForResponse(r => r.url().includes('/api/commands/EditStory')),
       this.page.getByTestId('story-save').click(),
@@ -95,6 +135,34 @@ export class StoryEditorPage {
     if (!response.ok()) {
       throw new Error(`EditStory command failed: ${response.status()} ${await response.text()}`);
     }
+  }
+
+  /** Commit the wizard's Details step, which creates (or updates) the story. */
+  async commitDetails(): Promise<void> {
+    await this.wizard.commitStep('EditStory');
+  }
+
+  /** The edit-route Save button, for asserting the disable policy. */
+  saveButton() {
+    return this.page.getByTestId('story-save').locator('button');
+  }
+
+  /** The inline error rendered by `app-field` under an invalid control. */
+  fieldError() {
+    return this.page.getByTestId('field-error');
+  }
+
+  /**
+   * Assert both `p-select` rows point their label at the input PrimeNG renders inside
+   * the wrapper — the wrapper case `app-field`'s `controlId` exists for.
+   */
+  async expectSelectsAccessiblyLabelled(): Promise<void> {
+    await expect(this.page.locator('label[for="storyTypeInput"]')).toContainText('Type');
+    await expect(this.page.locator('#storyTypeInput')).toHaveCount(1);
+    await expect(this.page.locator('label[for="storyPrimaryActorInput"]')).toContainText(
+      'Primary Actor'
+    );
+    await expect(this.page.locator('#storyPrimaryActorInput')).toHaveCount(1);
   }
 
   async clearPrimaryActor(): Promise<void> {
@@ -157,7 +225,11 @@ export class StoryEditorPage {
   }
 
   async expectNameValue(name: string): Promise<void> {
-    await expect(this.page.locator('#name')).toHaveValue(name);
+    await expect(this.nameInput()).toHaveValue(name);
+  }
+
+  async expectTextValue(text: string): Promise<void> {
+    await expect(this.textInput()).toHaveValue(text);
   }
 
   async expectStoryTypeValue(type: string): Promise<void> {

--- a/requel-angular/e2e/pages/StoryEditorPage.ts
+++ b/requel-angular/e2e/pages/StoryEditorPage.ts
@@ -25,7 +25,9 @@ export class StoryListPage extends BaseListPage {
 
   async clickStory(name: string): Promise<void> {
     await this.searchFor(name);
-    await this.clickTableRow(name, /\/stories\/\d+/);
+    // BaseListPage's readySelector defaults to '#name', which the story editor no longer
+    // has — since #158 its form is app-field rows with generated ids.
+    await this.clickTableRow(name, /\/stories\/\d+/, '[data-testid="story-name"]');
   }
 
   async expectStoryInTable(name: string): Promise<void> {

--- a/requel-angular/e2e/sse-refresh.e2e.ts
+++ b/requel-angular/e2e/sse-refresh.e2e.ts
@@ -55,7 +55,8 @@ test.describe('SSE live refresh', () => {
     );
 
     await page.goto(`/projects/${encodeURIComponent(projectName)}/goals/${goal.id}`);
-    const nameInput = page.locator('#name');
+    // Since #158 the goal form is app-field rows with generated ids — locate by testid.
+    const nameInput = page.getByTestId('goal-name');
     await expect(nameInput).toHaveValue(originalName);
     await subscriptionPromise;
 

--- a/requel-angular/src/app/core/command.service.ts
+++ b/requel-angular/src/app/core/command.service.ts
@@ -69,18 +69,25 @@ export class CommandService {
     }
   }
 
+  /**
+   * Normalises a failed request into a `CommandResult`, carrying the HTTP `status`
+   * through so callers can distinguish a **409** optimistic-lock conflict from an
+   * ordinary failure. A body that is already a `CommandResult` keeps its own fields
+   * and only gains `status`.
+   */
   private handleError<T>(err: unknown, commandType: string): CommandResult<T> {
     if (err instanceof HttpErrorResponse) {
       const body = err.error as CommandResult<T> | ErrorResponse;
-      if ('success' in body) {
-        return body as CommandResult<T>;
+      if (body && typeof body === 'object' && 'success' in body) {
+        return { ...(body as CommandResult<T>), status: err.status };
       }
       return {
         success: false,
         entityType: commandType,
-        error: (body as ErrorResponse).message ?? err.message,
+        error: (body as ErrorResponse)?.message ?? err.message,
         entity: null,
-        violations: null
+        violations: null,
+        status: err.status
       };
     }
     return {

--- a/requel-angular/src/app/features/goals/goal-editor.a11y.spec.ts
+++ b/requel-angular/src/app/features/goals/goal-editor.a11y.spec.ts
@@ -108,4 +108,83 @@ describe('GoalEditorComponent — relation-type dialog accessibility', () => {
     expect(document.activeElement).toBe(addBtn);
     expect(comp.pendingRelationGoal()).toBeNull();
   });
+
+  describe('the migrated forms (issue #158)', () => {
+    /** Render the edit route and settle. */
+    async function renderEdit(): Promise<HTMLElement> {
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+      return fixture.nativeElement as HTMLElement;
+    }
+
+    /** Render the create route, which renders the wizard instead of the edit card. */
+    async function renderCreate(): Promise<HTMLElement> {
+      paramMap$.next(convertToParamMap({ name: 'proj1', goalId: 'new' }));
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+      return fixture.nativeElement as HTMLElement;
+    }
+
+    /**
+     * `p-confirmdialog` is excluded: PrimeNG marks its host `role="alertdialog"` even
+     * when nothing is showing, so axe reports an unnamed dialog on every page that
+     * mounts one. Pre-existing and not specific to these forms — see the note on
+     * `expectNoAxeViolations` and #139.
+     */
+    const EXCLUDE = ['p-confirmdialog'];
+
+    it('has no axe-core violations on the edit form', async () => {
+      await expectNoAxeViolations(await renderEdit(), EXCLUDE);
+    });
+
+    it('has no axe-core violations on the create wizard', async () => {
+      await expectNoAxeViolations(await renderCreate(), EXCLUDE);
+    });
+
+    it('has no axe-core violations with the name error showing', async () => {
+      const el = await renderCreate();
+      comp.detailsForm.controls.name.markAsTouched();
+      comp.submitted.set(true);
+      fixture.detectChanges();
+
+      expect(el.querySelector('[data-testid="field-error"]')).not.toBeNull();
+      await expectNoAxeViolations(el, EXCLUDE);
+    });
+
+    it('associates the Name label and error with the input', async () => {
+      const el = await renderCreate();
+      comp.detailsForm.controls.name.markAsTouched();
+      fixture.detectChanges();
+
+      const input = el.querySelector<HTMLInputElement>('[data-testid="goal-name"]');
+      const error = el.querySelector('[data-testid="field-error"]');
+      const label = el.querySelector<HTMLLabelElement>(`label[for="${input?.id}"]`);
+
+      expect(label?.textContent).toContain('Name');
+      expect(input?.getAttribute('aria-invalid')).toBe('true');
+      expect(input?.getAttribute('aria-describedby')).toContain(error?.id ?? '');
+      expect(input?.getAttribute('aria-required')).toBe('true');
+    });
+
+    it('no longer renders the per-editor form-grid', async () => {
+      const editEl = await renderEdit();
+      expect(editEl.querySelector('.form-grid')).toBeNull();
+      expect(editEl.querySelectorAll('app-field').length).toBe(2);
+    });
+
+    it('reaches Tags and Relations during create without an isNew gate', async () => {
+      const el = await renderCreate();
+      const stepKeys = Array.from(el.querySelectorAll('[data-testid^="wizard-step-"]')).map(n =>
+        n.getAttribute('data-testid')
+      );
+
+      expect(stepKeys).toEqual([
+        'wizard-step-details',
+        'wizard-step-tags',
+        'wizard-step-relations',
+      ]);
+    });
+  });
 });

--- a/requel-angular/src/app/features/goals/goal-editor.spec.ts
+++ b/requel-angular/src/app/features/goals/goal-editor.spec.ts
@@ -10,13 +10,34 @@ import { CommandService } from '../../core/command.service';
 import { ProjectService } from '../../core/project.service';
 import { PermissionService } from '../../core/permission.service';
 import { EventStreamService } from '../../core/event-stream.service';
+import { AppWizardStepComponent, WizardCommitRequest } from '../../shared/app-form-wizard';
 
 const MOCK_GOAL = {
-  id: 10, version: 0, name: 'Improve UX', text: 'Make it great.',
+  id: 10, version: 5, name: 'Improve UX', text: 'Make it great.',
   relationsFromThisGoal: [], relationsToThisGoal: [], referencedBy: []
 };
 
 const flush = () => new Promise(r => setTimeout(r, 0));
+
+/** A stand-in for the wizard's commit handshake, so the host can be driven directly. */
+function commitRequest(key: string): WizardCommitRequest & {
+  completed: () => boolean;
+  failure: () => string | null;
+} {
+  let completed = false;
+  let failure: string | null = null;
+  return {
+    step: { key } as AppWizardStepComponent,
+    complete: () => {
+      completed = true;
+    },
+    fail: (message: string) => {
+      failure = message;
+    },
+    completed: () => completed,
+    failure: () => failure,
+  };
+}
 
 describe('GoalEditorComponent', () => {
   let paramMap$: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
@@ -29,6 +50,10 @@ describe('GoalEditorComponent', () => {
   let fixture: any;
   let comp: GoalEditorComponent;
   let router: Router;
+
+  /** Payload of the nth (0-based) EditGoal call. */
+  const editGoalCall = (n: number) =>
+    commandServiceMock.execute.mock.calls.filter(c => c[0] === 'EditGoal')[n]?.[1];
 
   beforeEach(() => {
     paramMap$ = new BehaviorSubject(convertToParamMap({ name: 'proj1', goalId: 'new' }));
@@ -75,28 +100,45 @@ describe('GoalEditorComponent', () => {
     vi.spyOn(router, 'navigate').mockResolvedValue(true);
   });
 
-  it('isNew() is true when goalId param is "new"', async () => {
+  /** Render the create route. */
+  async function renderNew(): Promise<void> {
     fixture.detectChanges();
     await flush();
+    fixture.detectChanges();
+  }
+
+  /** Render the edit route for goal 10. */
+  async function renderExisting(): Promise<void> {
+    paramMap$.next(convertToParamMap({ name: 'proj1', goalId: '10' }));
+    fixture.detectChanges();
+    await flush();
+    fixture.detectChanges();
+  }
+
+  it('isNew() is true when goalId param is "new"', async () => {
+    await renderNew();
     expect(comp.isNew()).toBe(true);
   });
 
   it('isNew() is false and goal() loaded when goalId is numeric', async () => {
-    paramMap$.next(convertToParamMap({ name: 'proj1', goalId: '10' }));
-    fixture.detectChanges();
-    await flush();
+    await renderExisting();
     expect(comp.isNew()).toBe(false);
     expect(goalServiceMock.getGoal).toHaveBeenCalledWith('proj1', 10);
     expect(comp.goalName()).toBe('Improve UX');
     expect(comp.goal()?.id).toBe(10);
   });
 
-  it('onSave calls commandService.execute("EditGoal") with projectName and name', async () => {
-    fixture.detectChanges();
-    await flush();
-    comp.name = 'New Goal';
-    comp.text = 'Details';
+  it('loads the existing goal into the reactive form', async () => {
+    await renderExisting();
+    expect(comp.detailsForm.getRawValue()).toEqual({ name: 'Improve UX', text: 'Make it great.' });
+    expect(comp.detailsForm.pristine).toBe(true);
+  });
+
+  it('onSave calls commandService.execute("EditGoal") with the form values', async () => {
+    await renderExisting();
+    comp.detailsForm.setValue({ name: 'New Goal', text: 'Details' });
     await comp.onSave();
+
     expect(commandServiceMock.execute).toHaveBeenCalledWith('EditGoal', expect.objectContaining({
       projectName: 'proj1',
       name: 'New Goal',
@@ -106,15 +148,218 @@ describe('GoalEditorComponent', () => {
 
   it('onSave sets errorMessage when command returns error', async () => {
     commandServiceMock.execute.mockResolvedValue({ success: false, error: 'Name conflict' });
-    comp.name = 'Duplicate';
+    await renderExisting();
+    comp.detailsForm.setValue({ name: 'Duplicate', text: '' });
     await comp.onSave();
+
     expect(comp.errorMessage()).toBe('Name conflict');
   });
 
+  it('onSave refuses an invalid form without calling the command', async () => {
+    await renderExisting();
+    commandServiceMock.execute.mockClear();
+    comp.detailsForm.setValue({ name: '', text: 'no name' });
+    await comp.onSave();
+
+    expect(commandServiceMock.execute).not.toHaveBeenCalled();
+    expect(comp.detailsForm.controls.name.touched).toBe(true);
+  });
+
+  describe('the edit-mode Save policy', () => {
+    it('is disabled while the form is pristine', async () => {
+      await renderExisting();
+      expect(comp.canSave()).toBe(false);
+    });
+
+    it('is enabled once a valid change is made', async () => {
+      await renderExisting();
+      comp.detailsForm.controls.name.setValue('Renamed');
+      comp.detailsForm.controls.name.markAsDirty();
+      expect(comp.canSave()).toBe(true);
+    });
+
+    it('is disabled again after a successful save', async () => {
+      await renderExisting();
+      comp.detailsForm.setValue({ name: 'Renamed', text: 'x' });
+      await comp.onSave();
+      expect(comp.canSave()).toBe(false);
+      expect(comp.hasUnsavedChanges()).toBe(false);
+    });
+
+    it('is disabled while the name is blank', async () => {
+      await renderExisting();
+      comp.detailsForm.setValue({ name: '', text: 'x' });
+      expect(comp.canSave()).toBe(false);
+    });
+  });
+
+  describe('the create wizard', () => {
+    it('renders the wizard on the create route and not on the edit route', async () => {
+      await renderNew();
+      expect(fixture.nativeElement.querySelector('app-form-wizard')).not.toBeNull();
+
+      await renderExisting();
+      expect(fixture.nativeElement.querySelector('app-form-wizard')).toBeNull();
+      expect(fixture.nativeElement.querySelector('[data-testid="goal-save"]')).not.toBeNull();
+    });
+
+    it('starts on the details step with an empty form', async () => {
+      await renderNew();
+      expect(comp.wizardStep).toBe('details');
+      expect(comp.detailsForm.getRawValue()).toEqual({ name: '', text: '' });
+      expect(comp.goalId).toBeNull();
+    });
+
+    it('creates the goal on the details commit, without a goalId or version', async () => {
+      await renderNew();
+      comp.detailsForm.setValue({ name: 'Reduce setup time', text: 'Cut it to a day.' });
+
+      const request = commitRequest('details');
+      await comp.onStepCommit(request);
+
+      expect(editGoalCall(0)).toEqual({
+        projectName: 'proj1',
+        name: 'Reduce setup time',
+        text: 'Cut it to a day.'
+      });
+      expect(request.completed()).toBe(true);
+      expect(comp.goalId).toBe(10);
+      expect(projectServiceMock.notifyTreeChanged).toHaveBeenCalled();
+    });
+
+    it('hydrates relations after create so the later steps have data', async () => {
+      await renderNew();
+      comp.detailsForm.setValue({ name: 'Reduce setup time', text: '' });
+      await comp.onStepCommit(commitRequest('details'));
+
+      expect(goalServiceMock.getGoal).toHaveBeenCalledWith('proj1', 10);
+      expect(comp.goal()?.id).toBe(10);
+    });
+
+    it('advances the optional steps without calling the API', async () => {
+      await renderNew();
+      commandServiceMock.execute.mockClear();
+
+      const tags = commitRequest('tags');
+      await comp.onStepCommit(tags);
+      const relations = commitRequest('relations');
+      await comp.onStepCommit(relations);
+
+      expect(tags.completed()).toBe(true);
+      expect(relations.completed()).toBe(true);
+      expect(commandServiceMock.execute).not.toHaveBeenCalled();
+    });
+
+    it('reports a failed create on the step instead of advancing', async () => {
+      commandServiceMock.execute.mockResolvedValue({ success: false, error: 'Name conflict' });
+      await renderNew();
+      comp.detailsForm.setValue({ name: 'Duplicate', text: '' });
+
+      const request = commitRequest('details');
+      await comp.onStepCommit(request);
+
+      expect(request.completed()).toBe(false);
+      expect(request.failure()).toBe('Name conflict');
+      expect(comp.goalId).toBeNull();
+    });
+
+    it('navigates to the saved goal when the wizard finishes', async () => {
+      await renderNew();
+      comp.detailsForm.setValue({ name: 'Reduce setup time', text: '' });
+      await comp.onStepCommit(commitRequest('details'));
+
+      comp.onWizardFinished();
+      expect(router.navigate).toHaveBeenCalledWith(['/projects', 'proj1', 'goals', 10]);
+    });
+  });
+
+  describe('the version contract', () => {
+    it('adopts the version from the response and sends it on the next save', async () => {
+      await renderExisting();
+      // The server bumps the version on each accepted edit; the editor must re-read it
+      // rather than keep sending the one it loaded with.
+      commandServiceMock.execute.mockResolvedValue({
+        success: true,
+        entity: { ...MOCK_GOAL, version: 9 }
+      });
+
+      comp.detailsForm.setValue({ name: 'First rename', text: '' });
+      await comp.onSave();
+      comp.detailsForm.setValue({ name: 'Second rename', text: '' });
+      await comp.onSave();
+
+      expect(editGoalCall(0)).toEqual(expect.objectContaining({ goalId: 10, version: 5 }));
+      expect(editGoalCall(1)).toEqual(expect.objectContaining({ goalId: 10, version: 9 }));
+    });
+
+    it('sends the refreshed version when the user steps back to Details and re-commits', async () => {
+      // The regression this whole contract exists for: create on step 1, walk forward,
+      // come back to fix a typo, Continue again. Re-sending the create-time version
+      // would be a guaranteed 409.
+      await renderNew();
+      comp.detailsForm.setValue({ name: 'Reduce setup time', text: '' });
+      await comp.onStepCommit(commitRequest('details'));
+
+      comp.detailsForm.setValue({ name: 'Reduce setup time drastically', text: '' });
+      const second = commitRequest('details');
+      await comp.onStepCommit(second);
+
+      expect(editGoalCall(0)['version']).toBeUndefined();
+      expect(editGoalCall(1)).toEqual(expect.objectContaining({ goalId: 10, version: 5 }));
+      expect(second.completed()).toBe(true);
+    });
+
+    it('recovers from a stale-version 409 by refetching and keeping the step', async () => {
+      await renderExisting();
+      goalServiceMock.getGoal.mockClear();
+      commandServiceMock.execute.mockResolvedValue({
+        success: false,
+        status: 409,
+        error: 'Goal has been changed by another user.'
+      });
+
+      comp.detailsForm.setValue({ name: 'Renamed', text: '' });
+      const request = commitRequest('details');
+      await comp.onStepCommit(request);
+
+      expect(goalServiceMock.getGoal).toHaveBeenCalledWith('proj1', 10);
+      expect(request.completed()).toBe(false);
+      expect(request.failure()).toContain('changed elsewhere');
+    });
+
+    it('surfaces the stale-version message on an edit-mode save', async () => {
+      await renderExisting();
+      commandServiceMock.execute.mockResolvedValue({
+        success: false,
+        status: 409,
+        error: 'Goal has been changed by another user.'
+      });
+
+      comp.detailsForm.setValue({ name: 'Renamed', text: '' });
+      await comp.onSave();
+
+      expect(comp.errorMessage()).toContain('changed elsewhere');
+    });
+
+    it('treats a non-409 failure as an ordinary error, with no refetch', async () => {
+      await renderExisting();
+      goalServiceMock.getGoal.mockClear();
+      commandServiceMock.execute.mockResolvedValue({
+        success: false,
+        status: 400,
+        error: 'Name is required.'
+      });
+
+      comp.detailsForm.setValue({ name: 'Renamed', text: '' });
+      await comp.onSave();
+
+      expect(goalServiceMock.getGoal).not.toHaveBeenCalled();
+      expect(comp.errorMessage()).toBe('Name is required.');
+    });
+  });
+
   it('onDelete triggers confirm then calls execute("DeleteGoal")', async () => {
-    paramMap$.next(convertToParamMap({ name: 'proj1', goalId: '10' }));
-    fixture.detectChanges();
-    await flush();
+    await renderExisting();
 
     const cs = fixture.debugElement.injector.get(ConfirmationService);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -131,9 +376,7 @@ describe('GoalEditorComponent', () => {
   });
 
   it('onCopy triggers confirm then calls execute("CopyGoal")', async () => {
-    paramMap$.next(convertToParamMap({ name: 'proj1', goalId: '10' }));
-    fixture.detectChanges();
-    await flush();
+    await renderExisting();
 
     commandServiceMock.execute.mockResolvedValue({ success: true, entity: { ...MOCK_GOAL, id: 99 } });
     const cs = fixture.debugElement.injector.get(ConfirmationService);
@@ -148,5 +391,33 @@ describe('GoalEditorComponent', () => {
       goalId: 10
     }));
     expect(router.navigate).toHaveBeenCalledWith(['/projects', 'proj1', 'goals', 99]);
+  });
+
+  it('sends the persisted name as the relation source, not an unsaved rename', async () => {
+    await renderExisting();
+    comp.detailsForm.controls.name.setValue('Unsaved rename');
+    comp.onRelationGoalSelected({ entityType: 'Goal', id: 2, name: 'Reduce churn' });
+    await comp.onConfirmRelation();
+
+    expect(commandServiceMock.execute).toHaveBeenCalledWith('EditGoalRelation', expect.objectContaining({
+      fromGoalName: 'Improve UX',
+      toGoalName: 'Reduce churn'
+    }));
+  });
+
+  it('keeps the SSE guard from clobbering unsaved edits but still takes the new version', async () => {
+    await renderExisting();
+    comp.detailsForm.controls.name.setValue('Local edit');
+    comp.detailsForm.controls.name.markAsDirty();
+
+    goalServiceMock.getGoal.mockResolvedValue({ ...MOCK_GOAL, name: 'Remote edit', version: 12 });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (comp as any).loadGoal(true);
+
+    expect(comp.detailsForm.controls.name.value).toBe('Local edit');
+
+    commandServiceMock.execute.mockResolvedValue({ success: true, entity: MOCK_GOAL });
+    await comp.onSave();
+    expect(editGoalCall(0)).toEqual(expect.objectContaining({ version: 12 }));
   });
 });

--- a/requel-angular/src/app/features/goals/goal-editor.ts
+++ b/requel-angular/src/app/features/goals/goal-editor.ts
@@ -19,11 +19,12 @@
  *
  */
 import { Component, computed, ElementRef, OnDestroy, OnInit, signal, ViewChild } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
 import { PageHeaderComponent } from '../../shared/page-header';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
-import { FormsModule } from '@angular/forms';
+import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
 import { InputText } from 'primeng/inputtext';
 import { TextareaModule } from 'primeng/textarea';
@@ -33,6 +34,7 @@ import { MessageModule } from 'primeng/message';
 import { DialogModule } from 'primeng/dialog';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { ConfirmationService, MessageService } from 'primeng/api';
+import { CommandResult } from '../../models/command';
 import { GoalDto, GoalRelationDto } from '../../models/goal';
 import { EntityReferenceDto } from '../../models/entity-reference';
 import { GoalService } from '../../core/goal.service';
@@ -44,13 +46,25 @@ import { EntitySelectorDialogComponent } from '../../shared/entity-selector-dial
 import { AnnotationsSectionComponent } from '../../shared/annotations-section';
 import { TagSelectorComponent } from '../../shared/tag-selector';
 import { AppCardComponent } from '../../shared/app-card';
+import { AppFieldComponent, AppFieldControlDirective } from '../../shared/app-field';
+import {
+  AppFormWizardComponent,
+  AppWizardStepComponent,
+  WizardCommitRequest,
+} from '../../shared/app-form-wizard';
+
+/** Wording for the stale-version recovery path, so the 409 case reads as recoverable. */
+const STALE_VERSION_MESSAGE =
+  'This goal was changed elsewhere. Your copy has been refreshed — review the values and continue.';
 
 @Component({
   selector: 'app-goal-editor',
   standalone: true,
-  imports: [PageHeaderComponent, RouterLink, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
+  imports: [PageHeaderComponent, RouterLink, FormsModule, ReactiveFormsModule, NgTemplateOutlet,
+            ButtonModule, InputText, TextareaModule, SelectModule,
             TableModule, MessageModule, DialogModule, ConfirmDialogModule, EntitySelectorDialogComponent,
-            AnnotationsSectionComponent, TagSelectorComponent, AppCardComponent],
+            AnnotationsSectionComponent, TagSelectorComponent, AppCardComponent, AppFieldComponent,
+            AppFieldControlDirective, AppFormWizardComponent, AppWizardStepComponent],
   providers: [ConfirmationService],
   template: `
     <div class="goal-editor" data-testid="goal-editor">
@@ -76,81 +90,59 @@ import { AppCardComponent } from '../../shared/app-card';
         <p-message severity="error" [text]="errorMessage()!" />
       }
 
-      <app-card>
-        <div class="form-grid">
-          <label for="name">Name</label>
-          <input id="name" pInputText [(ngModel)]="name" placeholder="Goal name" />
+      @if (isNew()) {
+        <!--
+          Create runs as a wizard so Tags and Relations are reachable before the first
+          save. Step 1 commits EditGoal on Continue, which is what gives steps 2 and 3
+          the persisted goalId they need.
+        -->
+        <app-form-wizard
+          [(activeKey)]="wizardStep"
+          navLabel="New goal steps"
+          (stepCommit)="onStepCommit($event)"
+          (cancelled)="onBack()"
+          (finished)="onWizardFinished()"
+          data-testid="goal-wizard"
+        >
+          <app-wizard-step key="details" label="Details" helper="Name and description"
+                           [form]="detailsForm">
+            <ng-template>
+              <ng-container [ngTemplateOutlet]="detailsFields" />
+            </ng-template>
+          </app-wizard-step>
 
-          <label for="text">Description</label>
-          <textarea id="text" pTextarea [(ngModel)]="text" rows="6"
-                    placeholder="Goal description"></textarea>
-        </div>
+          <app-wizard-step key="tags" label="Tags" helper="Categorise this goal" [optional]="true">
+            <ng-template>
+              <ng-container [ngTemplateOutlet]="tagsSection" />
+            </ng-template>
+          </app-wizard-step>
 
-        <div class="form-actions">
-          <p-button label="Save" icon="pi pi-check" data-testid="goal-save" (onClick)="onSave()" [loading]="saving()" />
-        </div>
-      </app-card>
+          <app-wizard-step key="relations" label="Relations" helper="Link to other goals"
+                           [optional]="true">
+            <ng-template>
+              <!-- heading: false — the wizard panel's own h2 already reads "Relations". -->
+              <ng-container [ngTemplateOutlet]="relationsSection"
+                            [ngTemplateOutletContext]="{ heading: false }" />
+            </ng-template>
+          </app-wizard-step>
+        </app-form-wizard>
+      } @else {
+        <app-card>
+          <ng-container [ngTemplateOutlet]="detailsFields" />
 
-      <!-- Relations: outgoing (this goal supports/conflicts with...) -->
-      @if (!isNew() && goal()) {
-        <div class="section">
-          <div class="section-header">
-            <h3>This Goal's Relations</h3>
-            @if (canEdit()) {
-              <p-button #addRelationBtn label="Add Relation" icon="pi pi-plus" size="small" data-testid="goal-add-relation"
-                        (onClick)="showRelationSelector = true" />
-            }
+          <div class="form-actions">
+            <p-button label="Save" icon="pi pi-check" data-testid="goal-save"
+                      [disabled]="!canSave()" [loading]="saving()" (onClick)="onSave()" />
           </div>
+        </app-card>
 
-          @if (goal()!.relationsFromThisGoal?.length) {
-            <p-table [value]="goal()!.relationsFromThisGoal!" [rows]="10">
-              <ng-template #header>
-                <tr>
-                  <th>Goal</th>
-                  <th>Type</th>
-                  @if (canEdit()) { <th class="col-actions"></th> }
-                </tr>
-              </ng-template>
-              <ng-template #body let-r>
-                <tr data-testid="goal-relation-row">
-                  <td><a class="entity-link" [routerLink]="['/projects', projectName, 'goals', r.goalId]">{{ r.goalName }}</a></td>
-                  <td>{{ r.relationType }}</td>
-                  @if (canEdit()) {
-                    <td><p-button icon="pi pi-trash" severity="danger" [text]="true" size="small"
-                                  data-testid="goal-remove-relation" [ariaLabel]="'Remove relation to ' + r.goalName"
-                                  (onClick)="onDeleteRelation(r)" /></td>
-                  }
-                </tr>
-              </ng-template>
-            </p-table>
-          } @else {
-            <p class="empty-text">No relations defined.</p>
-          }
+        <ng-container [ngTemplateOutlet]="relationsSection"
+                      [ngTemplateOutletContext]="{ heading: true }" />
 
-          <!-- Incoming relations (other goals relate to this one) -->
-          @if (goal()!.relationsToThisGoal?.length) {
-            <h4>Related To This Goal</h4>
-            <p-table [value]="goal()!.relationsToThisGoal!" [rows]="10">
-              <ng-template #header>
-                <tr>
-                  <th>Goal</th>
-                  <th>Type</th>
-                </tr>
-              </ng-template>
-              <ng-template #body let-r>
-                <tr>
-                  <td><a class="entity-link" [routerLink]="['/projects', projectName, 'goals', r.goalId]">{{ r.goalName }}</a></td>
-                  <td>{{ r.relationType }}</td>
-                </tr>
-              </ng-template>
-            </p-table>
-          }
-        </div>
-
-        <!-- Referenced By -->
-        @if (goal()!.referencedBy?.length) {
+        @if (goal()?.referencedBy?.length) {
           <div class="section">
-            <h3>Referenced By</h3>
+            <!-- h2: these sections sit directly under the page's single h1. -->
+            <h2 class="rq-section-title">Referenced By</h2>
             <p-table [value]="goal()!.referencedBy!" [rows]="10">
               <ng-template #header>
                 <tr>
@@ -167,6 +159,20 @@ import { AppCardComponent } from '../../shared/app-card';
             </p-table>
           </div>
         }
+
+        <ng-container [ngTemplateOutlet]="tagsSection" />
+      }
+
+      <!--
+        Annotations render against a persisted entity, so they stay outside the wizard
+        and appear once the goal exists rather than as a dead panel during create.
+      -->
+      @if (goalId != null) {
+        <app-annotations-section
+          [projectName]="projectName"
+          entityType="Goal"
+          [entityId]="goalId"
+          [canEdit]="canEdit()" />
       }
 
       <!-- Add Relation Dialog -->
@@ -194,32 +200,111 @@ import { AppCardComponent } from '../../shared/app-card';
         </div>
       </p-dialog>
 
-      @if (!isNew()) {
-        <app-tag-selector
-          [projectName]="projectName"
-          entityType="Goal"
-          [entityId]="goalId"
-          [canEdit]="canEdit()" />
-      }
-
-      <app-annotations-section
-        [projectName]="projectName"
-        entityType="Goal"
-        [entityId]="goalId"
-        [canEdit]="canEdit()" />
-
       <p-confirmDialog />
+
+      <!--
+        Shared bodies. Each is used by both the wizard step and the edit view, so the
+        two modes cannot drift apart. Controls bind with [formControl], not
+        formControlName: these templates are projected into the wizard, where
+        formControlName would look for a parent formGroup that is not there.
+      -->
+      <ng-template #detailsFields>
+        <app-field label="Name" helper="Short and outcome-focused."
+                   [control]="detailsForm.controls.name"
+                   [errorMessages]="nameErrors"
+                   [submitted]="submitted()">
+          <input appFieldControl pInputText [formControl]="detailsForm.controls.name"
+                 placeholder="Goal name" data-testid="goal-name" />
+        </app-field>
+
+        <app-field label="Description" [control]="detailsForm.controls.text" [divider]="false"
+                   [submitted]="submitted()">
+          <textarea appFieldControl pTextarea [formControl]="detailsForm.controls.text" rows="6"
+                    placeholder="Goal description" data-testid="goal-text"></textarea>
+        </app-field>
+      </ng-template>
+
+      <ng-template #tagsSection>
+        @if (goalId != null) {
+          <app-tag-selector
+            [projectName]="projectName"
+            entityType="Goal"
+            [entityId]="goalId"
+            [canEdit]="canEdit()" />
+        } @else {
+          <p class="empty-text">Save the goal's details first to add tags.</p>
+        }
+      </ng-template>
+
+      <ng-template #relationsSection let-heading="heading">
+        <div class="section">
+          <div class="section-header">
+            @if (heading) {
+              <h2 class="rq-section-title">This Goal's Relations</h2>
+            }
+            @if (canEdit() && goalId != null) {
+              <p-button #addRelationBtn label="Add Relation" icon="pi pi-plus" size="small" data-testid="goal-add-relation"
+                        (onClick)="showRelationSelector = true" />
+            }
+          </div>
+
+          @if (goalId == null) {
+            <p class="empty-text">Save the goal's details first to add relations.</p>
+          } @else if (goal()?.relationsFromThisGoal?.length) {
+            <p-table [value]="goal()!.relationsFromThisGoal!" [rows]="10">
+              <ng-template #header>
+                <tr>
+                  <th>Goal</th>
+                  <th>Type</th>
+                  @if (canEdit()) { <th class="col-actions"></th> }
+                </tr>
+              </ng-template>
+              <ng-template #body let-r>
+                <tr data-testid="goal-relation-row">
+                  <td><a class="entity-link" [routerLink]="['/projects', projectName, 'goals', r.goalId]">{{ r.goalName }}</a></td>
+                  <td>{{ r.relationType }}</td>
+                  @if (canEdit()) {
+                    <td><p-button icon="pi pi-trash" severity="danger" [text]="true" size="small"
+                                  data-testid="goal-remove-relation" [ariaLabel]="'Remove relation to ' + r.goalName"
+                                  (onClick)="onDeleteRelation(r)" /></td>
+                  }
+                </tr>
+              </ng-template>
+            </p-table>
+          } @else {
+            <p class="empty-text">No relations defined.</p>
+          }
+
+          <!-- Incoming relations (other goals relate to this one) -->
+          @if (goal()?.relationsToThisGoal?.length) {
+            <h3>Related To This Goal</h3>
+            <p-table [value]="goal()!.relationsToThisGoal!" [rows]="10">
+              <ng-template #header>
+                <tr>
+                  <th>Goal</th>
+                  <th>Type</th>
+                </tr>
+              </ng-template>
+              <ng-template #body let-r>
+                <tr>
+                  <td><a class="entity-link" [routerLink]="['/projects', projectName, 'goals', r.goalId]">{{ r.goalName }}</a></td>
+                  <td>{{ r.relationType }}</td>
+                </tr>
+              </ng-template>
+            </p-table>
+          }
+        </div>
+      </ng-template>
     </div>
   `,
   styles: [`
     .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
     .page-actions { display: flex; gap: 0.5rem; }
-    .form-grid { display: grid; grid-template-columns: 120px 1fr; gap: 0.75rem 1rem; align-items: start; max-width: 700px; }
     .form-actions { margin-top: 1rem; }
     .section { margin-top: 1.5rem; }
-    .section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
-    .section-header h3 { margin: 0; }
-    h4 { margin: 1rem 0 0.5rem; }
+    .section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; gap: 0.5rem; }
+    .section-header h2 { margin: 0; }
+    .section h3 { margin: 1rem 0 0.5rem; }
     .empty-text { color: var(--p-text-secondary-color); font-style: italic; }
     .entity-link { cursor: pointer; color: var(--p-primary-color); text-decoration: underline; }
     .dialog-body { display: flex; flex-direction: column; }
@@ -234,6 +319,8 @@ export class GoalEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
   saving = signal(false);
   canEdit = signal(false);
   canDelete = signal(false);
+  /** True once a save/commit has been attempted, so untouched invalid fields explain themselves. */
+  submitted = signal(false);
   pendingRelationGoal = signal<EntityReferenceDto | null>(null);
   relationDialogVisible = signal(false);
   relationDialogHeader = computed(() => {
@@ -243,10 +330,17 @@ export class GoalEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
 
   @ViewChild('addRelationBtn', { read: ElementRef }) addRelationBtn?: ElementRef<HTMLElement>;
 
-  name = '';
-  text = '';
-  private originalName = '';
-  private originalText = '';
+  /** Details step / edit form. Replaces the previous `name` + `text` ngModel fields. */
+  readonly detailsForm = new FormGroup({
+    name: new FormControl('', { validators: [Validators.required], nonNullable: true }),
+    text: new FormControl('', { nonNullable: true }),
+  });
+
+  readonly nameErrors = { required: 'A goal needs a name.' };
+
+  /** Active wizard step key, two-way bound to `app-form-wizard`. */
+  wizardStep = 'details';
+
   showRelationSelector = false;
   newRelationType = 'Supports';
   relationTypeOptions = [
@@ -285,11 +379,11 @@ export class GoalEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
       if (newIsNew) {
         this.isNew.set(true);
         this.goal.set(null);
-        this.name = '';
-        this.text = '';
-        this.originalName = '';
-        this.originalText = '';
+        this.goalId = null;
         this.version = null;
+        this.wizardStep = 'details';
+        this.submitted.set(false);
+        this.detailsForm.reset({ name: '', text: '' });
       }
 
       await this.permissionService.loadForProject(this.projectName);
@@ -305,7 +399,12 @@ export class GoalEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
   }
 
   hasUnsavedChanges(): boolean {
-    return this.name !== this.originalName || this.text !== this.originalText;
+    return this.detailsForm.dirty;
+  }
+
+  /** Edit-mode Save: blocked on invalid, unchanged, or in-flight. */
+  canSave(): boolean {
+    return this.detailsForm.valid && this.detailsForm.dirty && !this.saving();
   }
 
   ngOnDestroy(): void {
@@ -321,14 +420,15 @@ export class GoalEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
       const g = await this.goalService.getGoal(this.projectName, this.goalId!);
       // Don't overwrite unsaved user edits when called from an SSE notification.
       if (fromSSE && this.hasUnsavedChanges()) {
+        // Still take the new version: the entity moved on, and holding the stale one
+        // guarantees a 409 on the user's next save.
+        this.version = g.version;
+        this.goal.set(g);
         return;
       }
       this.goal.set(g);
       this.goalName.set(g.name);
-      this.name = g.name;
-      this.text = g.text;
-      this.originalName = g.name;
-      this.originalText = g.text;
+      this.detailsForm.reset({ name: g.name, text: g.text });
       this.version = g.version;
     } catch {
       this.errorMessage.set('Failed to load goal.');
@@ -353,40 +453,128 @@ export class GoalEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
     return ids;
   }
 
-  async onSave(): Promise<void> {
+  /**
+   * Runs the commit for the wizard's current step.
+   *
+   * Only Details talks to the API — Tags and Relations commit through their own
+   * widgets as the user works, so their Continue just advances.
+   */
+  async onStepCommit(request: WizardCommitRequest): Promise<void> {
+    if (request.step.key !== 'details') {
+      request.complete();
+      return;
+    }
+
+    this.submitted.set(true);
+    const result = await this.saveDetails();
+
+    if (result.success) {
+      request.complete();
+      return;
+    }
+
+    if (await this.recoverFromStaleVersion(result)) {
+      request.fail(STALE_VERSION_MESSAGE);
+      return;
+    }
+    request.fail(result.error ?? 'Save failed.');
+  }
+
+  /** Done on the last step: the goal is already saved, so just go to it. */
+  onWizardFinished(): void {
+    if (this.goalId != null) {
+      this.router.navigate(['/projects', this.projectName, 'goals', this.goalId]);
+    } else {
+      this.onBack();
+    }
+  }
+
+  /**
+   * Issues `EditGoal` for the Details values and, on success, adopts the id and
+   * version from the response.
+   *
+   * The version is **spent on use**: every accepted `EditGoal` bumps it server-side,
+   * so it is re-read from `result.entity` each time. Holding the value captured at
+   * create and sending it again — which is what happens if the user steps back to
+   * Details and presses Continue a second time — is a guaranteed 409.
+   */
+  private async saveDetails(): Promise<CommandResult<unknown>> {
     this.saving.set(true);
     this.errorMessage.set(null);
     try {
-      const input: Record<string, unknown> = {
-        projectName: this.projectName,
-        name: this.name,
-        text: this.text,
-      };
+      const { name, text } = this.detailsForm.getRawValue();
+      const input: Record<string, unknown> = { projectName: this.projectName, name, text };
       if (this.goalId != null) input['goalId'] = this.goalId;
       if (this.version != null) input['version'] = this.version;
+
       const result = await this.commandService.execute('EditGoal', input);
-      if (result.success) {
-        this.messageService.add({ severity: 'success', summary: 'Saved', detail: 'Goal saved.' });
-        if (this.isNew()) {
-          this.projectService.notifyTreeChanged();
-          if (result.entity) {
-            const saved = result.entity as GoalDto;
-            // Reset originals before navigation so CanDeactivate guard doesn't fire
-            this.originalName = this.name;
-            this.originalText = this.text;
-            this.router.navigate(['/projects', this.projectName, 'goals', saved.id]);
-          }
-        } else {
-          await this.loadGoal(); // resets originalName/originalText
-        }
-      } else {
-        this.errorMessage.set(result.error ?? 'Save failed.');
+      if (!result.success) {
+        return result;
       }
+
+      const wasCreate = this.goalId == null;
+      if (wasCreate) {
+        this.projectService.notifyTreeChanged();
+      }
+
+      const saved = result.entity as GoalDto | null;
+      if (saved) {
+        this.goalId = saved.id;
+        this.version = saved.version;
+        this.goalName.set(saved.name);
+      }
+      this.detailsForm.markAsPristine();
+      this.messageService.add({ severity: 'success', summary: 'Saved', detail: 'Goal saved.' });
+
+      // Hydrate relations / referencedBy (and start the SSE subscription) the first
+      // time the goal exists, so steps 2 and 3 have something to render.
+      if (wasCreate && this.goalId != null) {
+        await this.loadGoal();
+      }
+      return result;
     } catch {
-      this.errorMessage.set('An unexpected error occurred.');
+      return {
+        success: false,
+        entityType: 'Goal',
+        entity: null,
+        error: 'An unexpected error occurred.',
+        violations: null,
+      };
     } finally {
       this.saving.set(false);
     }
+  }
+
+  /**
+   * If `result` is an optimistic-lock conflict (HTTP 409 from
+   * `EntityLockException.staleEntity`), refetch so the held version is current and
+   * the user can retry. Returns whether it handled the result.
+   */
+  private async recoverFromStaleVersion(result: CommandResult<unknown>): Promise<boolean> {
+    if (result.status !== 409 || this.goalId == null) {
+      return false;
+    }
+    await this.loadGoal();
+    return true;
+  }
+
+  /** Edit-mode Save. */
+  async onSave(): Promise<void> {
+    this.submitted.set(true);
+    if (this.detailsForm.invalid) {
+      this.detailsForm.markAllAsTouched();
+      return;
+    }
+
+    const result = await this.saveDetails();
+    if (result.success) {
+      return;
+    }
+    if (await this.recoverFromStaleVersion(result)) {
+      this.errorMessage.set(STALE_VERSION_MESSAGE);
+      return;
+    }
+    this.errorMessage.set(result.error ?? 'Save failed.');
   }
 
   onCopy(): void {
@@ -419,6 +607,8 @@ export class GoalEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
         });
         if (result.success) {
           this.projectService.notifyTreeChanged();
+          // Nothing left to guard against — don't let the dirty check block the exit.
+          this.detailsForm.markAsPristine();
           this.router.navigate(['/projects', this.projectName, 'goals']);
         } else {
           this.errorMessage.set(result.error ?? 'Delete failed.');
@@ -451,7 +641,9 @@ export class GoalEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
 
     const result = await this.commandService.execute('EditGoalRelation', {
       projectName: this.projectName,
-      fromGoalName: this.name,
+      // The persisted name, not the form value: an unsaved rename in the Name field
+      // would otherwise be sent as the relation's from-goal and not resolve.
+      fromGoalName: this.goalName(),
       toGoalName: ref.name,
       relationType: this.newRelationType
     });

--- a/requel-angular/src/app/features/stories/story-editor.a11y.spec.ts
+++ b/requel-angular/src/app/features/stories/story-editor.a11y.spec.ts
@@ -1,0 +1,173 @@
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter, Router, ActivatedRoute, convertToParamMap } from '@angular/router';
+import { BehaviorSubject, EMPTY } from 'rxjs';
+import { MessageService } from 'primeng/api';
+import { StoryEditorComponent } from './story-editor';
+import { StoryService } from '../../core/story.service';
+import { ActorService } from '../../core/actor.service';
+import { CommandService } from '../../core/command.service';
+import { ProjectService } from '../../core/project.service';
+import { PermissionService } from '../../core/permission.service';
+import { EventStreamService } from '../../core/event-stream.service';
+import { expectNoAxeViolations } from '../../shared/testing/a11y';
+
+const MOCK_ACTORS = [
+  { id: 1, version: 0, name: 'Customer', text: null, goals: null, referencedByUseCases: null, referencedByStories: null },
+];
+
+const MOCK_STORY = {
+  id: 20, version: 4, name: 'User logs in', text: 'A user logs in with credentials.',
+  storyType: 'Success', primaryActorName: 'Customer', goals: [], actors: [],
+};
+
+const flush = () => new Promise(r => setTimeout(r, 0));
+
+/**
+ * `p-confirmdialog` is excluded: PrimeNG marks its host `role="alertdialog"` even when
+ * nothing is showing, so axe reports an unnamed dialog on every page that mounts one.
+ * Pre-existing and app-wide — see the note on `expectNoAxeViolations` and #139.
+ */
+const EXCLUDE = ['p-confirmdialog'];
+
+describe('StoryEditorComponent — migrated form accessibility (issue #158)', () => {
+  let paramMap$: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fixture: any;
+  let comp: StoryEditorComponent;
+
+  beforeEach(() => {
+    paramMap$ = new BehaviorSubject(convertToParamMap({ name: 'proj1', storyId: '20' }));
+
+    TestBed.configureTestingModule({
+      imports: [StoryEditorComponent],
+      providers: [
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: ActivatedRoute, useValue: { paramMap: paramMap$.asObservable() } },
+        { provide: StoryService, useValue: { getStory: vi.fn().mockResolvedValue(MOCK_STORY) } },
+        { provide: ActorService, useValue: { listActors: vi.fn().mockResolvedValue(MOCK_ACTORS) } },
+        { provide: CommandService, useValue: { execute: vi.fn().mockResolvedValue({ success: true, entity: MOCK_STORY }) } },
+        { provide: ProjectService, useValue: { notifyTreeChanged: vi.fn() } },
+        { provide: PermissionService, useValue: {
+            loadForProject: vi.fn().mockResolvedValue(undefined),
+            canEdit: vi.fn().mockReturnValue(true),
+            canDelete: vi.fn().mockReturnValue(true),
+          } },
+        { provide: EventStreamService, useValue: {
+            events$: EMPTY,
+            addSubscription: vi.fn().mockResolvedValue(undefined),
+            removeSubscription: vi.fn().mockResolvedValue(undefined),
+          } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
+    });
+    fixture = TestBed.createComponent(StoryEditorComponent);
+    comp = fixture.componentInstance;
+    const router = TestBed.inject(Router);
+    vi.spyOn(router, 'navigate').mockResolvedValue(true);
+  });
+
+  async function renderEdit(): Promise<HTMLElement> {
+    fixture.detectChanges();
+    await flush();
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  async function renderCreate(): Promise<HTMLElement> {
+    paramMap$.next(convertToParamMap({ name: 'proj1', storyId: 'new' }));
+    fixture.detectChanges();
+    await flush();
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  it('has no axe-core violations on the edit form', async () => {
+    await expectNoAxeViolations(await renderEdit(), EXCLUDE);
+  });
+
+  it('has no axe-core violations on the create wizard', async () => {
+    await expectNoAxeViolations(await renderCreate(), EXCLUDE);
+  });
+
+  it('has no axe-core violations with the name error showing', async () => {
+    const el = await renderCreate();
+    comp.detailsForm.controls.name.markAsTouched();
+    comp.submitted.set(true);
+    fixture.detectChanges();
+
+    expect(el.querySelector('[data-testid="field-error"]')).not.toBeNull();
+    await expectNoAxeViolations(el, EXCLUDE);
+  });
+
+  it('renders every details control as an app-field row, with no form-grid left', async () => {
+    const el = await renderEdit();
+    expect(el.querySelector('.form-grid')).toBeNull();
+    // Name, Type, Primary Actor, Text.
+    expect(el.querySelectorAll('app-field').length).toBe(4);
+  });
+
+  describe('label and error association', () => {
+    it('associates the Name label, error and required state with the input', async () => {
+      const el = await renderCreate();
+      comp.detailsForm.controls.name.markAsTouched();
+      fixture.detectChanges();
+
+      const input = el.querySelector<HTMLInputElement>('[data-testid="story-name"]');
+      const error = el.querySelector('[data-testid="field-error"]');
+      const label = el.querySelector<HTMLLabelElement>(`label[for="${input?.id}"]`);
+
+      expect(label?.textContent).toContain('Name');
+      expect(input?.getAttribute('aria-invalid')).toBe('true');
+      expect(input?.getAttribute('aria-describedby')).toContain(error?.id ?? '');
+      expect(input?.getAttribute('aria-required')).toBe('true');
+    });
+
+    /**
+     * The reason Story is a pilot at all: `p-select` is a wrapper whose focusable input
+     * is rendered inside it, so `app-field` must not stamp the label/ARIA onto the
+     * custom element. Both selects pass `controlId` matching their own `inputId`, and
+     * the label must resolve to a real element inside the wrapper.
+     */
+    it('points the Type label at the input p-select renders inside itself', async () => {
+      const el = await renderEdit();
+      const label = el.querySelector<HTMLLabelElement>('label[for="storyTypeInput"]');
+      const target = el.querySelector('#storyTypeInput');
+      const wrapper = el.querySelector('[data-testid="story-type"]');
+
+      expect(label?.textContent).toContain('Type');
+      expect(target).not.toBeNull();
+      // The id belongs to something inside the wrapper, not the wrapper itself.
+      expect(target).not.toBe(wrapper);
+      expect(wrapper?.contains(target!)).toBe(true);
+    });
+
+    it('points the Primary Actor label at its own select input', async () => {
+      const el = await renderEdit();
+      const label = el.querySelector<HTMLLabelElement>('label[for="storyPrimaryActorInput"]');
+      const target = el.querySelector('#storyPrimaryActorInput');
+
+      expect(label?.textContent).toContain('Primary Actor');
+      expect(target).not.toBeNull();
+      expect(el.querySelector('[data-testid="story-primary-actor"]')?.contains(target!)).toBe(true);
+    });
+
+    it('gives each row a distinct control id', async () => {
+      const el = await renderEdit();
+      const ids = Array.from(el.querySelectorAll('label[for]')).map(l => l.getAttribute('for'));
+
+      expect(ids.length).toBe(4);
+      expect(new Set(ids).size).toBe(4);
+    });
+  });
+
+  it('reaches Goals and Additional Actors during create without an isNew gate', async () => {
+    const el = await renderCreate();
+    const keys = Array.from(el.querySelectorAll('[data-testid^="wizard-step-"]')).map(n =>
+      n.getAttribute('data-testid')
+    );
+
+    expect(keys).toEqual(['wizard-step-details', 'wizard-step-goals', 'wizard-step-actors']);
+  });
+});

--- a/requel-angular/src/app/features/stories/story-editor.spec.ts
+++ b/requel-angular/src/app/features/stories/story-editor.spec.ts
@@ -10,6 +10,7 @@ import { CommandService } from '../../core/command.service';
 import { ProjectService } from '../../core/project.service';
 import { PermissionService } from '../../core/permission.service';
 import { EventStreamService } from '../../core/event-stream.service';
+import { AppWizardStepComponent, WizardCommitRequest } from '../../shared/app-form-wizard';
 
 const MOCK_ACTORS = [
   { id: 1, version: 0, name: 'Customer', text: null, goals: null, referencedByUseCases: null, referencedByStories: null },
@@ -17,11 +18,31 @@ const MOCK_ACTORS = [
 ];
 
 const MOCK_STORY = {
-  id: 20, version: 0, name: 'User logs in', text: 'A user logs in with credentials.',
+  id: 20, version: 4, name: 'User logs in', text: 'A user logs in with credentials.',
   storyType: 'Success', primaryActorName: 'Customer', goals: [], actors: []
 };
 
 const flush = () => new Promise(r => setTimeout(r, 0));
+
+/** A stand-in for the wizard's commit handshake, so the host can be driven directly. */
+function commitRequest(key: string): WizardCommitRequest & {
+  completed: () => boolean;
+  failure: () => string | null;
+} {
+  let completed = false;
+  let failure: string | null = null;
+  return {
+    step: { key } as AppWizardStepComponent,
+    complete: () => {
+      completed = true;
+    },
+    fail: (message: string) => {
+      failure = message;
+    },
+    completed: () => completed,
+    failure: () => failure,
+  };
+}
 
 describe('StoryEditorComponent', () => {
   let paramMap$: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
@@ -34,6 +55,10 @@ describe('StoryEditorComponent', () => {
   let fixture: any;
   let comp: StoryEditorComponent;
   let router: Router;
+
+  /** Payload of the nth (0-based) EditStory call. */
+  const editStoryCall = (n: number) =>
+    commandServiceMock.execute.mock.calls.filter(c => c[0] === 'EditStory')[n]?.[1];
 
   beforeEach(() => {
     paramMap$ = new BehaviorSubject(convertToParamMap({ name: 'proj1', storyId: 'new' }));
@@ -75,51 +100,314 @@ describe('StoryEditorComponent', () => {
     vi.spyOn(router, 'navigate').mockResolvedValue(true);
   });
 
-  it('isNew() is true when storyId param is "new"', async () => {
+  async function renderNew(): Promise<void> {
     fixture.detectChanges();
     await flush();
+    fixture.detectChanges();
+  }
+
+  async function renderExisting(): Promise<void> {
+    paramMap$.next(convertToParamMap({ name: 'proj1', storyId: '20' }));
+    fixture.detectChanges();
+    await flush();
+    fixture.detectChanges();
+  }
+
+  it('isNew() is true when storyId param is "new"', async () => {
+    await renderNew();
     expect(comp.isNew()).toBe(true);
   });
 
   it('loads story when storyId param is numeric', async () => {
-    paramMap$.next(convertToParamMap({ name: 'proj1', storyId: '20' }));
-    fixture.detectChanges();
-    await flush();
+    await renderExisting();
     expect(storyServiceMock.getStory).toHaveBeenCalledWith('proj1', 20);
     expect(comp.storyName()).toBe('User logs in');
     expect(comp.story()?.id).toBe(20);
   });
 
   it('actorOptions populated from actorService.listActors', async () => {
-    fixture.detectChanges();
-    await flush();
+    await renderNew();
     expect(actorServiceMock.listActors).toHaveBeenCalledWith('proj1');
     expect(comp.actorOptions().length).toBe(2);
     expect(comp.actorOptions()[0].label).toBe('Customer');
   });
 
-  it('trackChanges() sets hasChanges() when name differs from original', async () => {
-    paramMap$.next(convertToParamMap({ name: 'proj1', storyId: '20' }));
-    fixture.detectChanges();
-    await flush();
-    expect(comp.hasChanges()).toBe(false);
-    comp.name = 'Modified Name';
-    comp.trackChanges();
-    expect(comp.hasChanges()).toBe(true);
+  it('loads all four fields into the reactive form', async () => {
+    await renderExisting();
+    expect(comp.detailsForm.getRawValue()).toEqual({
+      name: 'User logs in',
+      storyType: 'Success',
+      primaryActorName: 'Customer',
+      text: 'A user logs in with credentials.',
+    });
+    expect(comp.detailsForm.pristine).toBe(true);
+  });
+
+  it('treats a missing primaryActorName as empty rather than null', async () => {
+    storyServiceMock.getStory.mockResolvedValue({ ...MOCK_STORY, primaryActorName: null });
+    await renderExisting();
+    expect(comp.detailsForm.controls.primaryActorName.value).toBe('');
   });
 
   it('onSave calls commandService.execute("EditStory") with story fields', async () => {
-    fixture.detectChanges();
-    await flush();
-    comp.name = 'My Story';
-    comp.text = 'Story content';
-    comp.storyType = 'Success';
+    await renderExisting();
+    comp.detailsForm.setValue({
+      name: 'My Story', storyType: 'Success', primaryActorName: 'Admin', text: 'Story content'
+    });
     await comp.onSave();
+
     expect(commandServiceMock.execute).toHaveBeenCalledWith('EditStory', expect.objectContaining({
       projectName: 'proj1',
       name: 'My Story',
       text: 'Story content',
-      storyTypeName: 'Success'
+      storyTypeName: 'Success',
+      primaryActorName: 'Admin'
     }));
+  });
+
+  it('sends a cleared primary actor as null', async () => {
+    await renderExisting();
+    comp.detailsForm.patchValue({ primaryActorName: '' });
+    comp.detailsForm.markAsDirty();
+    await comp.onSave();
+
+    expect(editStoryCall(0)).toEqual(expect.objectContaining({ primaryActorName: null }));
+  });
+
+  describe('the edit-mode Save policy', () => {
+    it('replaces the old trackChanges()/hasChanges() pair with the form dirty state', async () => {
+      await renderExisting();
+      expect(comp.hasUnsavedChanges()).toBe(false);
+      expect(comp.canSave()).toBe(false);
+
+      comp.detailsForm.controls.name.setValue('Modified Name');
+      comp.detailsForm.controls.name.markAsDirty();
+
+      expect(comp.hasUnsavedChanges()).toBe(true);
+      expect(comp.canSave()).toBe(true);
+    });
+
+    it('is disabled again after a successful save', async () => {
+      await renderExisting();
+      comp.detailsForm.patchValue({ name: 'Renamed' });
+      comp.detailsForm.markAsDirty();
+      await comp.onSave();
+
+      expect(comp.canSave()).toBe(false);
+      expect(comp.hasUnsavedChanges()).toBe(false);
+    });
+
+    it('is disabled while the name is blank', async () => {
+      await renderExisting();
+      comp.detailsForm.patchValue({ name: '' });
+      comp.detailsForm.markAsDirty();
+      expect(comp.canSave()).toBe(false);
+    });
+
+    it('refuses an invalid form without calling the command', async () => {
+      await renderExisting();
+      commandServiceMock.execute.mockClear();
+      comp.detailsForm.patchValue({ name: '' });
+      await comp.onSave();
+
+      expect(commandServiceMock.execute).not.toHaveBeenCalled();
+      expect(comp.detailsForm.controls.name.touched).toBe(true);
+    });
+  });
+
+  describe('the create wizard', () => {
+    it('renders the wizard on the create route and not on the edit route', async () => {
+      await renderNew();
+      expect(fixture.nativeElement.querySelector('app-form-wizard')).not.toBeNull();
+
+      await renderExisting();
+      expect(fixture.nativeElement.querySelector('app-form-wizard')).toBeNull();
+      expect(fixture.nativeElement.querySelector('[data-testid="story-save"]')).not.toBeNull();
+    });
+
+    it('offers Details, Goals and Additional Actors as the three steps', async () => {
+      await renderNew();
+      const keys = Array.from(
+        (fixture.nativeElement as HTMLElement).querySelectorAll('[data-testid^="wizard-step-"]')
+      ).map(n => n.getAttribute('data-testid'));
+
+      expect(keys).toEqual(['wizard-step-details', 'wizard-step-goals', 'wizard-step-actors']);
+    });
+
+    it('starts on details with the default story type and no id', async () => {
+      await renderNew();
+      expect(comp.wizardStep).toBe('details');
+      expect(comp.detailsForm.controls.storyType.value).toBe('Success');
+      expect(comp.storyId).toBeNull();
+    });
+
+    it('creates the story on the details commit, without a storyId or version', async () => {
+      await renderNew();
+      comp.detailsForm.setValue({
+        name: 'User logs out', storyType: 'Success', primaryActorName: 'Customer', text: 'Bye.'
+      });
+
+      const request = commitRequest('details');
+      await comp.onStepCommit(request);
+
+      expect(editStoryCall(0)).toEqual({
+        projectName: 'proj1',
+        name: 'User logs out',
+        text: 'Bye.',
+        storyTypeName: 'Success',
+        primaryActorName: 'Customer'
+      });
+      expect(request.completed()).toBe(true);
+      expect(comp.storyId).toBe(20);
+    });
+
+    it('hydrates goals and actors after create so the later steps have data', async () => {
+      await renderNew();
+      comp.detailsForm.patchValue({ name: 'User logs out' });
+      await comp.onStepCommit(commitRequest('details'));
+
+      expect(storyServiceMock.getStory).toHaveBeenCalledWith('proj1', 20);
+      expect(comp.story()?.id).toBe(20);
+    });
+
+    it('advances the optional steps without calling the API', async () => {
+      await renderNew();
+      commandServiceMock.execute.mockClear();
+
+      const goals = commitRequest('goals');
+      await comp.onStepCommit(goals);
+      const actors = commitRequest('actors');
+      await comp.onStepCommit(actors);
+
+      expect(goals.completed()).toBe(true);
+      expect(actors.completed()).toBe(true);
+      expect(commandServiceMock.execute).not.toHaveBeenCalled();
+    });
+
+    it('reports a failed create on the step instead of advancing', async () => {
+      commandServiceMock.execute.mockResolvedValue({ success: false, error: 'Name conflict' });
+      await renderNew();
+      comp.detailsForm.patchValue({ name: 'Duplicate' });
+
+      const request = commitRequest('details');
+      await comp.onStepCommit(request);
+
+      expect(request.completed()).toBe(false);
+      expect(request.failure()).toBe('Name conflict');
+      expect(comp.storyId).toBeNull();
+    });
+
+    it('navigates to the saved story when the wizard finishes', async () => {
+      await renderNew();
+      comp.detailsForm.patchValue({ name: 'User logs out' });
+      await comp.onStepCommit(commitRequest('details'));
+
+      comp.onWizardFinished();
+      expect(router.navigate).toHaveBeenCalledWith(['/projects', 'proj1', 'stories', 20]);
+    });
+  });
+
+  describe('the version contract', () => {
+    it('adopts the version from the response and sends it on the next save', async () => {
+      await renderExisting();
+      commandServiceMock.execute.mockResolvedValue({
+        success: true,
+        entity: { ...MOCK_STORY, version: 11 }
+      });
+
+      comp.detailsForm.patchValue({ name: 'First rename' });
+      comp.detailsForm.markAsDirty();
+      await comp.onSave();
+      comp.detailsForm.patchValue({ name: 'Second rename' });
+      comp.detailsForm.markAsDirty();
+      await comp.onSave();
+
+      expect(editStoryCall(0)).toEqual(expect.objectContaining({ storyId: 20, version: 4 }));
+      expect(editStoryCall(1)).toEqual(expect.objectContaining({ storyId: 20, version: 11 }));
+    });
+
+    it('sends the refreshed version when the user steps back to Details and re-commits', async () => {
+      await renderNew();
+      comp.detailsForm.patchValue({ name: 'User logs out' });
+      await comp.onStepCommit(commitRequest('details'));
+
+      comp.detailsForm.patchValue({ name: 'User signs out' });
+      const second = commitRequest('details');
+      await comp.onStepCommit(second);
+
+      expect(editStoryCall(0)['version']).toBeUndefined();
+      expect(editStoryCall(1)).toEqual(expect.objectContaining({ storyId: 20, version: 4 }));
+      expect(second.completed()).toBe(true);
+    });
+
+    it('recovers from a stale-version 409 by refetching and keeping the step', async () => {
+      await renderExisting();
+      storyServiceMock.getStory.mockClear();
+      commandServiceMock.execute.mockResolvedValue({
+        success: false,
+        status: 409,
+        error: 'Story has been changed by another user.'
+      });
+
+      comp.detailsForm.patchValue({ name: 'Renamed' });
+      const request = commitRequest('details');
+      await comp.onStepCommit(request);
+
+      expect(storyServiceMock.getStory).toHaveBeenCalledWith('proj1', 20);
+      expect(request.completed()).toBe(false);
+      expect(request.failure()).toContain('changed elsewhere');
+    });
+
+    it('treats a non-409 failure as an ordinary error, with no refetch', async () => {
+      await renderExisting();
+      storyServiceMock.getStory.mockClear();
+      commandServiceMock.execute.mockResolvedValue({
+        success: false,
+        status: 400,
+        error: 'Name is required.'
+      });
+
+      comp.detailsForm.patchValue({ name: 'Renamed' });
+      comp.detailsForm.markAsDirty();
+      await comp.onSave();
+
+      expect(storyServiceMock.getStory).not.toHaveBeenCalled();
+      expect(comp.errorMessage()).toBe('Name is required.');
+    });
+
+    it('keeps unsaved edits on an SSE reload but still takes the new version', async () => {
+      // The previous implementation had no fromSSE guard at all here and overwrote
+      // whatever the user was typing.
+      await renderExisting();
+      comp.detailsForm.controls.name.setValue('Local edit');
+      comp.detailsForm.controls.name.markAsDirty();
+
+      storyServiceMock.getStory.mockResolvedValue({ ...MOCK_STORY, name: 'Remote edit', version: 15 });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (comp as any).loadStory(true);
+
+      expect(comp.detailsForm.controls.name.value).toBe('Local edit');
+
+      commandServiceMock.execute.mockResolvedValue({ success: true, entity: MOCK_STORY });
+      await comp.onSave();
+      expect(editStoryCall(0)).toEqual(expect.objectContaining({ version: 15 }));
+    });
+  });
+
+  it('onDelete triggers confirm then calls execute("DeleteStory")', async () => {
+    await renderExisting();
+
+    const cs = fixture.debugElement.injector.get(ConfirmationService);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.spyOn(cs, 'confirm').mockImplementation((conf: any) => conf.accept?.());
+
+    comp.onDelete();
+    await flush();
+
+    expect(commandServiceMock.execute).toHaveBeenCalledWith('DeleteStory', expect.objectContaining({
+      projectName: 'proj1',
+      storyId: 20
+    }));
+    expect(router.navigate).toHaveBeenCalledWith(['/projects', 'proj1', 'stories']);
   });
 });

--- a/requel-angular/src/app/features/stories/story-editor.ts
+++ b/requel-angular/src/app/features/stories/story-editor.ts
@@ -19,12 +19,13 @@
  *
  */
 import { Component, OnDestroy, OnInit, signal } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
 import { PageHeaderComponent } from '../../shared/page-header';
 import { AppCardComponent } from '../../shared/app-card';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
-import { FormsModule } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
 import { InputText } from 'primeng/inputtext';
 import { TextareaModule } from 'primeng/textarea';
@@ -33,6 +34,7 @@ import { TableModule } from 'primeng/table';
 import { MessageModule } from 'primeng/message';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { ConfirmationService, MessageService } from 'primeng/api';
+import { CommandResult } from '../../models/command';
 import { StoryDto } from '../../models/story';
 import { EntityReferenceDto } from '../../models/entity-reference';
 import { StoryService } from '../../core/story.service';
@@ -43,13 +45,25 @@ import { PermissionService } from '../../core/permission.service';
 import { EventStreamService } from '../../core/event-stream.service';
 import { EntitySelectorDialogComponent } from '../../shared/entity-selector-dialog';
 import { AnnotationsSectionComponent } from '../../shared/annotations-section';
+import { AppFieldComponent, AppFieldControlDirective } from '../../shared/app-field';
+import {
+  AppFormWizardComponent,
+  AppWizardStepComponent,
+  WizardCommitRequest,
+} from '../../shared/app-form-wizard';
+
+/** Wording for the stale-version recovery path, so the 409 case reads as recoverable. */
+const STALE_VERSION_MESSAGE =
+  'This story was changed elsewhere. Your copy has been refreshed — review the values and continue.';
 
 @Component({
   selector: 'app-story-editor',
   standalone: true,
-  imports: [PageHeaderComponent, AppCardComponent, RouterLink, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
+  imports: [PageHeaderComponent, AppCardComponent, RouterLink, ReactiveFormsModule, NgTemplateOutlet,
+            ButtonModule, InputText, TextareaModule, SelectModule,
             TableModule, MessageModule, ConfirmDialogModule, EntitySelectorDialogComponent,
-            AnnotationsSectionComponent],
+            AnnotationsSectionComponent, AppFieldComponent, AppFieldControlDirective,
+            AppFormWizardComponent, AppWizardStepComponent],
   providers: [ConfirmationService],
   template: `
     <div class="story-editor" data-testid="story-editor">
@@ -78,57 +92,156 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
         <p-message severity="error" [text]="errorMessage()!" />
       }
 
-      <app-card>
-        <div class="form-grid">
-          <label for="name">Name</label>
-          <input id="name" pInputText [(ngModel)]="name" placeholder="Story name"
-                 (ngModelChange)="trackChanges()" />
+      @if (isNew()) {
+        <!--
+          Create runs as a wizard so Goals and Additional Actors are reachable before
+          the first save. Step 1 commits EditStory on Continue, which is what gives the
+          later steps the persisted storyId their association commands need.
+        -->
+        <app-form-wizard
+          [(activeKey)]="wizardStep"
+          navLabel="New story steps"
+          (stepCommit)="onStepCommit($event)"
+          (cancelled)="onBack()"
+          (finished)="onWizardFinished()"
+          data-testid="story-wizard"
+        >
+          <app-wizard-step key="details" label="Details" helper="Name, type and text"
+                           [form]="detailsForm">
+            <ng-template>
+              <ng-container [ngTemplateOutlet]="detailsFields" />
+            </ng-template>
+          </app-wizard-step>
 
-          <label for="type">Type</label>
-          <p-select id="type" inputId="storyTypeInput" data-testid="story-type"
-                    [(ngModel)]="storyType" [options]="storyTypeOptions"
-                    optionLabel="label" optionValue="value"
-                    (ngModelChange)="trackChanges()" />
+          <app-wizard-step key="goals" label="Goals" helper="Goals this story serves"
+                           [optional]="true">
+            <ng-template>
+              <ng-container [ngTemplateOutlet]="goalsSection"
+                            [ngTemplateOutletContext]="{ heading: false }" />
+            </ng-template>
+          </app-wizard-step>
 
-          <label for="primaryActor">Primary Actor</label>
-          <p-select id="primaryActor" inputId="storyPrimaryActorInput"
+          <app-wizard-step key="actors" label="Additional Actors"
+                           helper="Actors beyond the primary" [optional]="true">
+            <ng-template>
+              <ng-container [ngTemplateOutlet]="actorsSection"
+                            [ngTemplateOutletContext]="{ heading: false }" />
+            </ng-template>
+          </app-wizard-step>
+        </app-form-wizard>
+      } @else {
+        <app-card>
+          <ng-container [ngTemplateOutlet]="detailsFields" />
+
+          <div class="form-actions">
+            <p-button label="Save" icon="pi pi-check" data-testid="story-save"
+                      [disabled]="!canSave()" [loading]="saving()" (onClick)="onSave()" />
+          </div>
+        </app-card>
+
+        <ng-container [ngTemplateOutlet]="goalsSection"
+                      [ngTemplateOutletContext]="{ heading: true }" />
+        <ng-container [ngTemplateOutlet]="actorsSection"
+                      [ngTemplateOutletContext]="{ heading: true }" />
+      }
+
+      <app-entity-selector-dialog
+        [visible]="showGoalSelector"
+        [projectName]="projectName"
+        entityType="Goal"
+        [excludeIds]="existingGoalIds()"
+        (selected)="onGoalSelected($event)"
+        (closed)="showGoalSelector = false" />
+
+      <app-entity-selector-dialog
+        [visible]="showActorSelector"
+        [projectName]="projectName"
+        entityType="Actor"
+        [excludeIds]="existingActorIds()"
+        (selected)="onActorSelected($event)"
+        (closed)="showActorSelector = false" />
+
+      <!--
+        Annotations render against a persisted entity, so they stay outside the wizard
+        and appear once the story exists rather than as a dead panel during create.
+      -->
+      @if (storyId != null) {
+        <app-annotations-section
+          [projectName]="projectName"
+          entityType="Story"
+          [entityId]="storyId"
+          [canEdit]="canEdit()" />
+      }
+
+      <p-confirmDialog />
+
+      <!--
+        Shared bodies, used by both the wizard step and the edit view so the two modes
+        cannot drift apart. Controls bind with [formControl], not formControlName: these
+        templates are projected into the wizard, where formControlName would look for a
+        parent formGroup that is not there.
+
+        The two p-selects pass controlId matching their own inputId, so app-field's
+        <label for> targets the input PrimeNG renders inside its wrapper rather than
+        depending on DOM-probe timing.
+      -->
+      <ng-template #detailsFields>
+        <app-field label="Name" helper="What the story is called."
+                   [control]="detailsForm.controls.name"
+                   [errorMessages]="nameErrors"
+                   [submitted]="submitted()">
+          <input appFieldControl pInputText [formControl]="detailsForm.controls.name"
+                 placeholder="Story name" data-testid="story-name" />
+        </app-field>
+
+        <app-field label="Type" controlId="storyTypeInput"
+                   [control]="detailsForm.controls.storyType"
+                   [submitted]="submitted()">
+          <p-select appFieldControl inputId="storyTypeInput" data-testid="story-type"
+                    [formControl]="detailsForm.controls.storyType"
+                    [options]="storyTypeOptions"
+                    optionLabel="label" optionValue="value" />
+        </app-field>
+
+        <app-field label="Primary Actor" controlId="storyPrimaryActorInput"
+                   helper="The actor this story is told from."
+                   [control]="detailsForm.controls.primaryActorName"
+                   [submitted]="submitted()">
+          <p-select appFieldControl inputId="storyPrimaryActorInput"
                     data-testid="story-primary-actor"
-                    [(ngModel)]="primaryActorName"
+                    [formControl]="detailsForm.controls.primaryActorName"
                     [options]="actorOptions()"
                     optionLabel="label"
                     optionValue="value"
                     [showClear]="true"
                     [pt]="{ clearIcon: { 'data-testid': 'story-primary-actor-clear' } }"
                     placeholder="Select primary actor"
-                    (ngModelChange)="trackChanges()"
                     styleClass="w-full" />
+        </app-field>
 
-          <label for="text">Text</label>
-          <textarea id="text" pTextarea [(ngModel)]="text" rows="8"
-                    placeholder="Story text"
-                    (ngModelChange)="trackChanges()"></textarea>
-        </div>
+        <app-field label="Text" [control]="detailsForm.controls.text" [divider]="false"
+                   [submitted]="submitted()">
+          <textarea appFieldControl pTextarea [formControl]="detailsForm.controls.text" rows="8"
+                    placeholder="Story text" data-testid="story-text"></textarea>
+        </app-field>
+      </ng-template>
 
-        <div class="form-actions">
-          <p-button label="Save" icon="pi pi-check" data-testid="story-save"
-                    (onClick)="onSave()" [loading]="saving()"
-                    [disabled]="!isNew() && !hasChanges()" />
-        </div>
-      </app-card>
-
-      <!-- Goals sub-table -->
-      @if (!isNew() && story()) {
+      <ng-template #goalsSection let-heading="heading">
         <div class="section">
           <div class="section-header">
-            <h3>Goals</h3>
-            @if (canEdit()) {
+            @if (heading) {
+              <h2 class="rq-section-title">Goals</h2>
+            }
+            @if (canEdit() && storyId != null) {
               <p-button label="Add Goal" icon="pi pi-plus" size="small"
                         data-testid="story-add-goal"
                         (onClick)="showGoalSelector = true" />
             }
           </div>
 
-          @if (story()!.goals?.length) {
+          @if (storyId == null) {
+            <p class="empty-text">Save the story's details first to add goals.</p>
+          } @else if (story()?.goals?.length) {
             <p-table [value]="story()!.goals!" [rows]="10" data-testid="story-goals-table">
               <ng-template #header>
                 <tr>
@@ -151,18 +264,24 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
             <p class="empty-text">No goals associated.</p>
           }
         </div>
+      </ng-template>
 
-        <!-- Additional Actors sub-table -->
+      <ng-template #actorsSection let-heading="heading">
         <div class="section">
           <div class="section-header">
-            <h3>Additional Actors</h3>
-            @if (canEdit()) {
+            @if (heading) {
+              <h2 class="rq-section-title">Additional Actors</h2>
+            }
+            @if (canEdit() && storyId != null) {
               <p-button label="Add Actor" icon="pi pi-plus" size="small"
                         data-testid="story-add-actor"
                         (onClick)="showActorSelector = true" />
             }
           </div>
-          @if (story()!.actors?.length) {
+
+          @if (storyId == null) {
+            <p class="empty-text">Save the story's details first to add actors.</p>
+          } @else if (story()?.actors?.length) {
             <p-table [value]="story()!.actors!" [rows]="10" data-testid="story-additional-actors-table">
               <ng-template #header>
                 <tr>
@@ -185,41 +304,16 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
             <p class="empty-text">No actors associated.</p>
           }
         </div>
-      }
-
-      <app-entity-selector-dialog
-        [visible]="showGoalSelector"
-        [projectName]="projectName"
-        entityType="Goal"
-        [excludeIds]="existingGoalIds()"
-        (selected)="onGoalSelected($event)"
-        (closed)="showGoalSelector = false" />
-
-      <app-entity-selector-dialog
-        [visible]="showActorSelector"
-        [projectName]="projectName"
-        entityType="Actor"
-        [excludeIds]="existingActorIds()"
-        (selected)="onActorSelected($event)"
-        (closed)="showActorSelector = false" />
-
-      <app-annotations-section
-        [projectName]="projectName"
-        entityType="Story"
-        [entityId]="storyId"
-        [canEdit]="canEdit()" />
-
-      <p-confirmDialog />
+      </ng-template>
     </div>
   `,
   styles: [`
     .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
     .page-actions { display: flex; gap: 0.5rem; }
-    .form-grid { display: grid; grid-template-columns: 120px 1fr; gap: 0.75rem 1rem; align-items: start; max-width: 700px; }
     .form-actions { margin-top: 1rem; }
     .section { margin-top: 1.5rem; }
-    .section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
-    .section-header h3 { margin: 0; }
+    .section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; gap: 0.5rem; }
+    .section-header h2 { margin: 0; }
     .empty-text { color: var(--p-text-secondary-color); font-style: italic; }
     .entity-link { cursor: pointer; color: var(--p-primary-color); text-decoration: underline; }
   `]
@@ -232,16 +326,30 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
   saving = signal(false);
   canEdit = signal(false);
   canDelete = signal(false);
+  /** True once a save/commit has been attempted, so untouched invalid fields explain themselves. */
+  submitted = signal(false);
 
   actorOptions = signal<{label: string, value: string}[]>([]);
 
-  name = '';
-  text = '';
-  storyType = 'Success';
-  primaryActorName = '';
+  /**
+   * Details step / edit form. Replaces the previous `name` / `text` / `storyType` /
+   * `primaryActorName` ngModel fields and the hand-rolled `trackChanges()` +
+   * `original*` comparison, which the form's own dirty state now covers.
+   */
+  readonly detailsForm = new FormGroup({
+    name: new FormControl('', { validators: [Validators.required], nonNullable: true }),
+    storyType: new FormControl('Success', { validators: [Validators.required], nonNullable: true }),
+    primaryActorName: new FormControl('', { nonNullable: true }),
+    text: new FormControl('', { nonNullable: true }),
+  });
+
+  readonly nameErrors = { required: 'A story needs a name.' };
+
+  /** Active wizard step key, two-way bound to `app-form-wizard`. */
+  wizardStep = 'details';
+
   showGoalSelector = false;
   showActorSelector = false;
-  hasChanges = signal(false);
   storyTypeOptions = [
     { label: 'Success', value: 'Success' },
     { label: 'Exception', value: 'Exception' }
@@ -250,10 +358,6 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
   projectName = '';
   storyId: number | null = null;
   private version: number | null = null;
-  private originalName = '';
-  private originalText = '';
-  private originalStoryType = 'Success';
-  private originalPrimaryActorName = '';
   private paramSub?: Subscription;
   private sseSub?: Subscription;
 
@@ -284,10 +388,11 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
       if (newIsNew) {
         this.isNew.set(true);
         this.story.set(null);
-        this.name = '';
-        this.text = '';
-        this.storyType = 'Success';
+        this.storyId = null;
         this.version = null;
+        this.wizardStep = 'details';
+        this.submitted.set(false);
+        this.detailsForm.reset({ name: '', storyType: 'Success', primaryActorName: '', text: '' });
       }
 
       await this.permissionService.loadForProject(this.projectName);
@@ -306,7 +411,12 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
   }
 
   hasUnsavedChanges(): boolean {
-    return this.hasChanges();
+    return this.detailsForm.dirty;
+  }
+
+  /** Edit-mode Save: blocked on invalid, unchanged, or in-flight. */
+  canSave(): boolean {
+    return this.detailsForm.valid && this.detailsForm.dirty && !this.saving();
   }
 
   ngOnDestroy(): void {
@@ -317,21 +427,26 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
     this.sseSub?.unsubscribe();
   }
 
-  private async loadStory(): Promise<void> {
+  private async loadStory(fromSSE = false): Promise<void> {
     try {
       const s = await this.storyService.getStory(this.projectName, this.storyId!);
+      if (fromSSE && this.hasUnsavedChanges()) {
+        // Don't overwrite unsaved user edits, but still take the new version: the
+        // entity moved on, and holding the stale one guarantees a 409 on the next
+        // save. (The previous implementation had no such guard and clobbered edits.)
+        this.version = s.version;
+        this.story.set(s);
+        return;
+      }
       this.story.set(s);
       this.storyName.set(s.name);
-      this.name = s.name;
-      this.text = s.text;
-      this.storyType = s.storyType;
-      this.primaryActorName = s.primaryActorName ?? '';
+      this.detailsForm.reset({
+        name: s.name,
+        storyType: s.storyType,
+        primaryActorName: s.primaryActorName ?? '',
+        text: s.text,
+      });
       this.version = s.version;
-      this.originalName = s.name;
-      this.originalText = s.text;
-      this.originalStoryType = s.storyType;
-      this.originalPrimaryActorName = s.primaryActorName ?? '';
-      this.hasChanges.set(false);
     } catch {
       this.errorMessage.set('Failed to load story.');
     }
@@ -339,19 +454,10 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
       void this.eventStreamService.addSubscription('Story', this.storyId);
       this.sseSub = this.eventStreamService.events$.subscribe(envelope => {
         if (envelope.targetType === 'Story' && envelope.targetId === this.storyId) {
-          void this.loadStory();
+          void this.loadStory(true);
         }
       });
     }
-  }
-
-  trackChanges(): void {
-    this.hasChanges.set(
-      this.name !== this.originalName ||
-      this.text !== this.originalText ||
-      this.storyType !== this.originalStoryType ||
-      this.primaryActorName !== this.originalPrimaryActorName
-    );
   }
 
   existingGoalIds(): number[] {
@@ -366,45 +472,134 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
       .map(a => a.id!);
   }
 
-  async onSave(): Promise<void> {
+  /**
+   * Runs the commit for the wizard's current step.
+   *
+   * Only Details talks to the API — Goals and Additional Actors commit through their
+   * own association commands as the user works, so their Continue just advances.
+   */
+  async onStepCommit(request: WizardCommitRequest): Promise<void> {
+    if (request.step.key !== 'details') {
+      request.complete();
+      return;
+    }
+
+    this.submitted.set(true);
+    const result = await this.saveDetails();
+
+    if (result.success) {
+      request.complete();
+      return;
+    }
+
+    if (await this.recoverFromStaleVersion(result)) {
+      request.fail(STALE_VERSION_MESSAGE);
+      return;
+    }
+    request.fail(result.error ?? 'Save failed.');
+  }
+
+  /** Done on the last step: the story is already saved, so just go to it. */
+  onWizardFinished(): void {
+    if (this.storyId != null) {
+      this.router.navigate(['/projects', this.projectName, 'stories', this.storyId]);
+    } else {
+      this.onBack();
+    }
+  }
+
+  /**
+   * Issues `EditStory` for the Details values and, on success, adopts the id and
+   * version from the response.
+   *
+   * The version is **spent on use**: every accepted `EditStory` bumps it server-side,
+   * so it is re-read from `result.entity` each time. Holding the value captured at
+   * create and sending it again — which is what happens if the user steps back to
+   * Details and presses Continue a second time — is a guaranteed 409.
+   */
+  private async saveDetails(): Promise<CommandResult<unknown>> {
     this.saving.set(true);
     this.errorMessage.set(null);
     try {
+      const { name, storyType, primaryActorName, text } = this.detailsForm.getRawValue();
       const input: Record<string, unknown> = {
         projectName: this.projectName,
-        name: this.name,
-        text: this.text,
-        storyTypeName: this.storyType,
-        primaryActorName: this.primaryActorName || null,
+        name,
+        text,
+        storyTypeName: storyType,
+        primaryActorName: primaryActorName || null,
       };
       if (this.storyId != null) input['storyId'] = this.storyId;
       if (this.version != null) input['version'] = this.version;
+
       const result = await this.commandService.execute('EditStory', input);
-      if (result.success) {
-        this.messageService.add({ severity: 'success', summary: 'Saved', detail: 'Story saved.' });
-        if (this.isNew()) {
-          this.projectService.notifyTreeChanged();
-          if (result.entity) {
-            const saved = result.entity as StoryDto;
-            this.hasChanges.set(false);
-            this.router.navigate(['/projects', this.projectName, 'stories', saved.id]);
-          }
-        } else {
-          this.originalName = this.name;
-          this.originalText = this.text;
-          this.originalStoryType = this.storyType;
-          this.originalPrimaryActorName = this.primaryActorName;
-          this.hasChanges.set(false);
-          await this.loadStory();
-        }
-      } else {
-        this.errorMessage.set(result.error ?? 'Save failed.');
+      if (!result.success) {
+        return result;
       }
+
+      const wasCreate = this.storyId == null;
+      if (wasCreate) {
+        this.projectService.notifyTreeChanged();
+      }
+
+      const saved = result.entity as StoryDto | null;
+      if (saved) {
+        this.storyId = saved.id;
+        this.version = saved.version;
+        this.storyName.set(saved.name);
+      }
+      this.detailsForm.markAsPristine();
+      this.messageService.add({ severity: 'success', summary: 'Saved', detail: 'Story saved.' });
+
+      // Hydrate goals / actors (and start the SSE subscription) the first time the
+      // story exists, so the later steps have something to render.
+      if (wasCreate && this.storyId != null) {
+        await this.loadStory();
+      }
+      return result;
     } catch {
-      this.errorMessage.set('An unexpected error occurred.');
+      return {
+        success: false,
+        entityType: 'Story',
+        entity: null,
+        error: 'An unexpected error occurred.',
+        violations: null,
+      };
     } finally {
       this.saving.set(false);
     }
+  }
+
+  /**
+   * If `result` is an optimistic-lock conflict (HTTP 409 from
+   * `EntityLockException.staleEntity`), refetch so the held version is current and
+   * the user can retry. Returns whether it handled the result.
+   */
+  private async recoverFromStaleVersion(result: CommandResult<unknown>): Promise<boolean> {
+    if (result.status !== 409 || this.storyId == null) {
+      return false;
+    }
+    await this.loadStory();
+    return true;
+  }
+
+  /** Edit-mode Save. */
+  async onSave(): Promise<void> {
+    this.submitted.set(true);
+    if (this.detailsForm.invalid) {
+      this.detailsForm.markAllAsTouched();
+      return;
+    }
+
+    const result = await this.saveDetails();
+    if (result.success) {
+      return;
+    }
+    if (await this.recoverFromStaleVersion(result)) {
+      this.errorMessage.set(STALE_VERSION_MESSAGE);
+      return;
+    }
+    this.errorMessage.set(result.error ?? 'Save failed.');
   }
 
   onCopy(): void {
@@ -437,6 +632,8 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
         });
         if (result.success) {
           this.projectService.notifyTreeChanged();
+          // Nothing left to guard against — don't let the dirty check block the exit.
+          this.detailsForm.markAsPristine();
           this.router.navigate(['/projects', this.projectName, 'stories']);
         } else {
           this.errorMessage.set(result.error ?? 'Delete failed.');

--- a/requel-angular/src/app/models/command.ts
+++ b/requel-angular/src/app/models/command.ts
@@ -24,6 +24,15 @@ export interface CommandResult<T = unknown> {
   entity: T | null;
   error: string | null;
   violations: FieldViolation[] | null;
+  /**
+   * HTTP status, set by `CommandService` only when the command failed with an error
+   * response. Present so callers can tell an optimistic-lock conflict (**409**, from
+   * `EntityLockException.staleEntity` — see issue #108) apart from an ordinary
+   * validation or server failure, and recover by refetching instead of showing a
+   * generic "save failed". Absent on success, and on a network error where there is
+   * no status to report.
+   */
+  status?: number;
 }
 
 export interface FieldViolation {

--- a/requel-angular/src/app/shared/app-field.a11y.spec.ts
+++ b/requel-angular/src/app/shared/app-field.a11y.spec.ts
@@ -1,0 +1,67 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { AppFieldComponent, AppFieldControlDirective } from './app-field';
+import { expectNoAxeViolations } from './testing/a11y';
+
+@Component({
+  standalone: true,
+  imports: [AppFieldComponent, AppFieldControlDirective, ReactiveFormsModule],
+  template: `
+    <form [formGroup]="form">
+      <app-field
+        label="Name"
+        helper="Short, outcome-focused."
+        [control]="form.controls.name"
+        [submitted]="submitted"
+      >
+        <input appFieldControl formControlName="name" />
+      </app-field>
+
+      <app-field
+        label="Description"
+        [control]="form.controls.text"
+        [divider]="false"
+        [submitted]="submitted"
+      >
+        <textarea appFieldControl formControlName="text" rows="4"></textarea>
+      </app-field>
+    </form>`,
+})
+class FormHostComponent {
+  submitted = false;
+  form = new FormGroup({
+    name: new FormControl('', { validators: Validators.required, nonNullable: true }),
+    text: new FormControl('', { nonNullable: true }),
+  });
+}
+
+describe('AppFieldComponent accessibility (issue #158)', () => {
+  function render(configure?: (host: FormHostComponent) => void): HTMLElement {
+    TestBed.configureTestingModule({ imports: [FormHostComponent] });
+    const fixture = TestBed.createComponent(FormHostComponent);
+    configure?.(fixture.componentInstance);
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  it('has no axe-core violations in the pristine state', async () => {
+    await expectNoAxeViolations(render());
+  });
+
+  it('has no axe-core violations while showing a validation error', async () => {
+    const el = render(host => {
+      host.submitted = true;
+      host.form.controls.name.markAsTouched();
+    });
+    await expectNoAxeViolations(el);
+  });
+
+  it('has no axe-core violations once the form is valid', async () => {
+    const el = render(host => {
+      host.form.setValue({ name: 'Reduce onboarding time', text: 'Cut setup to one day.' });
+      host.form.markAllAsTouched();
+    });
+    await expectNoAxeViolations(el);
+  });
+});

--- a/requel-angular/src/app/shared/app-field.spec.ts
+++ b/requel-angular/src/app/shared/app-field.spec.ts
@@ -1,0 +1,227 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { AppFieldComponent, AppFieldControlDirective } from './app-field';
+
+@Component({
+  standalone: true,
+  imports: [AppFieldComponent, AppFieldControlDirective, ReactiveFormsModule],
+  template: `
+    <app-field
+      [label]="label"
+      [helper]="helper"
+      [control]="control"
+      [divider]="divider"
+      [errorMessages]="errorMessages"
+      [submitted]="submitted"
+    >
+      <input appFieldControl [formControl]="control" data-testid="control" />
+    </app-field>`,
+})
+class NativeHostComponent {
+  label = 'Name';
+  helper = '';
+  divider = true;
+  submitted = false;
+  errorMessages?: Record<string, string>;
+  control = new FormControl('', { validators: Validators.required, nonNullable: true });
+}
+
+/**
+ * Stands in for a PrimeNG wrapper such as `p-select`: the element carrying
+ * `appFieldControl` is not itself focusable and holds the real control inside.
+ */
+@Component({
+  standalone: true,
+  imports: [AppFieldComponent, AppFieldControlDirective, ReactiveFormsModule],
+  template: `
+    <app-field label="Type" [control]="control">
+      <div appFieldControl data-testid="wrapper">
+        <span>not focusable</span>
+        <input data-testid="inner" [formControl]="control" />
+      </div>
+    </app-field>`,
+})
+class WrapperHostComponent {
+  control = new FormControl('', { nonNullable: true });
+}
+
+@Component({
+  standalone: true,
+  imports: [AppFieldComponent, AppFieldControlDirective, ReactiveFormsModule],
+  template: `
+    <app-field label="Type" controlId="story-type" [control]="control">
+      <div appFieldControl>
+        <input id="story-type" data-testid="inner" [formControl]="control" />
+      </div>
+    </app-field>`,
+})
+class ExplicitIdHostComponent {
+  control = new FormControl('', { nonNullable: true });
+}
+
+describe('AppFieldComponent (issue #158)', () => {
+  beforeEach(() => {
+    // Configured once per test so a single test can create more than one fixture;
+    // re-calling configureTestingModule after instantiation throws.
+    TestBed.configureTestingModule({
+      imports: [NativeHostComponent, WrapperHostComponent, ExplicitIdHostComponent],
+    });
+  });
+
+  /**
+   * Host inputs are set BEFORE the first change-detection pass. Mutating them
+   * afterwards raises NG0100 under the zoneless TestBed, because a plain field
+   * assignment does not mark the host dirty and detectChanges goes straight to its
+   * verification pass. Control state (touched/value) is safe to change mid-test.
+   */
+  function render(
+    configure?: (host: NativeHostComponent) => void
+  ): ComponentFixture<NativeHostComponent> {
+    const fixture = TestBed.createComponent(NativeHostComponent);
+    configure?.(fixture.componentInstance);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  const control = (el: HTMLElement) => el.querySelector<HTMLElement>('[data-testid="control"]');
+  const fieldError = (el: HTMLElement) => el.querySelector('[data-testid="field-error"]');
+
+  it('renders the label as a real <label> bound to the projected control', () => {
+    const el: HTMLElement = render().nativeElement;
+
+    const label = el.querySelector('label.app-field-label');
+    expect(label?.textContent?.trim()).toContain('Name');
+    expect(control(el)?.id).toBeTruthy();
+    expect(label?.getAttribute('for')).toBe(control(el)?.id);
+  });
+
+  it('derives the required marker and aria-required from the control validators', () => {
+    const el: HTMLElement = render().nativeElement;
+
+    expect(el.querySelector('.app-field-required')).not.toBeNull();
+    expect(control(el)?.getAttribute('aria-required')).toBe('true');
+  });
+
+  it('omits the required marker and aria-required for an optional field', () => {
+    const el: HTMLElement = render(host => {
+      host.control = new FormControl('', { nonNullable: true });
+    }).nativeElement;
+
+    expect(el.querySelector('.app-field-required')).toBeNull();
+    expect(control(el)?.hasAttribute('aria-required')).toBe(false);
+  });
+
+  it('shows no error on a pristine untouched control', () => {
+    const el: HTMLElement = render().nativeElement;
+
+    expect(fieldError(el)).toBeNull();
+    expect(control(el)?.getAttribute('aria-invalid')).toBe('false');
+  });
+
+  it('shows the error once the control is touched, and sets aria-invalid', () => {
+    const fixture = render();
+    fixture.componentInstance.control.markAsTouched();
+    fixture.detectChanges();
+    const el: HTMLElement = fixture.nativeElement;
+
+    expect(fieldError(el)?.textContent?.trim()).toBe('This field is required.');
+    expect(control(el)?.getAttribute('aria-invalid')).toBe('true');
+  });
+
+  it('shows the error on an untouched control once a submit has been attempted', () => {
+    const el: HTMLElement = render(host => {
+      host.submitted = true;
+    }).nativeElement;
+
+    expect(fieldError(el)).not.toBeNull();
+  });
+
+  it('honours a per-field error override', () => {
+    const el: HTMLElement = render(host => {
+      host.errorMessages = { required: 'A goal needs a name.' };
+      host.control.markAsTouched();
+    }).nativeElement;
+
+    expect(fieldError(el)?.textContent?.trim()).toBe('A goal needs a name.');
+  });
+
+  it('clears the error and aria-invalid once the control becomes valid', () => {
+    const fixture = render(host => host.control.markAsTouched());
+    fixture.componentInstance.control.setValue('Reduce onboarding time');
+    fixture.detectChanges();
+    const el: HTMLElement = fixture.nativeElement;
+
+    expect(fieldError(el)).toBeNull();
+    expect(control(el)?.getAttribute('aria-invalid')).toBe('false');
+  });
+
+  it('links helper text via aria-describedby', () => {
+    const el: HTMLElement = render(host => {
+      host.helper = 'Short, outcome-focused.';
+    }).nativeElement;
+
+    const helper = el.querySelector('.app-field-helper');
+    expect(helper?.id).toBeTruthy();
+    expect(control(el)?.getAttribute('aria-describedby')).toBe(helper?.id);
+  });
+
+  it('describes the control by both helper and error while invalid', () => {
+    const el: HTMLElement = render(host => {
+      host.helper = 'Short, outcome-focused.';
+      host.control.markAsTouched();
+    }).nativeElement;
+
+    const helperId = el.querySelector('.app-field-helper')?.id;
+    const errorId = fieldError(el)?.id;
+    const describedBy = control(el)?.getAttribute('aria-describedby') ?? '';
+
+    expect(describedBy.split(' ')).toEqual([helperId, errorId]);
+  });
+
+  it('renders the divider by default and omits it on request', () => {
+    const withDivider: HTMLElement = render().nativeElement;
+    const withoutDivider: HTMLElement = render(host => {
+      host.divider = false;
+    }).nativeElement;
+
+    expect(
+      withDivider.querySelector('.app-field')?.classList.contains('app-field-bordered')
+    ).toBe(true);
+    expect(
+      withoutDivider.querySelector('.app-field')?.classList.contains('app-field-bordered')
+    ).toBe(false);
+  });
+
+  it('generates unique ids across rows so two fields never collide', () => {
+    const first: HTMLElement = render().nativeElement;
+    const second: HTMLElement = render().nativeElement;
+
+    expect(control(first)?.id).toBeTruthy();
+    expect(control(first)?.id).not.toBe(control(second)?.id);
+  });
+
+  describe('wrapper controls', () => {
+    it('stamps id and ARIA on the inner focusable, not the non-focusable wrapper', () => {
+      const fixture = TestBed.createComponent(WrapperHostComponent);
+      fixture.detectChanges();
+      const el: HTMLElement = fixture.nativeElement;
+
+      const wrapper = el.querySelector<HTMLElement>('[data-testid="wrapper"]');
+      const inner = el.querySelector<HTMLElement>('[data-testid="inner"]');
+
+      expect(inner?.id).toBeTruthy();
+      expect(wrapper?.hasAttribute('id')).toBe(false);
+      expect(el.querySelector('label')?.getAttribute('for')).toBe(inner?.id);
+    });
+
+    it('leaves a caller-supplied controlId in place instead of generating one', () => {
+      const fixture = TestBed.createComponent(ExplicitIdHostComponent);
+      fixture.detectChanges();
+      const el: HTMLElement = fixture.nativeElement;
+
+      expect(el.querySelector<HTMLElement>('[data-testid="inner"]')?.id).toBe('story-type');
+      expect(el.querySelector('label')?.getAttribute('for')).toBe('story-type');
+    });
+  });
+});

--- a/requel-angular/src/app/shared/app-field.ts
+++ b/requel-angular/src/app/shared/app-field.ts
@@ -1,0 +1,317 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import {
+  AfterContentChecked,
+  AfterContentInit,
+  ContentChild,
+  Component,
+  Directive,
+  ElementRef,
+  Input,
+  OnDestroy,
+  inject,
+} from '@angular/core';
+import { AbstractControl } from '@angular/forms';
+import { FormErrorOverrides, firstErrorMessage, isRequired } from './form-errors';
+
+/** Process-wide counter for generated field ids (`rq-field-1`, `rq-field-2`, ...). */
+let nextFieldId = 0;
+
+/**
+ * Marks the control projected into an {@link AppFieldComponent}.
+ *
+ * `app-field` queries this with `@ContentChild` and stamps `id`, `aria-describedby`,
+ * `aria-invalid` and `aria-required` onto it, so callers never wire ARIA by hand —
+ * which is what makes the label/error-association work (#138) structural rather than
+ * something each of nine editors has to remember.
+ *
+ * Usage: `<input pInputText appFieldControl [formControl]="form.controls.name" />`
+ */
+@Directive({
+  selector: '[appFieldControl]',
+  standalone: true,
+})
+export class AppFieldControlDirective {
+  private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+
+  /** The element the directive is applied to. */
+  get host(): HTMLElement {
+    return this.elementRef.nativeElement;
+  }
+
+  /**
+   * The element that should actually carry `id` / `aria-*`.
+   *
+   * For a native control (`input`, `textarea`, `select`) that is the host itself.
+   * For a PrimeNG wrapper such as `p-select` the host is a custom element that is
+   * not focusable and gets no accessible name from a `<label for>`, so we descend to
+   * the first focusable child instead.
+   *
+   * Wrapper components that render their inner control asynchronously may not have
+   * one yet at content-init time; for those, pass `app-field`'s `controlId` and the
+   * wrapper's own id input (e.g. `p-select`'s `inputId`) so both agree without
+   * depending on DOM timing.
+   */
+  resolveTarget(): HTMLElement {
+    const host = this.host;
+    const tag = host.tagName.toLowerCase();
+    if (tag === 'input' || tag === 'textarea' || tag === 'select') {
+      return host;
+    }
+    return (
+      host.querySelector<HTMLElement>(
+        'input:not([type="hidden"]), textarea, select, [tabindex]:not([tabindex="-1"])'
+      ) ?? host
+    );
+  }
+}
+
+/**
+ * Shared form-row primitive (issue #158).
+ *
+ * One form row: label + helper text on the left, control on the right, hairline
+ * divider below, inline error beneath the control. Replaces the per-editor
+ * `div.form-grid { grid-template-columns: 120px 1fr }` that #126's descope left in
+ * place — nine editors currently redefine that block at varying widths, and none of
+ * them associate their errors with their inputs.
+ *
+ * The row owns label <-> control <-> error association (see
+ * {@link AppFieldControlDirective}), so #138 is satisfied once here rather than per
+ * caller.
+ *
+ * All styling reads from `--rq-*` tokens; the component holds no color, spacing,
+ * radius or type literals.
+ */
+@Component({
+  selector: 'app-field',
+  standalone: true,
+  template: `
+    <div class="app-field" [class.app-field-bordered]="divider">
+      <div class="app-field-label-col">
+        <label class="app-field-label" [attr.for]="labelFor">
+          {{ label }}@if (required) {<span class="app-field-required" aria-hidden="true">*</span>}
+        </label>
+        @if (helper) {
+          <p class="app-field-helper" [id]="helperId">{{ helper }}</p>
+        }
+      </div>
+      <div class="app-field-control-col">
+        <ng-content />
+        @if (showError) {
+          <p class="app-field-error" [id]="errorId" data-testid="field-error">
+            {{ errorMessage }}
+          </p>
+        }
+      </div>
+    </div>
+  `,
+  styles: [`
+    /* container-type establishes the query container the @container rule below targets. */
+    :host { display: block; container-type: inline-size; }
+    .app-field {
+      display: grid;
+      grid-template-columns: var(--rq-field-label-w) 1fr;
+      gap: var(--rq-space-2) var(--rq-space-4);
+      align-items: start;
+      padding-block: var(--rq-space-3);
+    }
+    .app-field-bordered { border-bottom: 1px solid var(--rq-field-divider); }
+    .app-field-label {
+      display: block;
+      font-size: var(--rq-text-label-size);
+      font-weight: var(--rq-text-label-weight);
+      line-height: var(--rq-text-label-line);
+    }
+    .app-field-required {
+      color: var(--rq-field-required-fg);
+      margin-inline-start: var(--rq-space-1);
+    }
+    .app-field-helper {
+      margin: var(--rq-space-1) 0 0;
+      color: var(--rq-text-muted-color);
+      font-size: var(--rq-text-helper-size);
+      font-weight: var(--rq-text-helper-weight);
+      line-height: var(--rq-text-helper-line);
+    }
+    .app-field-error {
+      margin: var(--rq-space-1) 0 0;
+      color: var(--rq-field-error-fg);
+      font-size: var(--rq-text-helper-size);
+      line-height: var(--rq-text-helper-line);
+    }
+
+    /*
+     * Narrow viewports stack label above control. Uses a container query rather
+     * than --rq-editor-max, which is a max-width token (48rem), not a breakpoint.
+     */
+    @container (max-width: 30rem) {
+      .app-field { grid-template-columns: 1fr; }
+    }
+  `],
+})
+export class AppFieldComponent implements AfterContentInit, AfterContentChecked, OnDestroy {
+  /** Row label. Rendered as a real `<label for>` bound to the projected control. */
+  @Input({ required: true }) label!: string;
+
+  /** Optional helper text under the label; linked via `aria-describedby`. */
+  @Input() helper = '';
+
+  /**
+   * The reactive control backing this row. Drives the error message, the required
+   * marker, `aria-invalid` and `aria-required`. Optional so a row can host a
+   * display-only or not-yet-migrated control.
+   */
+  @Input() control?: AbstractControl | null;
+
+  /** Hairline divider below the row. Off for the last row in a group. */
+  @Input() divider = true;
+
+  /** Per-field message overrides, keyed by validation error (e.g. `{ required: '...' }`). */
+  @Input() errorMessages?: FormErrorOverrides;
+
+  /**
+   * Caller-supplied control id. Use this for wrapper components that render their
+   * own inner input (pass the same value to e.g. `p-select`'s `inputId`). When
+   * omitted, an id is generated.
+   */
+  @Input() controlId?: string;
+
+  /**
+   * Set by a submit/step-commit attempt so errors show on untouched controls too.
+   * `app-form-wizard` sets this when Continue is pressed.
+   */
+  @Input() submitted = false;
+
+  @ContentChild(AppFieldControlDirective) private projectedControl?: AppFieldControlDirective;
+
+  /** Stable per-instance id base, used for the helper and error ids. */
+  private readonly uid = `rq-field-${++nextFieldId}`;
+
+  /** The element we stamped attributes onto, kept so we can clean up on destroy. */
+  private target?: HTMLElement;
+
+  get helperId(): string {
+    return `${this.uid}-helper`;
+  }
+
+  get errorId(): string {
+    return `${this.uid}-error`;
+  }
+
+  /** The id the `<label for>` points at — the caller's if given, else generated. */
+  get labelFor(): string {
+    return this.controlId ?? this.uid;
+  }
+
+  get required(): boolean {
+    return isRequired(this.control);
+  }
+
+  /**
+   * Errors appear once the user has engaged with the field (`touched`) or a submit
+   * has been attempted — never on a pristine, untouched form, which would greet the
+   * user with red text on a create form they have not filled in yet.
+   */
+  get showError(): boolean {
+    const control = this.control;
+    return !!control && control.invalid && (control.touched || this.submitted);
+  }
+
+  get errorMessage(): string | null {
+    return this.showError ? firstErrorMessage(this.control, this.errorMessages) : null;
+  }
+
+  ngAfterContentInit(): void {
+    this.wireControl();
+  }
+
+  ngOnDestroy(): void {
+    // The projected control can outlive this row (it belongs to the caller's
+    // template), so leave nothing of ours stamped on it.
+    const target = this.target;
+    if (!target) {
+      return;
+    }
+    target.removeAttribute('aria-describedby');
+    target.removeAttribute('aria-invalid');
+    target.removeAttribute('aria-required');
+  }
+
+  /**
+   * Stamps id + ARIA onto the projected control.
+   *
+   * Runs in `ngAfterContentInit` — before the view is first checked — so setting
+   * `labelFor`-adjacent state here cannot trigger an
+   * `ExpressionChangedAfterItHasBeenCheckedError`.
+   *
+   * `aria-invalid` and `aria-describedby` are refreshed on every change-detection
+   * pass by {@link syncValidationState}, called from the template's `showError`
+   * read path; see `ngAfterContentChecked` below.
+   */
+  private wireControl(): void {
+    const projected = this.projectedControl;
+    if (!projected) {
+      return;
+    }
+    const target = projected.resolveTarget();
+    this.target = target;
+
+    if (!target.getAttribute('id')) {
+      target.setAttribute('id', this.labelFor);
+    }
+    this.syncValidationState();
+  }
+
+  /**
+   * Keeps `aria-describedby` / `aria-invalid` / `aria-required` in step with the
+   * control's validation state. Called from `ngAfterContentChecked` so it tracks
+   * every state change (blur, value edit, submit) without a manual subscription.
+   */
+  ngAfterContentChecked(): void {
+    this.syncValidationState();
+  }
+
+  private syncValidationState(): void {
+    const target = this.target;
+    if (!target) {
+      return;
+    }
+
+    const describedBy = [this.helper ? this.helperId : null, this.showError ? this.errorId : null]
+      .filter(Boolean)
+      .join(' ');
+
+    if (describedBy) {
+      target.setAttribute('aria-describedby', describedBy);
+    } else {
+      target.removeAttribute('aria-describedby');
+    }
+
+    if (this.control) {
+      target.setAttribute('aria-invalid', String(this.showError));
+    }
+    if (this.required) {
+      target.setAttribute('aria-required', 'true');
+    } else {
+      target.removeAttribute('aria-required');
+    }
+  }
+}

--- a/requel-angular/src/app/shared/app-form-wizard.a11y.spec.ts
+++ b/requel-angular/src/app/shared/app-form-wizard.a11y.spec.ts
@@ -1,0 +1,123 @@
+import { Component, viewChild } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { AppFieldComponent, AppFieldControlDirective } from './app-field';
+import {
+  AppFormWizardComponent,
+  AppWizardStepComponent,
+  WizardCommitRequest,
+} from './app-form-wizard';
+import { expectNoAxeViolations } from './testing/a11y';
+
+@Component({
+  standalone: true,
+  imports: [
+    AppFormWizardComponent,
+    AppWizardStepComponent,
+    AppFieldComponent,
+    AppFieldControlDirective,
+    ReactiveFormsModule,
+  ],
+  template: `
+    <app-form-wizard [(activeKey)]="activeKey" (stepCommit)="onCommit($event)">
+      <app-wizard-step key="details" label="Details" [form]="detailsForm">
+        <ng-template>
+          <!--
+            [formControl], not formControlName: the step body is projected into the
+            wizard, and formControlName resolves its parent formGroup from the
+            injector at the INSERTION point, where there is none.
+          -->
+          <app-field label="Name" helper="Short, outcome-focused."
+                     [control]="detailsForm.controls.name" [submitted]="submitted">
+            <input appFieldControl [formControl]="detailsForm.controls.name" />
+          </app-field>
+          <app-field label="Description" [control]="detailsForm.controls.text" [divider]="false">
+            <textarea appFieldControl [formControl]="detailsForm.controls.text" rows="4"></textarea>
+          </app-field>
+        </ng-template>
+      </app-wizard-step>
+
+      <app-wizard-step key="tags" label="Tags" helper="Optional." [optional]="true">
+        <ng-template>
+          <p>Tag selector goes here.</p>
+        </ng-template>
+      </app-wizard-step>
+    </app-form-wizard>`,
+})
+class WizardA11yHostComponent {
+  readonly wizard = viewChild.required(AppFormWizardComponent);
+
+  activeKey = 'details';
+  submitted = false;
+  failWith: string | null = null;
+
+  detailsForm = new FormGroup({
+    name: new FormControl('', { validators: Validators.required, nonNullable: true }),
+    text: new FormControl('', { nonNullable: true }),
+  });
+
+  onCommit(request: WizardCommitRequest): void {
+    if (this.failWith) {
+      request.fail(this.failWith);
+      return;
+    }
+    request.complete();
+  }
+}
+
+describe('AppFormWizardComponent accessibility (issue #158)', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [WizardA11yHostComponent] });
+  });
+
+  function render(configure?: (host: WizardA11yHostComponent) => void): HTMLElement {
+    const fixture = TestBed.createComponent(WizardA11yHostComponent);
+    configure?.(fixture.componentInstance);
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  /** `fixture.nativeElement` is `any`, so narrow it before a generic querySelector. */
+  function clickContinue(el: HTMLElement): void {
+    el.querySelector<HTMLButtonElement>('[data-testid="wizard-continue"] button')?.click();
+  }
+
+  it('has no axe-core violations on the first step', async () => {
+    await expectNoAxeViolations(render());
+  });
+
+  it('has no axe-core violations while a field shows a validation error', async () => {
+    const el = render(host => {
+      host.submitted = true;
+      host.detailsForm.controls.name.markAsTouched();
+    });
+    await expectNoAxeViolations(el);
+  });
+
+  it('has no axe-core violations while the commit-failure alert is showing', async () => {
+    const fixture = TestBed.createComponent(WizardA11yHostComponent);
+    fixture.componentInstance.detailsForm.setValue({ name: 'Reduce setup time', text: '' });
+    fixture.componentInstance.failWith = 'This goal was changed elsewhere.';
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    clickContinue(el);
+    fixture.detectChanges();
+
+    expect(el.querySelector('[data-testid="wizard-error"]')).not.toBeNull();
+    await expectNoAxeViolations(el);
+  });
+
+  it('has no axe-core violations on an optional step', async () => {
+    const fixture = TestBed.createComponent(WizardA11yHostComponent);
+    fixture.componentInstance.detailsForm.setValue({ name: 'Reduce setup time', text: '' });
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    clickContinue(el);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.wizard().activeKey).toBe('tags');
+    await expectNoAxeViolations(el);
+  });
+});

--- a/requel-angular/src/app/shared/app-form-wizard.spec.ts
+++ b/requel-angular/src/app/shared/app-form-wizard.spec.ts
@@ -1,0 +1,480 @@
+import { Component, viewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import {
+  AppFormWizardComponent,
+  AppWizardStepComponent,
+  WizardCommitRequest,
+} from './app-form-wizard';
+
+@Component({
+  standalone: true,
+  imports: [AppFormWizardComponent, AppWizardStepComponent, ReactiveFormsModule],
+  template: `
+    <app-form-wizard
+      [(activeKey)]="activeKey"
+      (stepCommit)="onCommit($event)"
+      (cancelled)="cancelled = true"
+      (finished)="finished = true"
+    >
+      <app-wizard-step key="details" label="Details" [form]="detailsForm">
+        <ng-template>
+          <input data-testid="name" [formControl]="detailsForm.controls.name" />
+        </ng-template>
+      </app-wizard-step>
+
+      <app-wizard-step key="tags" label="Tags" [optional]="true">
+        <ng-template>
+          <p data-testid="tags-body">tag selector</p>
+        </ng-template>
+      </app-wizard-step>
+
+      <app-wizard-step key="relations" label="Relations" [optional]="true">
+        <ng-template>
+          <p data-testid="relations-body">relation picker</p>
+        </ng-template>
+      </app-wizard-step>
+    </app-form-wizard>`,
+})
+class WizardHostComponent {
+  readonly wizard = viewChild.required(AppFormWizardComponent);
+
+  activeKey = 'details';
+  cancelled = false;
+  finished = false;
+
+  /** Commits seen, in order, so tests can assert what the host was asked to save. */
+  commits: string[] = [];
+
+  /** Set to a message to make the next commit fail. */
+  failWith: string | null = null;
+
+  /** Set true to leave the commit unresolved, mimicking an in-flight request. */
+  hang = false;
+
+  detailsForm = new FormGroup({
+    name: new FormControl('', { validators: Validators.required, nonNullable: true }),
+  });
+
+  onCommit(request: WizardCommitRequest): void {
+    this.commits.push(request.step.key);
+    if (this.hang) {
+      return;
+    }
+    if (this.failWith) {
+      request.fail(this.failWith);
+      return;
+    }
+    request.complete();
+  }
+}
+
+describe('AppFormWizardComponent (issue #158)', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [WizardHostComponent] });
+  });
+
+  function render(
+    configure?: (host: WizardHostComponent) => void
+  ): ComponentFixture<WizardHostComponent> {
+    const fixture = TestBed.createComponent(WizardHostComponent);
+    configure?.(fixture.componentInstance);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  const q = (fixture: ComponentFixture<WizardHostComponent>, testid: string) =>
+    (fixture.nativeElement as HTMLElement).querySelector<HTMLElement>(`[data-testid="${testid}"]`);
+
+  /**
+   * `p-button` puts our `data-testid` on its host element and renders the real
+   * `<button>` inside, so descend one level for click and disabled state — the same
+   * pattern as `empty-state.spec.ts` / `error-state.spec.ts`.
+   */
+  const continueButton = (fixture: ComponentFixture<WizardHostComponent>) =>
+    (fixture.nativeElement as HTMLElement).querySelector<HTMLButtonElement>(
+      '[data-testid="wizard-continue"] button'
+    );
+
+  const cancelButton = (fixture: ComponentFixture<WizardHostComponent>) =>
+    (fixture.nativeElement as HTMLElement).querySelector<HTMLButtonElement>(
+      '[data-testid="wizard-cancel"] button'
+    );
+
+  /** A step-nav button. Hand-rolled, so the testid is on the <button> itself. */
+  const navButton = (fixture: ComponentFixture<WizardHostComponent>, key: string) =>
+    (fixture.nativeElement as HTMLElement).querySelector<HTMLButtonElement>(
+      `[data-testid="wizard-step-${key}"]`
+    );
+
+  const navButtons = (fixture: ComponentFixture<WizardHostComponent>) =>
+    Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll<HTMLButtonElement>(
+        '[data-testid^="wizard-step-"]'
+      )
+    );
+
+  function pressKey(button: HTMLButtonElement | null, key: string): void {
+    button?.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+  }
+
+  function clickContinue(fixture: ComponentFixture<WizardHostComponent>): void {
+    continueButton(fixture)?.click();
+    fixture.detectChanges();
+  }
+
+  it('renders a nav entry for every declared step', () => {
+    const fixture = render();
+
+    expect(q(fixture, 'wizard-step-details')).not.toBeNull();
+    expect(q(fixture, 'wizard-step-tags')).not.toBeNull();
+    expect(q(fixture, 'wizard-step-relations')).not.toBeNull();
+  });
+
+  it('starts on the first step and renders only its body', () => {
+    const fixture = render();
+
+    expect(q(fixture, 'name')).not.toBeNull();
+    expect(q(fixture, 'tags-body')).toBeNull();
+  });
+
+  it('defaults activeKey to the first step when the host supplies none', () => {
+    const fixture = render(host => {
+      host.activeKey = undefined as unknown as string;
+    });
+
+    expect(fixture.componentInstance.wizard().activeKey).toBe('details');
+  });
+
+  it('labels the last step Done and the others Continue', () => {
+    const fixture = render();
+    expect(continueButton(fixture)?.textContent).toContain('Continue');
+
+    const onLast = render(host => {
+      host.activeKey = 'relations';
+    });
+    expect(continueButton(onLast)?.textContent).toContain('Done');
+  });
+
+  describe('the disable policy', () => {
+    it('disables Continue while a required step\'s form is invalid', () => {
+      const fixture = render();
+      expect(continueButton(fixture)?.disabled).toBe(true);
+    });
+
+    it('enables Continue once the required form is valid', () => {
+      const fixture = render(host => host.detailsForm.setValue({ name: 'Reduce setup time' }));
+      expect(continueButton(fixture)?.disabled).toBe(false);
+    });
+
+    it('allows an optional step to be skipped with nothing filled in', () => {
+      const fixture = render(host => {
+        host.detailsForm.setValue({ name: 'Reduce setup time' });
+      });
+      clickContinue(fixture);
+
+      expect(fixture.componentInstance.wizard().activeKey).toBe('tags');
+      expect(continueButton(fixture)?.disabled).toBe(false);
+    });
+
+    it('does not block Continue on a pristine but already-valid step', () => {
+      // With commit-on-step-1 the user can return to a step whose values are
+      // already saved; a pristine guard would trap them there.
+      const fixture = render(host => host.detailsForm.setValue({ name: 'Reduce setup time' }));
+
+      expect(fixture.componentInstance.detailsForm.pristine).toBe(true);
+      expect(continueButton(fixture)?.disabled).toBe(false);
+    });
+
+    it('marks an invalid form as touched on Continue so its errors surface', () => {
+      const fixture = render();
+      // Continue is disabled, so drive the handler directly - the guard still holds.
+      fixture.componentInstance.wizard().onContinue();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.commits).toEqual([]);
+    });
+  });
+
+  describe('committing a step', () => {
+    it('emits stepCommit for the active step and advances when the host completes', () => {
+      const fixture = render(host => host.detailsForm.setValue({ name: 'Reduce setup time' }));
+      clickContinue(fixture);
+
+      expect(fixture.componentInstance.commits).toEqual(['details']);
+      expect(fixture.componentInstance.wizard().activeKey).toBe('tags');
+      expect(q(fixture, 'tags-body')).not.toBeNull();
+    });
+
+    it('emits activeKeyChange so the host can mirror the step into the route', () => {
+      const fixture = render(host => host.detailsForm.setValue({ name: 'Reduce setup time' }));
+      clickContinue(fixture);
+
+      expect(fixture.componentInstance.activeKey).toBe('tags');
+    });
+
+    it('stays on the step and shows the host message in an alert region on failure', () => {
+      const fixture = render(host => {
+        host.detailsForm.setValue({ name: 'Reduce setup time' });
+        host.failWith = 'This goal was changed elsewhere.';
+      });
+      clickContinue(fixture);
+
+      const alert = q(fixture, 'wizard-error');
+      expect(fixture.componentInstance.wizard().activeKey).toBe('details');
+      expect(alert?.textContent?.trim()).toBe('This goal was changed elsewhere.');
+      expect(alert?.getAttribute('role')).toBe('alert');
+    });
+
+    it('lets the user retry after a failure', () => {
+      const fixture = render(host => {
+        host.detailsForm.setValue({ name: 'Reduce setup time' });
+        host.failWith = 'Save failed.';
+      });
+      clickContinue(fixture);
+
+      fixture.componentInstance.failWith = null;
+      clickContinue(fixture);
+
+      expect(fixture.componentInstance.commits).toEqual(['details', 'details']);
+      expect(fixture.componentInstance.wizard().activeKey).toBe('tags');
+    });
+
+    it('clears a stale failure message once the step changes', () => {
+      const fixture = render(host => {
+        host.detailsForm.setValue({ name: 'Reduce setup time' });
+        host.failWith = 'Save failed.';
+      });
+      clickContinue(fixture);
+      expect(q(fixture, 'wizard-error')).not.toBeNull();
+
+      fixture.componentInstance.failWith = null;
+      clickContinue(fixture);
+
+      expect(q(fixture, 'wizard-error')).toBeNull();
+    });
+
+    it('stays busy and blocks Continue while a commit is unresolved', () => {
+      const fixture = render(host => {
+        host.detailsForm.setValue({ name: 'Reduce setup time' });
+        host.hang = true;
+      });
+      clickContinue(fixture);
+
+      expect(fixture.componentInstance.wizard().busy()).toBe(true);
+      expect(fixture.componentInstance.wizard().activeKey).toBe('details');
+      expect(continueButton(fixture)?.disabled).toBe(true);
+    });
+
+    it('ignores a second response from a host that completes and then fails', () => {
+      const fixture = render(host => {
+        host.detailsForm.setValue({ name: 'Reduce setup time' });
+      });
+      let captured: WizardCommitRequest | undefined;
+      fixture.componentInstance.onCommit = (request: WizardCommitRequest) => {
+        captured = request;
+        request.complete();
+      };
+      clickContinue(fixture);
+
+      captured?.fail('too late');
+      fixture.detectChanges();
+
+      expect(q(fixture, 'wizard-error')).toBeNull();
+      expect(fixture.componentInstance.wizard().activeKey).toBe('tags');
+    });
+
+    it('emits finished instead of advancing past the last step', () => {
+      const fixture = render(host => {
+        host.detailsForm.setValue({ name: 'Reduce setup time' });
+        host.activeKey = 'relations';
+      });
+      clickContinue(fixture);
+
+      expect(fixture.componentInstance.finished).toBe(true);
+      expect(fixture.componentInstance.wizard().activeKey).toBe('relations');
+    });
+  });
+
+  describe('linear gating', () => {
+    it('locks a later step until the required steps before it are complete', () => {
+      const wizard = render().componentInstance.wizard();
+
+      expect(wizard.isStepLocked(0)).toBe(false);
+      expect(wizard.isStepLocked(1)).toBe(true);
+      expect(wizard.isStepLocked(2)).toBe(true);
+    });
+
+    it('unlocks the next step once the required step commits', () => {
+      const fixture = render(host => host.detailsForm.setValue({ name: 'Reduce setup time' }));
+      clickContinue(fixture);
+      const wizard = fixture.componentInstance.wizard();
+
+      expect(wizard.isStepLocked(1)).toBe(false);
+      // Step 3 sits behind only optional steps now, so it is reachable too.
+      expect(wizard.isStepLocked(2)).toBe(false);
+    });
+
+    it('keeps completed steps clickable so the user can go back', () => {
+      const fixture = render(host => host.detailsForm.setValue({ name: 'Reduce setup time' }));
+      clickContinue(fixture);
+
+      navButton(fixture, 'details')?.click();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.wizard().activeKey).toBe('details');
+      expect(q(fixture, 'name')).not.toBeNull();
+    });
+
+    it('ignores a click on a locked step', () => {
+      const fixture = render();
+
+      navButton(fixture, 'relations')?.click();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.wizard().activeKey).toBe('details');
+    });
+
+    it('marks a locked step aria-disabled but leaves it focusable', () => {
+      const fixture = render();
+      const locked = navButton(fixture, 'relations');
+
+      expect(locked?.getAttribute('aria-disabled')).toBe('true');
+      // aria-disabled rather than the disabled attribute, so screen-reader users can
+      // still reach the step and hear that it is not yet available.
+      expect(locked?.hasAttribute('disabled')).toBe(false);
+    });
+
+    it('marks a completed step complete and drops aria-disabled from the next', () => {
+      const fixture = render(host => host.detailsForm.setValue({ name: 'Reduce setup time' }));
+      clickContinue(fixture);
+
+      expect(navButton(fixture, 'details')?.classList.contains('is-complete')).toBe(true);
+      expect(navButton(fixture, 'relations')?.hasAttribute('aria-disabled')).toBe(false);
+    });
+  });
+
+  describe('the step nav', () => {
+    it('marks the active step with aria-current', () => {
+      const fixture = render();
+
+      expect(navButton(fixture, 'details')?.getAttribute('aria-current')).toBe('step');
+      expect(navButton(fixture, 'tags')?.hasAttribute('aria-current')).toBe(false);
+    });
+
+    it('exposes the nav as a labelled <nav> around an ordered list', () => {
+      const el = render().nativeElement as HTMLElement;
+      const nav = el.querySelector('nav');
+
+      expect(nav?.getAttribute('aria-label')).toBe('Steps');
+      expect(nav?.querySelector('ol')).not.toBeNull();
+    });
+
+    it('keeps exactly one step button tabbable (roving tabindex)', () => {
+      const fixture = render();
+      const tabbable = navButtons(fixture).filter(b => b.getAttribute('tabindex') === '0');
+
+      expect(tabbable.length).toBe(1);
+      expect(tabbable[0]).toBe(navButton(fixture, 'details'));
+    });
+
+    it('moves focus down and up with the arrow keys without changing the step', () => {
+      const fixture = render();
+
+      pressKey(navButton(fixture, 'details'), 'ArrowDown');
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.wizard().focusedIndex()).toBe(1);
+      expect(navButton(fixture, 'tags')?.getAttribute('tabindex')).toBe('0');
+      // Focus moved; the active step did not.
+      expect(fixture.componentInstance.wizard().activeKey).toBe('details');
+
+      pressKey(navButton(fixture, 'tags'), 'ArrowUp');
+      fixture.detectChanges();
+      expect(fixture.componentInstance.wizard().focusedIndex()).toBe(0);
+    });
+
+    it('jumps to the first and last step with Home and End', () => {
+      const fixture = render();
+
+      pressKey(navButton(fixture, 'details'), 'End');
+      fixture.detectChanges();
+      expect(fixture.componentInstance.wizard().focusedIndex()).toBe(2);
+
+      pressKey(navButton(fixture, 'relations'), 'Home');
+      fixture.detectChanges();
+      expect(fixture.componentInstance.wizard().focusedIndex()).toBe(0);
+    });
+
+    it('does not wrap past the ends', () => {
+      const fixture = render();
+
+      pressKey(navButton(fixture, 'details'), 'ArrowUp');
+      fixture.detectChanges();
+      expect(fixture.componentInstance.wizard().focusedIndex()).toBe(0);
+
+      pressKey(navButton(fixture, 'details'), 'End');
+      pressKey(navButton(fixture, 'relations'), 'ArrowDown');
+      fixture.detectChanges();
+      expect(fixture.componentInstance.wizard().focusedIndex()).toBe(2);
+    });
+
+    it('ignores unrelated keys', () => {
+      const fixture = render();
+
+      pressKey(navButton(fixture, 'details'), 'a');
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.wizard().focusedIndex()).toBe(0);
+    });
+  });
+
+  describe('cancel', () => {
+    it('emits cancelled', () => {
+      const fixture = render();
+      cancelButton(fixture)?.click();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.cancelled).toBe(true);
+    });
+
+    it('does not emit cancelled while a commit is in flight', () => {
+      const fixture = render(host => {
+        host.detailsForm.setValue({ name: 'Reduce setup time' });
+        host.hang = true;
+      });
+      clickContinue(fixture);
+
+      fixture.componentInstance.wizard().onCancel();
+      expect(fixture.componentInstance.cancelled).toBe(false);
+    });
+  });
+
+  describe('focus on step change', () => {
+    it('gives the active panel a focusable heading that names the panel', () => {
+      const fixture = render();
+      const heading = q(fixture, 'wizard-panel-details');
+      // app-card's own root is a <section>, so target the panel by class.
+      const panel = (fixture.nativeElement as HTMLElement).querySelector(
+        'section.app-wizard-panel'
+      );
+
+      expect(heading?.tagName.toLowerCase()).toBe('h2');
+      expect(heading?.getAttribute('tabindex')).toBe('-1');
+      expect(panel?.getAttribute('aria-labelledby')).toBe(heading?.id);
+    });
+
+    it('moves focus to the panel heading when the step changes', () => {
+      const fixture = render(host => host.detailsForm.setValue({ name: 'Reduce setup time' }));
+      clickContinue(fixture);
+
+      expect(document.activeElement).toBe(q(fixture, 'wizard-panel-tags'));
+    });
+
+    it('does not steal focus on first render', () => {
+      const fixture = render();
+
+      expect(document.activeElement).not.toBe(q(fixture, 'wizard-panel-details'));
+    });
+  });
+});

--- a/requel-angular/src/app/shared/app-form-wizard.ts
+++ b/requel-angular/src/app/shared/app-form-wizard.ts
@@ -1,0 +1,548 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import {
+  AfterContentInit,
+  Component,
+  ContentChild,
+  ContentChildren,
+  ElementRef,
+  EventEmitter,
+  Input,
+  Output,
+  QueryList,
+  TemplateRef,
+  ViewChild,
+  ViewChildren,
+  signal,
+} from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
+import { FormGroup } from '@angular/forms';
+import { ButtonModule } from 'primeng/button';
+import { AppCardComponent } from './app-card';
+
+/** Process-wide counter so each wizard's heading id is unique. */
+let nextWizardId = 0;
+
+/**
+ * One step of an {@link AppFormWizardComponent}.
+ *
+ * Declared as a child element rather than an entry in a `steps` array input so the
+ * step's fields can arrive as a `<ng-template>` — the caller keeps its own markup
+ * and never has to pass `TemplateRef`s around by hand.
+ *
+ * ```html
+ * <app-wizard-step key="details" label="Details" [form]="detailsForm">
+ *   <ng-template>
+ *     <app-field label="Name" [control]="detailsForm.controls.name">
+ *       <input appFieldControl [formControl]="detailsForm.controls.name" />
+ *     </app-field>
+ *   </ng-template>
+ * </app-wizard-step>
+ * ```
+ *
+ * Note for callers: inside that template use `[formControl]`, not
+ * `formControlName`. The body is projected into the wizard, and `formControlName`
+ * resolves its parent `formGroup` from the injector at the *insertion* point, where
+ * there is none.
+ */
+@Component({
+  selector: 'app-wizard-step',
+  standalone: true,
+  template: '',
+})
+export class AppWizardStepComponent {
+  /** Stable identity for the step. Appears in the route fragment; never an index. */
+  @Input({ required: true }) key!: string;
+
+  /** Step label shown in the left-hand nav. */
+  @Input({ required: true }) label!: string;
+
+  /** Optional short description under the step label. */
+  @Input() helper = '';
+
+  /**
+   * The step's form. Drives Continue's disabled state and the step's completion
+   * marker. Steps that only host association widgets (Tags, Relations, Goals,
+   * Actors) have no fields to validate and pass no form.
+   */
+  @Input() form?: FormGroup;
+
+  /** Skippable step: Continue is never blocked and no completion is required. */
+  @Input() optional = false;
+
+  /** The step's body, supplied as the child `<ng-template>`. */
+  @ContentChild(TemplateRef) content?: TemplateRef<unknown>;
+}
+
+/**
+ * Handed to the host on each Continue so it can run the commit for that step and
+ * report the outcome. The wizard stays busy until one of the two callbacks fires,
+ * so a host that forgets to respond visibly hangs on its own step rather than
+ * silently advancing past a failed save.
+ */
+export interface WizardCommitRequest {
+  /** The step being committed. */
+  readonly step: AppWizardStepComponent;
+  /** Commit succeeded — advance (or finish, on the last step). */
+  complete(): void;
+  /** Commit failed — stay on the step and show `message` in the alert region. */
+  fail(message: string): void;
+}
+
+/**
+ * Shared multi-step form shell (issue #158).
+ *
+ * A two-column card: vertical step nav on the left, the active step's fields on the
+ * right, a Cancel / Continue footer underneath.
+ *
+ * ## Why this does not wrap PrimeNG's `p-stepper`
+ *
+ * The plan originally specified wrapping `p-stepper` the way `app-data-table` wraps
+ * `p-table`, to inherit its keyboard nav. That does not work: in PrimeNG 21.1.3
+ * `p-stepper` unconditionally carries `role="tablist"` while its children are
+ * `role="presentation"` (`p-step`) and `role="tabpanel"` (`p-step-panel`) — never
+ * `role="tab"` — so axe reports a critical `aria-required-children` violation. Both
+ * the vertical (`p-step-item`) and horizontal (`p-step-list` + `p-step-panels`)
+ * compositions fail it, and `p-step-list` gets no role at all, so the tablist is on
+ * the wrong element. There is no way to override a component's host binding from
+ * outside it.
+ *
+ * Hand-rolling is also the more accurate semantic. Tabs are peer views the user
+ * browses; wizard steps are a linear process with progress state. This renders a
+ * `<nav>` + `<ol>` of buttons with `aria-current="step"`, which carries no
+ * tablist child requirements and describes what the control actually is.
+ *
+ * ## Keyboard model
+ *
+ * Roving tabindex over the step buttons: exactly one is tabbable, Up/Down (and
+ * Left/Right) move focus, Home/End jump to the ends, and Enter/Space activate via
+ * the native button. Moving focus does not change the step — activation is
+ * explicit, so arrowing past a step never commits anything.
+ *
+ * ## Commit model
+ *
+ * Continue emits {@link stepCommit} with a {@link WizardCommitRequest}; the host
+ * decides whether that hits the API. Nothing about entity versions lives here —
+ * the host owns the version it sends and refreshes it from each command's returned
+ * entity. The wizard's part of that contract is to keep the step on failure
+ * (including a stale-version 409) and surface the host's message, instead of
+ * advancing and losing the user's edit.
+ */
+@Component({
+  selector: 'app-form-wizard',
+  standalone: true,
+  imports: [ButtonModule, NgTemplateOutlet, AppCardComponent],
+  template: `
+    <app-card>
+      <div class="app-wizard">
+        <nav class="app-wizard-nav" [attr.aria-label]="navLabel">
+          <ol class="app-wizard-steps">
+            @for (step of stepList; track step.key; let i = $index) {
+              <li class="app-wizard-step">
+                <button
+                  #navButton
+                  type="button"
+                  class="app-wizard-step-button"
+                  [class.is-active]="isActive(i)"
+                  [class.is-complete]="isStepComplete(step)"
+                  [attr.aria-current]="isActive(i) ? 'step' : null"
+                  [attr.aria-disabled]="isStepLocked(i) ? 'true' : null"
+                  [attr.tabindex]="i === focusedIndex() ? 0 : -1"
+                  [attr.data-testid]="'wizard-step-' + step.key"
+                  (click)="onNavActivate(i)"
+                  (keydown)="onNavKeydown($event, i)"
+                >
+                  <span class="app-wizard-step-marker" aria-hidden="true">
+                    @if (isStepComplete(step)) {
+                      <i class="pi pi-check"></i>
+                    } @else {
+                      {{ i + 1 }}
+                    }
+                  </span>
+                  <span class="app-wizard-step-text">
+                    <span class="app-wizard-step-label">{{ step.label }}</span>
+                    @if (step.optional) {
+                      <span class="app-wizard-step-optional">Optional</span>
+                    }
+                    @if (step.helper) {
+                      <span class="app-wizard-step-helper">{{ step.helper }}</span>
+                    }
+                  </span>
+                  @if (isStepComplete(step)) {
+                    <span class="rq-visually-hidden">Completed</span>
+                  }
+                </button>
+              </li>
+            }
+          </ol>
+        </nav>
+
+        @if (activeStep(); as step) {
+          <section class="app-wizard-panel" [attr.aria-labelledby]="headingId">
+            <h2
+              #panelHeading
+              class="rq-section-title app-wizard-panel-title"
+              [id]="headingId"
+              tabindex="-1"
+              [attr.data-testid]="'wizard-panel-' + step.key"
+            >
+              {{ step.label }}
+            </h2>
+
+            @if (errorMessage()) {
+              <p class="app-wizard-error" role="alert" data-testid="wizard-error">
+                {{ errorMessage() }}
+              </p>
+            }
+
+            <ng-container [ngTemplateOutlet]="step.content ?? null" />
+
+            <div class="app-wizard-footer">
+              <p-button
+                label="Cancel"
+                severity="secondary"
+                [text]="true"
+                [disabled]="busy()"
+                data-testid="wizard-cancel"
+                (onClick)="onCancel()"
+              />
+              <p-button
+                [label]="isLastStep(activeIndex()) ? 'Done' : 'Continue'"
+                [disabled]="!canContinue(step)"
+                [loading]="busy()"
+                data-testid="wizard-continue"
+                (onClick)="onContinue()"
+              />
+            </div>
+          </section>
+        }
+      </div>
+    </app-card>
+  `,
+  styles: [`
+    :host { display: block; }
+    .app-wizard {
+      display: grid;
+      grid-template-columns: minmax(11rem, 14rem) 1fr;
+      gap: var(--rq-space-6);
+      align-items: start;
+    }
+    .app-wizard-steps { list-style: none; margin: 0; padding: 0; }
+    .app-wizard-step + .app-wizard-step { margin-top: var(--rq-space-1); }
+    .app-wizard-step-button {
+      display: flex;
+      align-items: flex-start;
+      gap: var(--rq-space-2);
+      width: 100%;
+      padding: var(--rq-space-2);
+      border: 0;
+      border-radius: var(--rq-radius-md);
+      background: transparent;
+      font: inherit;
+      text-align: start;
+      cursor: pointer;
+      color: inherit;
+    }
+    .app-wizard-step-button[aria-disabled='true'] {
+      color: var(--rq-text-muted-color);
+      cursor: default;
+    }
+    .app-wizard-step-button.is-active { background: var(--rq-wizard-step-active-bg); }
+    .app-wizard-step-button:focus-visible {
+      outline: var(--rq-focus-ring-width) solid var(--rq-focus-ring-color);
+      outline-offset: var(--rq-focus-ring-offset);
+    }
+    .app-wizard-step-marker {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      inline-size: var(--rq-wizard-marker-size);
+      block-size: var(--rq-wizard-marker-size);
+      border-radius: 50%;
+      background: var(--rq-wizard-marker-bg);
+      font-size: var(--rq-font-size-xs);
+      flex: none;
+    }
+    .is-complete .app-wizard-step-marker {
+      background: var(--rq-wizard-marker-complete-bg);
+      color: var(--rq-wizard-marker-complete-fg);
+    }
+    .app-wizard-step-text { display: block; }
+    .app-wizard-step-label { display: block; font-weight: var(--rq-font-weight-medium); }
+    .app-wizard-step-optional,
+    .app-wizard-step-helper {
+      display: block;
+      color: var(--rq-text-muted-color);
+      font-size: var(--rq-font-size-xs);
+    }
+    .app-wizard-panel-title { margin: 0 0 var(--rq-space-4); }
+    .app-wizard-panel-title:focus-visible {
+      outline: var(--rq-focus-ring-width) solid var(--rq-focus-ring-color);
+      outline-offset: var(--rq-focus-ring-offset);
+    }
+    .app-wizard-error {
+      margin: 0 0 var(--rq-space-4);
+      color: var(--rq-field-error-fg);
+      font-size: var(--rq-text-helper-size);
+    }
+    .app-wizard-footer {
+      display: flex;
+      justify-content: flex-end;
+      gap: var(--rq-space-2);
+      margin-top: var(--rq-space-6);
+    }
+
+    @container (max-width: 40rem) {
+      .app-wizard { grid-template-columns: 1fr; }
+    }
+  `],
+})
+export class AppFormWizardComponent implements AfterContentInit {
+  @ContentChildren(AppWizardStepComponent) private stepQuery!: QueryList<AppWizardStepComponent>;
+
+  @ViewChildren('navButton') private navButtons!: QueryList<ElementRef<HTMLButtonElement>>;
+
+  @ViewChild('panelHeading') private panelHeading?: ElementRef<HTMLElement>;
+
+  /**
+   * The active step's key. Two-way bound so the host can mirror it into a route
+   * fragment and land on the right step after a back/refresh.
+   */
+  @Input() activeKey?: string;
+  @Output() activeKeyChange = new EventEmitter<string>();
+
+  /** Accessible name for the step nav. */
+  @Input() navLabel = 'Steps';
+
+  /** Fires on Continue. See {@link WizardCommitRequest}. */
+  @Output() stepCommit = new EventEmitter<WizardCommitRequest>();
+
+  /** Cancel pressed. The host decides whether to navigate away or confirm first. */
+  @Output() cancelled = new EventEmitter<void>();
+
+  /** Continue pressed on the last step and its commit succeeded. */
+  @Output() finished = new EventEmitter<void>();
+
+  /** Keys of steps whose commit has succeeded. */
+  private readonly completed = signal<ReadonlySet<string>>(new Set());
+
+  /** True while a commit is in flight. Blocks Continue/Cancel and shows a spinner. */
+  readonly busy = signal(false);
+
+  /** Host-supplied failure text for the current step, cleared on any navigation. */
+  readonly errorMessage = signal<string | null>(null);
+
+  /**
+   * Which step button is tabbable. Tracked separately from the active step so
+   * arrowing through the nav moves focus without activating anything.
+   */
+  readonly focusedIndex = signal(0);
+
+  /** Snapshot of the declared steps, resolved once content has initialised. */
+  stepList: AppWizardStepComponent[] = [];
+
+  private readonly uid = `rq-wizard-${++nextWizardId}`;
+
+  get headingId(): string {
+    return `${this.uid}-panel-title`;
+  }
+
+  ngAfterContentInit(): void {
+    this.stepList = this.stepQuery.toArray();
+    this.stepQuery.changes.subscribe(() => {
+      this.stepList = this.stepQuery.toArray();
+    });
+    if (!this.activeKey && this.stepList.length) {
+      this.activeKey = this.stepList[0].key;
+    }
+    this.focusedIndex.set(this.activeIndex());
+  }
+
+  /** Index of the active step; an unknown key falls back to the first step. */
+  activeIndex(): number {
+    const index = this.stepList.findIndex(step => step.key === this.activeKey);
+    return index < 0 ? 0 : index;
+  }
+
+  activeStep(): AppWizardStepComponent | undefined {
+    return this.stepList[this.activeIndex()];
+  }
+
+  isActive(index: number): boolean {
+    return index === this.activeIndex();
+  }
+
+  isLastStep(index: number): boolean {
+    return index === this.stepList.length - 1;
+  }
+
+  isStepComplete(step: AppWizardStepComponent): boolean {
+    return this.completed().has(step.key);
+  }
+
+  /**
+   * Linear forward, free backward: a step is reachable once every required step
+   * before it is complete. Already-visited steps stay reachable so the user can go
+   * back and fix a typo.
+   */
+  isStepLocked(index: number): boolean {
+    if (index <= this.activeIndex()) {
+      return false;
+    }
+    return this.stepList
+      .slice(0, index)
+      .some(step => !step.optional && !this.isStepComplete(step));
+  }
+
+  /**
+   * Continue is enabled unless the step's form is invalid or a commit is running.
+   *
+   * Deliberately not gated on `pristine`: with commit-on-step-1 the user can come
+   * back to a step whose values are already saved and correct, and a pristine guard
+   * would trap them there with no way forward. An optional step has nothing to
+   * validate, so it can always be skipped.
+   */
+  canContinue(step: AppWizardStepComponent): boolean {
+    if (this.busy()) {
+      return false;
+    }
+    if (step.optional || !step.form) {
+      return true;
+    }
+    return step.form.valid;
+  }
+
+  onContinue(): void {
+    const step = this.activeStep();
+    if (!step || this.busy() || !this.canContinue(step)) {
+      return;
+    }
+
+    // Reveal any errors the user has not touched into view yet, so an invalid form
+    // explains itself instead of just refusing to advance.
+    step.form?.markAllAsTouched();
+
+    this.errorMessage.set(null);
+    this.busy.set(true);
+
+    let settled = false;
+    const request: WizardCommitRequest = {
+      step,
+      complete: () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        this.busy.set(false);
+        this.completed.update(keys => new Set(keys).add(step.key));
+        this.advance();
+      },
+      fail: (message: string) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        this.busy.set(false);
+        this.errorMessage.set(message);
+      },
+    };
+
+    this.stepCommit.emit(request);
+  }
+
+  private advance(): void {
+    const next = this.stepList[this.activeIndex() + 1];
+    if (!next) {
+      this.finished.emit();
+      return;
+    }
+    this.goTo(next.key);
+  }
+
+  onCancel(): void {
+    if (this.busy()) {
+      return;
+    }
+    this.cancelled.emit();
+  }
+
+  /** Step-nav activation (click, Enter, Space). Locked steps are inert. */
+  onNavActivate(index: number): void {
+    const step = this.stepList[index];
+    if (!step || this.isStepLocked(index) || this.busy()) {
+      return;
+    }
+    this.focusedIndex.set(index);
+    this.goTo(step.key);
+  }
+
+  /**
+   * Roving-tabindex keyboard nav. Moves focus only — Enter/Space still do the
+   * activating, via the native button.
+   */
+  onNavKeydown(event: KeyboardEvent, index: number): void {
+    const last = this.stepList.length - 1;
+    let target: number | null = null;
+
+    switch (event.key) {
+      case 'ArrowDown':
+      case 'ArrowRight':
+        target = Math.min(index + 1, last);
+        break;
+      case 'ArrowUp':
+      case 'ArrowLeft':
+        target = Math.max(index - 1, 0);
+        break;
+      case 'Home':
+        target = 0;
+        break;
+      case 'End':
+        target = last;
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    if (target === index) {
+      return;
+    }
+    this.focusedIndex.set(target);
+    this.focusNavButton(target);
+  }
+
+  private focusNavButton(index: number): void {
+    this.navButtons?.get(index)?.nativeElement.focus();
+  }
+
+  private goTo(key: string): void {
+    if (this.activeKey === key) {
+      return;
+    }
+    this.activeKey = key;
+    this.errorMessage.set(null);
+    this.focusedIndex.set(this.activeIndex());
+    this.activeKeyChange.emit(key);
+    // The panel section persists across step changes (only its content swaps), so
+    // the heading is already in the DOM and can take focus straight away.
+    this.panelHeading?.nativeElement.focus();
+  }
+}

--- a/requel-angular/src/app/shared/form-errors.spec.ts
+++ b/requel-angular/src/app/shared/form-errors.spec.ts
@@ -1,0 +1,115 @@
+import { FormControl, Validators } from '@angular/forms';
+import {
+  DEFAULT_FORM_ERRORS,
+  firstErrorMessage,
+  isRequired,
+  resolveErrorMessage,
+} from './form-errors';
+
+describe('form-errors (issue #158)', () => {
+  describe('resolveErrorMessage', () => {
+    it('returns null when there are no errors', () => {
+      expect(resolveErrorMessage(null)).toBeNull();
+      expect(resolveErrorMessage(undefined)).toBeNull();
+      expect(resolveErrorMessage({})).toBeNull();
+    });
+
+    it('prefers required over every other error so an empty field reads cleanly', () => {
+      const message = resolveErrorMessage({
+        pattern: { requiredPattern: '^a+$', actualValue: '' },
+        required: true,
+      });
+      expect(message).toBe(DEFAULT_FORM_ERRORS['required'](true));
+      expect(message).toBe('This field is required.');
+    });
+
+    it('renders minlength with the required length', () => {
+      expect(resolveErrorMessage({ minlength: { requiredLength: 3, actualLength: 1 } })).toBe(
+        'Must be at least 3 characters.'
+      );
+    });
+
+    it('singularises a one-character minlength', () => {
+      expect(resolveErrorMessage({ minlength: { requiredLength: 1, actualLength: 0 } })).toBe(
+        'Must be at least 1 character.'
+      );
+    });
+
+    it('renders maxlength with the required length', () => {
+      expect(resolveErrorMessage({ maxlength: { requiredLength: 80, actualLength: 92 } })).toBe(
+        'Must be at most 80 characters.'
+      );
+    });
+
+    it('falls back to generic wording when a payload has no requiredLength', () => {
+      expect(resolveErrorMessage({ minlength: null })).toBe('Value is too short.');
+      expect(resolveErrorMessage({ maxlength: {} })).toBe('Value is too long.');
+    });
+
+    it('lets a per-field override win over the default wording', () => {
+      expect(
+        resolveErrorMessage({ required: true }, { required: 'A goal needs a name.' })
+      ).toBe('A goal needs a name.');
+    });
+
+    it('uses the default when an override exists for a different key', () => {
+      expect(resolveErrorMessage({ required: true }, { email: 'Bad address.' })).toBe(
+        'This field is required.'
+      );
+    });
+
+    it('never renders a raw validator key for an unknown error', () => {
+      const message = resolveErrorMessage({ goalSelfRelation: true });
+      expect(message).toBe('This value is not valid.');
+      expect(message).not.toContain('goalSelfRelation');
+    });
+
+    it('prefers an override for an unknown error over the generic fallback', () => {
+      expect(
+        resolveErrorMessage(
+          { goalSelfRelation: true },
+          { goalSelfRelation: 'A goal cannot relate to itself.' }
+        )
+      ).toBe('A goal cannot relate to itself.');
+    });
+  });
+
+  describe('firstErrorMessage', () => {
+    it('reads the errors off a control', () => {
+      const control = new FormControl('', { validators: Validators.required });
+      expect(firstErrorMessage(control)).toBe('This field is required.');
+
+      control.setValue('Reduce onboarding time');
+      expect(firstErrorMessage(control)).toBeNull();
+    });
+
+    it('tolerates a null control', () => {
+      expect(firstErrorMessage(null)).toBeNull();
+      expect(firstErrorMessage(undefined)).toBeNull();
+    });
+  });
+
+  describe('isRequired', () => {
+    it('detects a bare required validator', () => {
+      expect(isRequired(new FormControl('', { validators: Validators.required }))).toBe(true);
+    });
+
+    it('detects required inside a composed validator', () => {
+      const control = new FormControl('', {
+        validators: [Validators.required, Validators.maxLength(80)],
+      });
+      expect(isRequired(control)).toBe(true);
+    });
+
+    it('is false for a control with only non-required validators', () => {
+      expect(isRequired(new FormControl('', { validators: Validators.maxLength(80) }))).toBe(
+        false
+      );
+    });
+
+    it('is false for an unvalidated or missing control', () => {
+      expect(isRequired(new FormControl(''))).toBe(false);
+      expect(isRequired(null)).toBe(false);
+    });
+  });
+});

--- a/requel-angular/src/app/shared/form-errors.ts
+++ b/requel-angular/src/app/shared/form-errors.ts
@@ -1,0 +1,138 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import { AbstractControl, ValidationErrors } from '@angular/forms';
+
+/**
+ * Shared validation-message map (issue #158, the N5-sized slice of #132's "unified
+ * validation helper").
+ *
+ * One place decides how a `ValidationErrors` key becomes user-facing text, so nine
+ * editors don't each invent their own wording. `app-field` calls
+ * {@link firstErrorMessage} to render the inline error under a control; callers
+ * override individual messages per field via `app-field`'s `errorMessages` input.
+ *
+ * #132 extends this during rollout (cross-field, password confirmation). Keep
+ * additions here rather than in components.
+ */
+
+/** Builds a message from a validation error's payload (e.g. `minlength`'s lengths). */
+export type FormErrorMessageFactory = (error: unknown) => string;
+
+/** Per-field overrides accepted by `app-field`: error key -> literal message. */
+export type FormErrorOverrides = Record<string, string>;
+
+/**
+ * Precedence order. A control can hold several errors at once (`required` and
+ * `minlength` never co-occur, but `pattern` and `maxlength` can), and we render
+ * exactly one message — so the order must be deterministic rather than depending
+ * on `Object.keys` insertion order.
+ *
+ * `required` comes first because an empty field's other complaints are noise.
+ */
+const ERROR_PRECEDENCE = ['required', 'minlength', 'maxlength', 'email', 'pattern'] as const;
+
+/** Default wording for the built-in Angular validators. */
+export const DEFAULT_FORM_ERRORS: Record<string, FormErrorMessageFactory> = {
+  required: () => 'This field is required.',
+  minlength: error => {
+    const required = (error as { requiredLength?: number } | null)?.requiredLength;
+    return required != null
+      ? `Must be at least ${required} character${required === 1 ? '' : 's'}.`
+      : 'Value is too short.';
+  },
+  maxlength: error => {
+    const required = (error as { requiredLength?: number } | null)?.requiredLength;
+    return required != null
+      ? `Must be at most ${required} character${required === 1 ? '' : 's'}.`
+      : 'Value is too long.';
+  },
+  email: () => 'Enter a valid email address.',
+  pattern: () => 'Value is not in the expected format.',
+};
+
+/** Last-resort text for a validator we have no wording for. Never shows a raw key. */
+const FALLBACK_MESSAGE = 'This value is not valid.';
+
+/**
+ * Resolves the single message to show for `errors`, honouring `overrides` first,
+ * then {@link DEFAULT_FORM_ERRORS}, then a generic fallback.
+ *
+ * Returns `null` when there is nothing to report.
+ */
+export function resolveErrorMessage(
+  errors: ValidationErrors | null | undefined,
+  overrides?: FormErrorOverrides
+): string | null {
+  if (!errors) {
+    return null;
+  }
+
+  const keys = Object.keys(errors);
+  if (keys.length === 0) {
+    return null;
+  }
+
+  // Known keys in precedence order, then any unknown keys in their own order, so a
+  // custom validator still produces a message instead of silently rendering nothing.
+  const ordered = [
+    ...ERROR_PRECEDENCE.filter(key => keys.includes(key)),
+    ...keys.filter(key => !ERROR_PRECEDENCE.includes(key as (typeof ERROR_PRECEDENCE)[number])),
+  ];
+
+  for (const key of ordered) {
+    const override = overrides?.[key];
+    if (override) {
+      return override;
+    }
+    const factory = DEFAULT_FORM_ERRORS[key];
+    if (factory) {
+      return factory(errors[key]);
+    }
+  }
+
+  return FALLBACK_MESSAGE;
+}
+
+/** Convenience wrapper: {@link resolveErrorMessage} for a control's current errors. */
+export function firstErrorMessage(
+  control: AbstractControl | null | undefined,
+  overrides?: FormErrorOverrides
+): string | null {
+  return resolveErrorMessage(control?.errors, overrides);
+}
+
+/**
+ * Whether `control` carries a `required` validator, so `app-field` can derive its
+ * required marker and `aria-required` from the validators instead of taking a
+ * separate boolean input that can drift out of sync with them.
+ *
+ * Probes the composed validator with an empty value rather than using
+ * `hasValidator(Validators.required)`, because the latter misses `required` when it
+ * has been folded into a composed or wrapped validator function.
+ */
+export function isRequired(control: AbstractControl | null | undefined): boolean {
+  const validator = control?.validator;
+  if (!validator) {
+    return false;
+  }
+  const result = validator({ value: null } as AbstractControl);
+  return !!result?.['required'];
+}

--- a/requel-angular/src/app/shared/testing/a11y.ts
+++ b/requel-angular/src/app/shared/testing/a11y.ts
@@ -39,9 +39,24 @@ export function getOpenDialog(): HTMLElement | null {
  * The `color-contrast` rule is disabled: jsdom has no layout engine / real getComputedStyle box
  * model, so contrast results are unreliable in unit tests. Color contrast is governed separately
  * (UI/UX review Finding 4.7), not here.
+ *
+ * `exclude` takes CSS selectors for subtrees to skip, so a whole-page assertion is still
+ * possible when some third-party host element carries a defect of its own. The known case is
+ * `p-confirmdialog`: PrimeNG puts `role="alertdialog"` on the component's host element even
+ * when no confirmation is showing (its container is an empty comment), so axe reports an
+ * unnamed dialog on every page that mounts one. That is a PrimeNG-level issue affecting all
+ * such pages rather than anything the page under test controls — it belongs with the modal
+ * a11y work (#139), not to whichever ticket happens to run axe over the page.
  */
-export async function expectNoAxeViolations(root: Element = document.body): Promise<void> {
-  const results = await axe.run(root, {
+export async function expectNoAxeViolations(
+  root: Element = document.body,
+  exclude: string[] = []
+): Promise<void> {
+  const context = exclude.length
+    ? { include: [root], exclude: exclude.map(selector => [selector]) }
+    : root;
+
+  const results = await axe.run(context as Parameters<typeof axe.run>[0], {
     rules: { 'color-contrast': { enabled: false } },
   });
 

--- a/requel-angular/src/styles.scss
+++ b/requel-angular/src/styles.scss
@@ -98,6 +98,31 @@
   --rq-card-shadow: 0 1px 2px rgba(15, 23, 42, 0.06),
     0 1px 3px rgba(15, 23, 42, 0.04);
 
+  // Form row (issue #158, N5). The single source of truth for the label column
+  // width and row divider that nine editors each redefined locally as
+  // `.form-grid { grid-template-columns: 120px 1fr }` at varying widths. The label
+  // column is the one field-specific measure (7.5rem == the 120px the editors had
+  // converged on, expressed in the rem scale); everything else aliases existing
+  // tokens so app-field introduces no new colour literals — the divider reuses the
+  // card border so a stack of rows matches the surface it sits on, and the error /
+  // required marker colours read the same red ramp stop as --rq-tag-danger-fg.
+  --rq-field-label-w: 7.5rem;
+  --rq-field-divider: var(--rq-card-border);
+  --rq-field-error-fg: var(--rq-tag-danger-fg);
+  --rq-field-required-fg: var(--rq-tag-danger-fg);
+
+  // Form wizard step nav (issue #158, N5). app-form-wizard hand-rolls its step nav
+  // rather than wrapping p-stepper, which hard-codes role="tablist" on itself and so
+  // fails axe's aria-required-children in every composition. These tokens cover the
+  // only chrome that nav needs: the active row tint and the numbered/checked step
+  // marker. Everything aliases the surface and primary ramps from the #125 preset -
+  // no new literals, and dark mode (N6) inherits automatically.
+  --rq-wizard-step-active-bg: var(--p-surface-100);
+  --rq-wizard-marker-size: 1.5rem;
+  --rq-wizard-marker-bg: var(--p-surface-200);
+  --rq-wizard-marker-complete-bg: var(--p-primary-color);
+  --rq-wizard-marker-complete-fg: var(--p-primary-contrast-color);
+
   // Tag / chip severity-tint system (issue #155, N2). The single source of truth
   // for the soft-tinted status tags and chips (app-tag / app-chip). Each tone
   // pairs a soft background tint with an AA-contrast text/icon colour, sourced

--- a/scripts/set-lookandfeel-points.sh
+++ b/scripts/set-lookandfeel-points.sh
@@ -27,7 +27,9 @@ done <<'EOF'
 155 3   # N2 Tag & Chip severity system (two wrappers, variants, replace 3 usages)
 156 2   # N3 Card / content-surface primitive
 157 8   # N4 Data-table pattern component + migrate >=2 list pages
-158 8   # N5 Form wizard + app-field + migrate one create flow to reactive forms
+158 13  # N5 Form wizard + app-field + form-errors helper + Goal AND Story migrations
+        # (was 8; re-pointed when the helper and the reactive-forms migration for both
+        # pilots moved out of #132 into N5 - see doc/158-form-wizard-field.md sec 7)
 159 3   # N6 Theme switcher + dark mode (optional)
 EOF
 


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/158

N5 entity-create wizard: add app-field + app-form-wizard + form-errors, and migrate the Goal and Story forms to reactive forms

Implements N5 from doc/124-lookandfeel-plan.md as three shared primitives and proves them on
the Goal and Story create/edit flows. Create becomes a 3-step wizard so the enrichment
sections (Tags, Relations, Goals, Additional Actors) are reachable before the first save,
removing the `@if (!isNew())` gate that forced a user to save a half-configured entity before
they could finish configuring it. Edit keeps its single card and swaps `div.form-grid` for
`app-field` rows. Concretizes #132 and #146; satisfies the label/error association from #138
structurally rather than per caller; builds on app-card (#156). Full plan and the decisions
behind it: doc/158-form-wizard-field.md.

Summary of the scope change agreed while planning: the form-errors helper and the reactive-forms
migration for both pilots moved out of #132 into this issue, so #158 went 8 -> 13 points and
#132 keeps the rollout to the remaining editors.

New shared primitives
- requel-angular/src/app/shared/form-errors.ts: the shared validation-message map.
  `resolveErrorMessage` / `firstErrorMessage` turn a ValidationErrors key into user-facing
  text with a deterministic precedence order (required first, then minlength, maxlength,
  email, pattern) rather than depending on Object.keys order, plus per-field overrides and a
  generic fallback so a custom validator never renders a raw key. `isRequired` derives the
  required marker by probing the composed validator with an empty value instead of
  `hasValidator(Validators.required)`, which misses `required` once it has been folded into a
  composed validator. This is the N5-sized slice of #132's "unified validation helper"; #132
  extends it with cross-field and password-confirmation rules.
- requel-angular/src/app/shared/app-field.ts: the form row (`app-field`) plus the
  `appFieldControl` directive. Label + helper on the left, control on the right, hairline
  divider, inline error beneath the control. The row owns id / aria-describedby / aria-invalid
  / aria-required on the projected control, so callers never wire ARIA by hand. The directive
  resolves which element should carry those attributes: the host for a native input/textarea/
  select, otherwise the first focusable descendant, which is what makes PrimeNG wrappers like
  p-select work. `controlId` is the escape hatch for wrappers that render their inner input
  asynchronously — pass it alongside the wrapper's own inputId. Errors render only once the
  control is touched or a save has been attempted, so a create form does not greet the user
  with red text. Replaces the per-editor `.form-grid { grid-template-columns: 120px 1fr }`
  that #126's descope left in place.
- requel-angular/src/app/shared/app-form-wizard.ts: the multi-step shell
  (`app-form-wizard` + `app-wizard-step`). Two-column card, vertical step nav on the left, the
  active step's fields on the right, subtle Cancel + primary Continue/Done footer. Steps are
  declared as child elements holding an `<ng-template>` rather than passed as an array, so each
  step's body stays in the caller's markup. Linear forward, free backward: a step unlocks once
  every required step before it is complete, and completed steps stay clickable. Continue is
  gated on `form.invalid || saving()` but deliberately NOT on `form.pristine` — with
  commit-on-step-1 the user can return to a step whose values are already saved and valid, and
  a pristine guard would trap them there. The commit handshake is a request object
  (`complete()` / `fail(message)`) so the wizard owns the busy state and a host that never
  responds visibly hangs on its own step instead of silently advancing past a failed save; a
  second response after the first is ignored.

  Deviation from the plan, with reason: the plan specified wrapping PrimeNG's p-stepper the way
  app-data-table wraps p-table, to inherit its keyboard nav. That is not viable. In PrimeNG
  21.1.3 p-stepper hard-codes `role="tablist"` on itself while its children are
  `role="presentation"` (p-step) and `role="tabpanel"` (p-step-panel), never `role="tab"`, so
  axe reports a critical aria-required-children violation. Verified against BOTH the vertical
  (p-step-item) and horizontal (p-step-list + p-step-panels) compositions, and p-step-list
  carries no role at all, so the tablist is on the wrong element; a component's host binding
  cannot be overridden from outside it. The nav is therefore a `<nav>` + `<ol>` of buttons with
  `aria-current="step"`, which carries no tablist child requirements and is the more accurate
  semantic anyway — tabs are peer views you browse, wizard steps are a linear process with
  progress state. Locked steps use aria-disabled rather than the disabled attribute so screen
  reader users can still reach a step and hear that it is not yet available. Keyboard model is
  a roving tabindex: Up/Down/Left/Right move focus, Home/End jump to the ends, and Enter/Space
  activate via the native button — moving focus never activates, so arrowing past a step
  cannot commit anything. Focus moves to the panel heading on step change and is not stolen on
  first render.

Design tokens
- requel-angular/src/styles.scss: adds `--rq-field-*` and `--rq-wizard-*`. The only new measure
  is `--rq-field-label-w: 7.5rem` (the 120px the editors had converged on, in the rem scale);
  the divider aliases `--rq-card-border`, the error/required colours alias
  `--rq-tag-danger-fg`, and the wizard's active-row tint and step marker read the surface and
  primary ramps from the #125 preset. No new colour literals, so N6's dark mode inherits them.
  The narrow-viewport stack in app-field uses a container query rather than reusing
  `--rq-editor-max`, which is a max-width token (48rem), not a breakpoint.

Goal editor migration
- requel-angular/src/app/features/goals/goal-editor.ts: `/goals/new` becomes a 3-step wizard
  (Details -> Tags -> Relations); Details commits EditGoal on Continue, which is what gives
  Tags and Relations the persisted goalId they need, and the two optional steps advance without
  touching the API because their widgets commit inline. `/goals/:goalId` keeps its single card
  with app-field rows and no wizard chrome. `.form-grid` and its local
  `grid-template-columns` deleted. The name/text ngModel fields become a FormGroup; Save is
  gated on `valid && dirty && !saving`. Both modes render from the same `<ng-template>` bodies
  via ngTemplateOutlet so they cannot drift apart. The `@if (!isNew())` gate is gone from Tags
  and Relations. Annotations render only once goalId exists rather than as a dead panel during
  create. Section headings go h3 -> h2 (and the nested "Related To This Goal" h4 -> h3), fixing
  a pre-existing h1 -> h3 heading-order violation that only showed up once axe ran over the
  whole page; inside the wizard the section heading is suppressed because the panel's own h2
  already names the step.

  Version handling (the correctness risk in commit-on-step-1). #108 wired caller-supplied
  optimistic-lock versions through every Edit* command, so a stale version throws
  EntityLockException.staleEntity and CommandController maps it to HTTP 409. That never bit
  before because onSave navigated away immediately after a create; a wizard stays on the page.
  The version is now treated as spent on use: id and version are both read from
  `result.entity` after every accepted EditGoal, never carried across two mutations. Without
  this, creating on step 1, walking forward, returning to Details to fix a typo and pressing
  Continue re-sends the create-time version and is a guaranteed 409 with no way for the UI to
  explain it. A 409 is now handled distinctly from an ordinary failure: refetch, keep the step,
  and say the goal was changed elsewhere. Confirmed while investigating that the enrichment
  steps do NOT bump the parent's version — AssignTagCommandImpl mutates the Tag
  (`tagImpl.getTaggables().add(...)`) and EditGoalRelationCommandImpl persists a standalone
  GoalRelationImpl — so no refetch is needed after steps 2 and 3.

  Bug fixed: the SSE reload guard returned early when the user had unsaved edits, keeping the
  local text but also keeping the stale version, which guaranteed a 409 on the next save. It
  now preserves the edits and adopts the incoming version.

  Bug fixed: EditGoalRelation was sending `this.name` — the live form value — as fromGoalName,
  so an unsaved rename in the Name field would be sent as the relation's source and fail to
  resolve. It now sends the persisted goalName().

- goal-editor.spec.ts: rewritten for reactive forms and extended to 30 tests covering the
  create wizard, the Save disable policy, and the version contract, including the
  back-navigate-and-re-commit regression and the SSE-guard-keeps-version case.
- goal-editor.a11y.spec.ts: adds whole-page axe checks for the create wizard and edit form,
  the Name label/error/required association, absence of .form-grid, and that all three steps
  are present during create.

Story editor migration
- requel-angular/src/app/features/stories/story-editor.ts: same treatment. `/stories/new`
  becomes Details -> Goals -> Additional Actors. All four controls stay on Details, including
  Primary Actor, which is a scalar property of the story rather than an association — that also
  makes the actor picker a step-1 requirement, which is what proves app-field is control-
  agnostic and not merely input-agnostic. Both p-selects pass `controlId` matching their own
  inputId so the label targets the input PrimeNG renders inside the wrapper. The four ngModel
  fields become a FormGroup, and `trackChanges()` plus the four `original*` shadow fields are
  deleted — the form's own dirty state replaces the whole hand-rolled comparison. `.form-grid`
  deleted. Same version contract and 409 recovery as Goal.

  Bug fixed: loadStory had no fromSSE guard at all, unlike goal-editor, so any SSE
  notification for the story silently overwrote whatever the user was typing. It now keeps
  local edits and adopts the incoming version.

- story-editor.spec.ts: rewritten for reactive forms, 26 tests, same coverage shape as Goal.
- story-editor.a11y.spec.ts (new): whole-page axe checks plus the p-select association tests —
  the label's target must be a descendant of the p-select wrapper and not the wrapper itself,
  which is the assertion that would catch ARIA landing on a non-focusable custom element.

Core
- requel-angular/src/app/models/command.ts, core/command.service.ts: CommandResult gains an
  optional `status`, populated by handleError from the HttpErrorResponse. Without it a 409
  optimistic-lock conflict is indistinguishable from any other failure, since handleError threw
  the status away and the only signal left was exception message text. Backward compatible —
  existing callers ignore it. Also useful for #133's violation mapping.

Testing helper
- requel-angular/src/app/shared/testing/a11y.ts: expectNoAxeViolations gains an optional
  `exclude` selector list. Needed because PrimeNG marks the `<p-confirmDialog>` HOST element
  `role="alertdialog"` even when nothing is showing (its container is an empty comment), so axe
  reports an unnamed dialog on every page that mounts one. That is pre-existing and app-wide
  rather than anything these forms control, so the pilots exclude `p-confirmdialog` and the
  finding is filed on #139 (https://github.com/rreganjr/Requel/issues/139) instead of being
  absorbed here. Grep for `p-confirmdialog` to find the exclusions to remove once fixed. The
  alternative — narrowing the assertions to a subtree — would have quietly lost whole-page
  coverage.

e2e
- requel-angular/e2e/pages/FormWizardPage.ts (new): page object for the shared wizard — step
  nav, Continue/Cancel, the alert region, active/locked/complete step state, commitStep,
  skipToStep, finish, and keyboard helpers.
- requel-angular/e2e/pages/GoalEditorPage.ts, StoryEditorPage.ts: the migration broke these.
  They located `#name` / `#text`, but app-field generates ids, so those static ids no longer
  exist. Both now locate by data-testid, and `save()` is mode-aware: on the edit route it is the
  Save button, on the create route there is no Save so it commits Details, skips the optional
  steps and presses Done, landing on the saved entity exactly as the pre-wizard save() did.
  That is what keeps goals.e2e.ts and stories.e2e.ts passing with no changes.
- requel-angular/e2e/form-wizard.e2e.ts (new): 8 tests. Both pilots walked end to end with one
  optional step skipped and an enrichment item added during create; the 409 regression asserted
  on the raw response status for both, so a stale-version bug fails loudly rather than looking
  like a stuck wizard; cancel-on-step-2 leaving the created entity intact (the documented
  consequence of commit-on-step-1); keyboard nav moving focus without changing the step; and the
  edit routes having no wizard chrome, the right app-field count, Save gated on a real change,
  and the shared form-errors message on a cleared required field.
- requel-angular/e2e/sse-refresh.e2e.ts, annotations.e2e.ts, open-issues.e2e.ts,
  actors.e2e.ts: four `#name` / `#text` locators against the migrated editors switched to
  data-testid. The remaining `#name` uses target unmigrated editors (actor, use-case, project,
  account) and are untouched.
- requel-angular/e2e/pages/BaseListPage.ts: `clickTableRow`'s `readySelector` — the "editor is
  populated" wait — defaults to `#name`, and GoalListPage.clickGoal / StoryListPage.clickStory
  both relied on that default, so both broke on the migration. They now pass
  `[data-testid="goal-name"]` / `[data-testid="story-name"]`. The default itself is correct for
  the five unmigrated editors (actor, project, scenario, term, use-case) and is left alone, with
  a comment recording that #132 must flip each one as it migrates. This was the same
  static-id-reached-into-from-e2e class as the four locators above, but one layer up as a
  default parameter value rather than a literal at the call site.

Docs and scripts
- doc/158-form-wizard-field.md: the implementation plan — locked decisions, the version
  contract, the verified-platform-facts table (what the tree actually supports, including the
  p-stepper and Vitest findings), replacement text for the plan's N5 section and the issue
  body, the #132 scope handover, and the points change.
- scripts/set-lookandfeel-points.sh: #158 8 -> 13, so a re-run does not revert the estimate.

Frontend unit suite green: 77 files / 545 tests. Production build clean. e2e typechecks clean
(`npx tsc -p tsconfig.e2e.json`); note the one error it reports, projects.e2e.ts TS4111, is
pre-existing and unrelated.

Closes #158
