### PR TITLE
172: app-field-group — two-column row layout for app-field

### DIFF
--- a/doc/132-reactive-forms-plan.md
+++ b/doc/132-reactive-forms-plan.md
@@ -1,0 +1,515 @@
+# Implementation Plan — #132 3.1 Reactive forms + consistent validation
+
+Part of the UI/UX remediation epic #124. Source: `doc/UI_UX_REVIEW.md` Finding 3.1. Phase 3.
+Follows **N5 #158** (`app-field` + `app-form-wizard` + `form-errors`), which merged as PR #170.
+
+Grounded in `requel-angular` on `release/2.0` at **`4ac9b73`** — i.e. *after* the N5 primitives
+and the Goal/Story pilots landed. The current body of issue #132 was written before that and is
+stale in ways that change the work; §10 lists the ticket edits.
+
+This plan rolls the N5 pattern out to the eleven remaining form surfaces, and takes on three
+things #132's body left ambiguous: the create-flow wizards, the command-error adapter, and a
+two-column row group.
+
+## Decisions (locked)
+
+1. **Wizard where create hides authorable content; rows everywhere else.** The rule is
+   structural: if a create form gates *authorable* fields or add/remove affordances behind
+   `@if (!isNew())`, the user is being asked to save a half-configured entity before they can
+   finish configuring it — that becomes an `app-form-wizard`. If every input is already visible
+   on create, a wizard adds chrome and buys nothing. §1 classifies all eleven; five convert.
+2. **Read-only derived sections are not gated authorable content and do not become steps.**
+   "Referenced By", "Alternate Terms", and `app-annotations-section` render *against* a
+   persisted entity and take no input. They stay gated and stay outside the wizard, exactly as
+   #158 left annotations. This is why `term-editor` and `report-editor` — which do have
+   `!isNew()` blocks — are rows-only, not wizards. §1.3 records that call explicitly so it
+   isn't re-litigated in review.
+3. **Backend `@Size` constraints land first, as a blocker.** There is exactly **one** bean
+   validation size constraint in all of `modules/*/src/main/java` — `UserImpl:385`,
+   `@Size(min = 1)` on roles. No `@Size` and no `@Column(length=…)` on any artifact `name` or
+   `text`; `EditGoalInput` carries only `@NotBlank`. Rather than invent client-side caps,
+   **#171** adds the real constraints and #132 mirrors them. §2.3 specifies that issue and §9
+   covers the sequencing consequence.
+4. **Password rules are `minLength(1)` + `maxLength(128)`, sourced from
+   `UserImpl.MAX_PASSWORD_LENGTH`.** That constant is the only password bound the server
+   enforces (`isValidPassword` = non-blank and `≤ MAX_PASSWORD_LENGTH`). The client mirrors it
+   rather than inventing a stronger policy, so the form never rejects a password the server
+   would accept. A real password policy is a product decision and out of scope.
+5. **#132 ships the command-error adapter; #133 keeps the inline-vs-toast policy.** #132 is the
+   ticket holding all eleven forms, so it is the cheapest place to build `applyCommandErrors`
+   and the name mapping it needs. #133 narrows to where errors *render* (inline for blocking,
+   toast for non-blocking confirmations only) and the `aria-live` behavior. §4 draws the line
+   and §4.2 handles the property-name problem, which is the real work.
+6. **`app-field` gains a two-column group variant.** `project-editor` and `user-editor` stay
+   dense rather than collapsing to a long single-column stack. This amends a primitive #158
+   shipped one commit ago; §5 keeps the change additive so no existing caller changes behavior.
+7. **Dirty checking is derived from the form; every hand-rolled `trackChanges()` is deleted.**
+   All eleven editors implement `DirtyCheckable` with a bespoke change-tracker. Once a control
+   owns the value, `hasUnsavedChanges()` is `this.form.dirty`, and the
+   `(ngModelChange)="trackChanges()"` wiring, the `hasChanges()` signals, and the
+   `detectChanges()` timing workarounds (`user-editor.ts:155-156`, `settings.ts:122-125`) go
+   with them.
+8. **`settings.ts` and `report-editor.ts` are in scope.** Neither appears in #158's
+   out-of-scope enumeration, and `settings.ts:122-125` is cited in #132's own Problems list.
+   They are small and no other ticket would pick them up.
+9. **Split three ways; #132 stays at 8.** `doc/158-form-wizard-field.md` §7 repointed #132 to
+   8 assuming a rows-and-validators sweep, and that number is right — for that scope. The five
+   wizards (§1.1), the two-column variant (§5), and the version-contract hazard the Goal/Story
+   pilots did not face (§3) move to their own issues. #132 keeps the helpers and the six
+   rows-only editors. §9 has the table.
+
+## 1. Inventory and classification
+
+Eleven surfaces remain on `[(ngModel)]`. Applying decisions 1 and 2:
+
+### 1.1 Wizards — create gates authorable content
+
+| Editor | Gated behind `!isNew()` | Steps |
+|---|---|---|
+| `project-editor.ts` | Tags (`app-tag-selector`) | 2 · Details → Tags |
+| `actor-editor.ts` | Goals (add/remove via `app-entity-selector-dialog`) | 2 · Details → Goals |
+| `stakeholder-editor.ts` | Goals | 2 · Details (incl. Permissions) → Goals |
+| `scenario-editor.ts` | **Steps** (add / edit / remove / sub-scenario) | 2 · Details → Steps |
+| `use-case-editor.ts` | Primary Scenario, Additional Scenarios, Goals, Stories, Additional Actors | 4 · Details → Scenarios → Goals & Stories → Actors |
+
+Notes:
+
+- `scenario-editor` is the highest-value conversion in the ticket. Steps *are* the scenario;
+  gating them means today's create flow produces an empty scenario and forces the user to
+  navigate back in to write it.
+- `use-case-editor` is the largest (749 lines, five gated sections) and warrants its own PR.
+- `stakeholder-editor` has two modes (`isUserType()`, user-backed / non-user) and Permissions
+  is *already* visible on create, so only the Goals step is new chrome. The mode selector is
+  `[disabled]="!isNew()"` and must stay on step 1.
+- `actor-editor`'s "Referenced By" tables (use cases, stories) are derived and read-only; they
+  stay edit-only per decision 2.
+
+### 1.2 Rows only — all inputs visible on create
+
+| Editor | Controls | Validators |
+|---|---|---|
+| `term-editor.ts` | Term, Definition, Canonical Term (`p-select`) | name required |
+| `report-editor.ts` | Name, XSLT Template (textarea) | name required |
+| `user-editor.ts` | Username, Name, Email, Phone, Organization, Password, Confirm, Roles + per-role Permissions | username & name required, email format, password 1–128, confirm matches, ≥1 role |
+| `edit-account.ts` | Username (disabled), Name, Email, Phone, Organization, New Password, Confirm | name required, email format, password 1–128 when non-blank, confirm matches |
+| `settings.ts` | Sidebar Project Limit (number), Staleness Threshold (`p-select`) | limit required, integer, ≥1 |
+| `login.ts` | Username, Password | both required |
+
+### 1.3 Why `term-editor` and `report-editor` are not wizards
+
+Both have `!isNew()` blocks, so they look like wizard candidates on a grep. They aren't:
+
+- `term-editor` gates **Alternate Terms** and **Referenced By** — both derived from
+  `term()?.alternateTerms` / `term()?.referers`, both additionally gated on `.length`, and
+  neither editable. Its three inputs are all on screen at create.
+- `report-editor` gates the **Run** button and annotations. Run is an action on a saved
+  template, not a creation step. Its two inputs are both on screen at create.
+
+Wrapping either in wizard chrome would produce a one-step wizard, which is a worse form.
+
+## 2. The validation contract
+
+### 2.1 What `form-errors.ts` gains
+
+N5 shipped the message map for `required | minlength | maxlength | email | pattern` with
+per-field overrides. #132 adds the two cross-field validators the user surfaces need, as
+exported factories so no editor hand-rolls them:
+
+```ts
+/** Cross-field: confirm must equal the password control. Error key: `passwordMismatch`. */
+export function passwordsMatch(passwordKey: string, confirmKey: string): ValidatorFn;
+
+/** At least one selection in a multi-select / checkbox-group control. Error key: `atLeastOne`. */
+export function atLeastOne(): ValidatorFn;
+```
+
+Both need entries in `DEFAULT_FORM_ERRORS` and in `ERROR_PRECEDENCE`.
+
+`passwordMismatch` is a **group-level** error, and `app-field.showError` reads
+`control.invalid` — a group error does not mark its children invalid, so a naive group
+validator renders no message anywhere. Attach the validator to the group *and* have it set the
+error onto the confirm control, which keeps `app-field` unchanged and puts the message under
+the field the user has to fix. Cover this in `form-errors.spec.ts` — it's the failure mode most
+likely to ship silently.
+
+### 2.2 The per-field validator table
+
+| Field | Validator | Source of truth |
+|---|---|---|
+| Any artifact `name` | `required` + `maxLength(n)` | `@NotBlank` today; `n` from **#171** (§2.3) |
+| Any artifact `text` / description | `maxLength(n)` | from **#171** (§2.3) |
+| `emailAddress` | `email` | `type="email"` today; §2.3 should add `@Email` |
+| `password` | `minLength(1)`, `maxLength(128)` | `UserImpl.MAX_PASSWORD_LENGTH` |
+| `repassword` | `passwordsMatch` | client-only concern |
+| Roles | `atLeastOne` | **`UserImpl:385` `@Size(min = 1)`** — already backend-backed |
+| `sidebarProjectLimit` | `required`, `min(1)`, integer | UI concern |
+
+`edit-account`'s password is *optional* ("leave blank to keep current"), so its validators are
+conditional: apply `minLength`/`maxLength`/match only when the control is non-blank.
+
+Keep the numbers in one exported constants module (e.g. `shared/validation-limits.ts`) that
+names its backend source per entry, so the next person can diff it against the annotations
+rather than guessing which numbers are real.
+
+### 2.3 Blocker: backend `@Size` constraints — **#171**
+
+**#132 is blocked by #171.** Scope:
+
+- Add `@Size(max = …)` to the `name` and `text` fields on the `Edit*Input` records in
+  `modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/` and to the
+  corresponding JPA entity fields in `project-jpa` / `user-jpa`.
+- Add `@Email` to the user/account email inputs so the client `email` validator mirrors
+  something.
+- Audit `@Column(length)` on the affected columns and add a Flyway migration wherever a column
+  needs widening to match the chosen `@Size`.
+- Confirm the chosen limits round-trip through XML import/export (`doc/samples/project.xsd`)
+  and the MCP command gateway, both of which accept the same DTOs.
+
+Note for whoever picks it up: `VerbNetFrame` already uses `length = 16277215` for text columns,
+so the artifact text fields are likely effectively unbounded already and most of the real work
+is on `name`. Pick limits deliberately rather than inheriting whatever the DDL happens to say.
+
+Once #171 merges, #132 reads the values into `validation-limits.ts`. The
+`maxlength` message wording already exists in `DEFAULT_FORM_ERRORS`, so no message work is
+needed.
+
+## 3. The version contract for the new wizards — this differs from Goal/Story
+
+`doc/158-form-wizard-field.md` §2 established the rule: capture `id` **and** `version` from
+`result.entity` on the step-1 commit, treat a held version as spent on use, and never carry one
+across two mutations. §2 then narrowed the risk by verifying that the Goal/Story enrichment
+commands *don't* touch the parent's `@Version` — `AssignTagCommandImpl` mutates the `Tag`, and
+`EditGoalRelationCommandImpl` mutates a standalone `GoalRelationImpl`.
+
+**That verification does not carry over.** `AddGoalToGoalContainerCommandImpl.execute()`
+(`modules/project-jpa/.../command/`) ends with:
+
+```java
+addingContainer.getGoals().add(addedGoal);
+addingContainer = getRepository().merge(addingContainer);
+```
+
+The container **is** the actor / stakeholder / use-case being created. Merging it bumps its
+`@Version`. So for three of the five new wizards the Goals step *does* spend the parent's
+version, and the belt-and-braces refetch that #158 deliberately dropped is **required here**.
+
+Requirements for the wizard hosts:
+
+- After **every** step commit — not just step 1 — refresh the held `version` from the command
+  result, or refetch when the command does not return the parent. `AddGoalToGoalContainer`
+  returns the container, so prefer the result.
+- Verify per command rather than assuming. The ones this ticket touches and must be checked:
+  `AddGoalToGoalContainer` / `RemoveGoalFromGoalContainer` (bumps — confirmed),
+  `AddScenarioToUseCase` / `RemoveScenarioFromUseCase`, `SetPrimaryScenarioOnUseCase`,
+  `AddStoryToStoryContainer`, `AddActorToActorContainer`, `EditScenarioStep` /
+  `DeleteScenarioStep` / `CopyScenarioStep` / `ConvertStepToScenario`, and `AssignTag`
+  (verified clean in #158).
+- Keep each editor's existing `if (fromSSE && this.hasUnsavedChanges()) return;` guard intact
+  inside the wizard — an SSE reload must refresh `version` without clobbering the active step.
+  `story-editor` had no such guard until #158 added one, so check each of these five rather
+  than assuming.
+- A 409 keeps the step, refetches, and renders the "changed elsewhere — version refreshed"
+  message in the wizard's `role="alert"` region. Never a silent overwrite, never a dead end.
+
+**Required test per wizard:** create → advance to the last step → mutate an association →
+navigate **back** to step 1 → edit the name → Continue. Asserts success, not 409. This is the
+test that catches the `AddGoalToGoalContainer` bump.
+
+## 4. The command-error adapter (owned here)
+
+### 4.1 The adapter
+
+Add to `src/app/shared/form-errors.ts`:
+
+```ts
+/**
+ * Applies a failed CommandResult's field violations onto a form.
+ *
+ * Violations whose field resolves to a control set `{ server: message }` on that control.
+ * Anything unresolved is returned so the caller can render it page-level — nothing is
+ * ever dropped.
+ */
+export function applyCommandErrors(
+  form: FormGroup,
+  violations: FieldViolation[] | null | undefined,
+  map?: Record<string, string>
+): string[];
+```
+
+- `server` joins `ERROR_PRECEDENCE` last, so a live client-side complaint outranks a stale
+  server one.
+- A `server` error must clear on the next change to that control, or the user is stuck staring
+  at an error they've already fixed with a disabled Save. Wire `valueChanges` per control to
+  drop the `server` key.
+- `FieldViolation.field` is nullable; a null field is command-level and goes straight into the
+  returned array.
+- Return type is deliberately `string[]` rather than `void`: the caller feeds it to
+  `submitError`, which is how nothing gets silently swallowed.
+
+### 4.2 The name-mapping problem — the actual work
+
+`CommandController:136-157` builds `FieldViolation.field` from
+`BeanValidationException.getEntityPropertyNames()` — **JPA entity property names**. The form's
+control names come from the input DTO. They coincide often (`name`, `text`) and diverge exactly
+where it matters (`emailAddress` vs the `email` control id, `encryptedPassword` vs `password`,
+`selectedRoleNames` vs `roles`).
+
+Two ways to close it. Do both, in this order:
+
+1. **Now, in #132:** the optional `map` parameter — a small per-editor
+   `{ entityProperty: controlName }` object living next to that editor's form definition.
+   Eleven small maps, most of them empty. Unresolvable names fall through to page-level, so a
+   missing entry degrades rather than breaks.
+2. **Follow-up issue:** change `CommandController` to emit input-DTO field names instead of
+   entity property names, then delete the maps. One backend change replacing eleven client
+   maps. Worth filing now with a pointer back here, but not worth blocking on — the fallback
+   path makes #132 correct either way.
+
+### 4.3 What stays with #133
+
+- Inline-vs-toast policy: inline `role="alert"` for blocking form/page errors, toasts reserved
+  for non-blocking confirmations, `aria-live="polite"` for success.
+- Retryable inline alert for network failures.
+- Auditing the existing toast sites (`goal-editor.ts:361`, `tag-selector.ts:183`,
+  `annotations-section.ts:311`) against that policy.
+
+The existing `violations` **concatenation** in `project-editor.ts:260-264`,
+`user-editor.ts:273-277`, and `edit-account.ts:178-181` is *replaced* by `applyCommandErrors` in
+this ticket — those three sites are the adapter's first callers.
+
+409 keeps its own path, using the `status` field `CommandService` already carries (see §3).
+
+## 5. The two-column `app-field` group
+
+`project-editor` and `user-editor` are the only two editors on `grid-template-columns: 1fr 1fr`.
+They stay dense (decision 6), which means extending the N5 primitive.
+
+Design constraint: **additive only**. `app-field` shipped one commit ago and `goal-editor` /
+`story-editor` depend on its current behavior. Nothing here changes an existing caller.
+
+```html
+<app-field-group [columns]="2">
+  <app-field label="Username" [control]="form.controls.username"> … </app-field>
+  <app-field label="Name" [control]="form.controls.name"> … </app-field>
+</app-field-group>
+```
+
+- `app-field-group` is a layout-only wrapper: a CSS grid of `columns` tracks that lays out
+  child `app-field` hosts. It owns no label, no error, no ARIA.
+- Each `app-field` keeps its own internal label/control grid, so a cell still reads label-left.
+  Requires a `--rq-field-label-w` narrower inside a group — add a token rather than a literal.
+- `app-field`'s existing `@container (max-width: 30rem)` collapse already stacks label above
+  control per cell. The group needs its own container query to collapse `columns` → 1 first, so
+  a narrow viewport degrades two-column → one-column → stacked, in that order.
+- `divider` interacts badly with multi-column: a hairline under one cell of a two-cell row
+  looks like a mistake. Either the group suppresses child dividers and draws its own per row,
+  or callers pass `[divider]="false"` inside groups. Prefer the former — the group knows where
+  its rows are, the caller shouldn't have to.
+- Needs `app-field-group.spec.ts` and `app-field-group.a11y.spec.ts`. The a11y case that
+  matters: reading order in a screen reader must follow visual order, and each control must
+  still resolve to exactly one label.
+
+If review finds the group fighting the row contract, the documented fallback is single column
+with `app-card` section grouping (Identity / Contact / Password / Roles). Don't hold the
+editor migrations on the group landing — sequence it first (§9) so they aren't blocked.
+
+## 6. Per-editor work plan
+
+Suggested slicing, smallest-risk first, each independently reviewable:
+
+1. **`app-field-group`** (§5) — shared primitive, lands before its consumers.
+2. **`applyCommandErrors` + `passwordsMatch` + `atLeastOne`** (§2.1, §4) — shared helpers with
+   specs, no editor changes yet.
+3. **`login.ts`, `settings.ts`** — 2 controls each, no wizard, no `DirtyCheckable` on login.
+   Establishes the rows-only recipe end-to-end including the adapter.
+4. **`term-editor.ts`, `report-editor.ts`** — rows only; deletes the imperative name checks at
+   `term-editor.ts:277-280` and `report-editor.ts:199-202` that `required` now covers.
+5. **`edit-account.ts`, `user-editor.ts`** — rows + `app-field-group`; the full validator table
+   from §2.2 including conditional password and `atLeastOne` roles; deletes the
+   `detectChanges()` workaround at `user-editor.ts:155-156` and both `1fr 1fr` grids.
+6. **`project-editor.ts`, `actor-editor.ts`** — first two wizards, 2 steps each; `actor-editor`
+   is where the §3 version bump first bites.
+7. **`stakeholder-editor.ts`** — wizard, plus the `isUserType()` mode branch on step 1.
+8. **`scenario-editor.ts`** — wizard with the Steps step, including the step-edit dialog.
+9. **`use-case-editor.ts`** — wizard, 4 steps, largest surface. Own PR.
+
+Every editor PR deletes that editor's local `.form-grid` block (they range from 120px to 160px
+label columns, plus the two `1fr 1fr`) and its `trackChanges()` machinery.
+
+## 7. Tests
+
+Inherits the N5 harness — Vitest via `@angular/build:unit-test`, `TestBed`, and
+`expectNoAxeViolations` from `src/app/shared/testing/a11y.ts`. Per migrated editor:
+
+- **`*.spec.ts`** — validators fire as specified; Save/Continue disabled per decision;
+  `hasUnsavedChanges()` tracks `form.dirty`; the command payload is byte-identical to what the
+  `ngModel` version sent. That last one is the regression that matters: an entity created
+  through the migrated form must equal one created before.
+- **`*.a11y.spec.ts`** — axe clean with a field in its error state, not just at rest. Copy
+  `goal-editor.a11y.spec.ts`.
+- **Per wizard** — the §3 back-navigate-and-re-Continue test. Non-negotiable.
+- **`form-errors.spec.ts`** — extend for `passwordsMatch` (including the group-vs-control
+  placement in §2.1), `atLeastOne`, and `applyCommandErrors`: resolved field → control error,
+  unresolved field → returned string, null field → returned string, `server` error clears on
+  next edit, `server` loses to a live client error.
+- **`app-field-group`** — §5.
+- Remember `p-button` puts `data-testid` on the host: query `[data-testid="x"] button`.
+
+Existing Playwright e2e driving these forms need selector updates where `app-field` generates
+ids (`rq-field-{n}`). Pass `controlId` to keep stable ids on any control an e2e test targets.
+
+## 8. Sequencing
+
+```
+#171 backend @Size (§2.3) ─┐
+      #172 app-field-group ─┤
+              #158 ✅ ─────┴─→ #132 ─┬─→ #173 wizards ─┐
+                                     │                 ├─→ #138 (label/error sweep)
+                                     └─────────────────┘
+                                     └─→ #143, #144
+```
+
+- #132 is **blocked by #171** (decision 3), **#172**, and #158 (merged).
+- #133 no longer blocks #132 — the dependency inverts, since #132 now ships the adapter and
+  #133 consumes the rendering policy question. Update `scripts/update-ui-ux-subissues.sh`
+  accordingly; it currently encodes only `add_blocked_by 132 158` (line 583). That dependency
+  already exists on the issue, and `add_blocked_by` is idempotent, so the line is a no-op —
+  #171 needs adding to the script for the next fresh run.
+- #138 stays blocked by #132, and should gain **#173** as a blocker too.
+- The §4.2 follow-up (backend emits DTO field names) is independent and can land any time
+  after #132.
+
+## 9. Points and splitting
+
+Split three ways, decided 2026-08-04. #132 keeps its existing 8 and the scope that number was
+set for; the two pieces that were never in it get their own issues.
+
+| Issue | Scope | Points |
+|---|---|---|
+| **#171** | Backend `@Size` / `@Email` / column audit + Flyway (§2.3) | 3 |
+| **#172** | `app-field-group` two-column variant (§5) | 3 |
+| **#132** | Helpers (§2.1, §4) + the six rows-only editors (§1.2) | 8 |
+| **#173** | The five create-flow wizards (§1.1, §3) | 8 |
+
+Dependency shape after the split:
+
+- **#172 blocks #132** — `user-editor` and `edit-account` are in #132 and both need the
+  two-column group. It is the smallest piece and should land first.
+- **#132 blocks #173** — the wizards consume `applyCommandErrors`, `passwordsMatch`,
+  `atLeastOne`, and `validation-limits.ts`, all built in #132.
+- **#171 blocks #132** only for the `name`/`text` max-length values. Everything else in #132 is
+  independent of it, so if #171 stalls, ship #132 with `validation-limits.ts` covering only what
+  is already backend-backed (password from `UserImpl.MAX_PASSWORD_LENGTH`, roles from
+  `UserImpl:385`) and add the `name`/`text` entries when #171 merges. One file changes.
+- **#138** should wait on #173 as well as #132, since it sweeps labels and errors across all
+  eleven surfaces.
+
+§6's nine slices map to the split as: slice 1 → #172; slices 2–5 → #132; slices 6–9 → #173.
+
+## 10. Ticket hygiene
+
+### 10.1 #132 as it stands on GitHub
+
+- **"What exists today" is stale.** It cites `goal-editor.ts:76-87` and
+  `story-editor.ts:79-113` as `div.form-grid` + `[(ngModel)]`; both are reactive + `app-field`
+  as of `4ac9b73`. The "few fields have native validators" framing predates N5 too.
+- **No acceptance criteria on the issue.** `scripts/update-ui-ux-subissues.sh:417` defines
+  `append_acceptance 132` with six criteria and none are on the issue — that script has not been
+  run against it, though `create-ui-ux-lookandfeel.sh`'s `append_to_issue 132` *has* (the
+  "Target look-and-feel" paragraph is present). Replace that heredoc with §10.2 before running
+  it. Note the guard at line 82 is body-based: once criteria exist, re-running skips the issue,
+  so the heredoc has to be right before the first run.
+- **Title and body should narrow to the split scope** — the wizards and the group primitive now
+  live in #173 and #172.
+- **Blocked-by links.** #158 and #171 are linked (#158 was already there; re-adding returns
+  HTTP 422 "Target issue has already been taken"). #172 still needs adding.
+- **Story Points: 8**, via `scripts/set-points.sh 132 8`.
+- **The violations bullet stays** in Recommendations — #132 owns it (decision 5) — but should
+  name `applyCommandErrors` and point at §4.2 for the name-mapping caveat.
+
+### 10.2 Acceptance criteria — #132 (helpers + rows-only editors)
+
+- [ ] `login`, `settings`, `term-editor`, `report-editor`, `edit-account`, and `user-editor` use
+      reactive forms and `app-field` rows; no `[(ngModel)]` and no local `.form-grid` remains in
+      any of them.
+- [ ] `form-errors.ts` gains `passwordsMatch`, `atLeastOne`, and `applyCommandErrors`, all with
+      specs; no validation message text lives in a component.
+- [ ] `passwordsMatch` renders its message under the confirm field — the group-level error is
+      also set on the confirm control, since `app-field.showError` reads `control.invalid` and a
+      group error does not mark children invalid. Covered by a spec.
+- [ ] `applyCommandErrors` maps field violations onto controls via the per-editor
+      `{ entityProperty: controlName }` map, returns anything unresolved for page-level display,
+      drops `server` errors on the next edit to that control, loses to a live client-side error
+      in `ERROR_PRECEDENCE`, and replaces the semicolon-joining in `project-editor`,
+      `user-editor`, and `edit-account`.
+- [ ] Validators match the §2.2 table for these six editors, with limits read from
+      `shared/validation-limits.ts` — not hard-coded per editor. Password bounds come from
+      `UserImpl.MAX_PASSWORD_LENGTH`; `name`/`text` bounds come from #171.
+- [ ] `edit-account`'s password validators apply only when the control is non-blank.
+- [ ] Save is disabled when `form.invalid || form.pristine || saving()`.
+- [ ] Inline field errors render via `app-field`, associated by `aria-describedby` /
+      `aria-invalid`; axe clean with fields in the error state, not just at rest.
+- [ ] `hasUnsavedChanges()` derives from `form.dirty` in all six; every `trackChanges()`,
+      `hasChanges()`, and `detectChanges()` change-tracking workaround in them is deleted —
+      including `user-editor.ts:155-156` and `settings.ts:122-125`.
+- [ ] Command-level failures render inline with `role="alert"`, not as a toast.
+- [ ] An entity created through each migrated form is identical to one created by the previous
+      form.
+- [ ] All styling from `--rq-*` tokens; no literals.
+
+### 10.3 Acceptance criteria — #173 (create-flow wizards)
+
+- [ ] `project-editor`, `actor-editor`, `stakeholder-editor`, `scenario-editor`, and
+      `use-case-editor` create flows are `app-form-wizard` flows with the steps in §1.1; their
+      `@if (!isNew())` gates on authorable content are gone.
+- [ ] Read-only derived sections ("Referenced By", annotations) stay gated and stay outside the
+      wizard, per decision 2.
+- [ ] Edit mode for all five uses `app-field` rows with no wizard chrome.
+- [ ] `stakeholder-editor`'s `isUserType()` mode selector stays on step 1 and stays
+      `[disabled]="!isNew()"`.
+- [ ] Held `version` is refreshed from the command result after **every** step commit, not just
+      step 1 — `AddGoalToGoalContainerCommandImpl` merges the container and bumps its
+      `@Version`, so the Goal/Story precedent in `doc/158-form-wizard-field.md` §2 does not
+      carry over.
+- [ ] Each command listed in §3 is verified for whether it bumps the parent's `@Version`, rather
+      than assumed.
+- [ ] Each editor's `if (fromSSE && this.hasUnsavedChanges()) return;` guard survives inside the
+      wizard, so an SSE reload refreshes `version` without clobbering the active step.
+- [ ] A 409 keeps the step, refetches, and renders "changed elsewhere — version refreshed" in
+      the wizard's `role="alert"` region. No silent overwrite, no dead end.
+- [ ] **Per wizard:** create → advance to the last step → mutate an association → navigate back
+      to step 1 → edit the name → Continue succeeds with no 409. This is the test that catches
+      the `AddGoalToGoalContainer` bump.
+- [ ] `hasUnsavedChanges()` derives from `form.dirty`; `trackChanges()` machinery in all five is
+      deleted.
+- [ ] Validators, error rendering, and `applyCommandErrors` reuse the #132 helpers — nothing
+      re-implemented locally.
+- [ ] An entity created through each wizard is identical to one created by the previous form.
+- [ ] axe clean per editor with fields in the error state.
+
+### 10.4 Acceptance criteria — #172 (`app-field-group`)
+
+- [ ] `app-field-group` exists with a `columns` input, is layout-only (no label, no error, no
+      ARIA of its own), and lays out child `app-field` hosts in a CSS grid.
+- [ ] No existing `app-field` caller changes behavior — `goal-editor` and `story-editor` render
+      identically before and after.
+- [ ] Each cell still reads label-left, via a narrower `--rq-field-label-w` token inside a
+      group rather than a literal.
+- [ ] Responsive collapse degrades two-column → one-column → label-above-control, in that
+      order: the group's own container query collapses `columns` first, then `app-field`'s
+      existing `@container (max-width: 30rem)` stacks.
+- [ ] The group suppresses child `divider` and draws its own per row, so a hairline never
+      appears under one cell of a two-cell row.
+- [ ] `app-field-group.spec.ts` and `app-field-group.a11y.spec.ts` exist; the a11y spec asserts
+      screen-reader reading order follows visual order and each control resolves to exactly one
+      label.
+- [ ] Documented fallback if the group fights the row contract: single column with `app-card`
+      section grouping. #132 is not held on the group landing.
+
+### 10.5 Out of scope (all three)
+
+- Mini-forms in annotations, tags, admin tools, and dialogs — **#134**.
+- Inline-vs-toast policy and the toast-site audit — **#133** (§4.3).
+- The broader form-labelling sweep — **#138**.
+- Signal/state hygiene beyond the form itself — **#143**.
+- Changing `CommandController` to emit DTO field names — follow-up issue, §4.2.

--- a/requel-angular/src/app/shared/app-field-group.a11y.spec.ts
+++ b/requel-angular/src/app/shared/app-field-group.a11y.spec.ts
@@ -1,0 +1,133 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { AppFieldComponent, AppFieldControlDirective } from './app-field';
+import { AppFieldGroupComponent } from './app-field-group';
+import { expectNoAxeViolations } from './testing/a11y';
+
+/**
+ * Two-column group with an odd row count, so the partial last row is covered too.
+ * Mirrors the shape `user-editor` will take: identity fields side by side, then a
+ * full-width description row outside the group.
+ */
+@Component({
+  standalone: true,
+  imports: [
+    AppFieldGroupComponent,
+    AppFieldComponent,
+    AppFieldControlDirective,
+    ReactiveFormsModule,
+  ],
+  template: `
+    <form [formGroup]="form">
+      <app-field-group [columns]="2">
+        <app-field label="Username" helper="Lowercase, no spaces." [control]="form.controls.username" [submitted]="submitted">
+          <input appFieldControl formControlName="username" />
+        </app-field>
+        <app-field label="Name" [control]="form.controls.name" [submitted]="submitted">
+          <input appFieldControl formControlName="name" />
+        </app-field>
+        <app-field label="Email" [control]="form.controls.email" [submitted]="submitted">
+          <input appFieldControl type="email" formControlName="email" />
+        </app-field>
+      </app-field-group>
+
+      <app-field label="Organization" [control]="form.controls.organization" [divider]="false">
+        <input appFieldControl formControlName="organization" />
+      </app-field>
+    </form>
+  `,
+})
+class GroupHostComponent {
+  submitted = false;
+  form = new FormGroup({
+    username: new FormControl('', { validators: Validators.required, nonNullable: true }),
+    name: new FormControl('', { validators: Validators.required, nonNullable: true }),
+    email: new FormControl('', { validators: Validators.email, nonNullable: true }),
+    organization: new FormControl('', { nonNullable: true }),
+  });
+}
+
+describe('AppFieldGroupComponent accessibility (issue #172)', () => {
+  function render(configure?: (host: GroupHostComponent) => void): HTMLElement {
+    TestBed.configureTestingModule({ imports: [GroupHostComponent] });
+    const fixture = TestBed.createComponent(GroupHostComponent);
+    configure?.(fixture.componentInstance);
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  it('has no axe-core violations in the pristine state', async () => {
+    await expectNoAxeViolations(render());
+  });
+
+  it('has no axe-core violations while rows are showing validation errors', async () => {
+    const el = render(host => {
+      host.submitted = true;
+      host.form.markAllAsTouched();
+      host.form.controls.email.setValue('not-an-email');
+    });
+    await expectNoAxeViolations(el);
+  });
+
+  it('has no axe-core violations once the form is valid', async () => {
+    const el = render(host => {
+      host.form.setValue({
+        username: 'rregan',
+        name: 'Ron Regan',
+        email: 'ron@example.com',
+        organization: 'Requel',
+      });
+      host.form.markAllAsTouched();
+    });
+    await expectNoAxeViolations(el);
+  });
+
+  /**
+   * The group is a CSS grid, and `grid-auto-flow: row` lays cells out in source
+   * order — so DOM order, which is what assistive tech and sequential focus both
+   * follow, matches the visual left-to-right / top-to-bottom reading order. This
+   * asserts the invariant that makes that true: nothing reorders the cells.
+   */
+  it('keeps DOM order (and so reading and tab order) matching visual order', () => {
+    const el = render();
+    const labels = Array.from(el.querySelectorAll('.app-field-group app-field label')).map(label =>
+      label.textContent?.trim().replace(/\*$/, '')
+    );
+
+    expect(labels).toEqual(['Username', 'Name', 'Email']);
+  });
+
+  it('gives every control in the group exactly one label', () => {
+    const el = render();
+    const controls = Array.from(
+      el.querySelectorAll<HTMLInputElement>('.app-field-group app-field input')
+    );
+
+    expect(controls).toHaveLength(3);
+    for (const control of controls) {
+      const forLabels = el.querySelectorAll(`label[for="${control.id}"]`);
+      expect(control.id).toBeTruthy();
+      expect(forLabels).toHaveLength(1);
+    }
+  });
+
+  it('adds no landmark, group or region semantics of its own', () => {
+    const el = render();
+    const group = el.querySelector('.app-field-group')!;
+
+    expect(group.getAttribute('role')).toBeNull();
+    expect(group.getAttribute('aria-labelledby')).toBeNull();
+    expect(group.getAttribute('aria-describedby')).toBeNull();
+    expect(group.tagName.toLowerCase()).toBe('div');
+  });
+
+  it('associates helper text with its own control only', () => {
+    const el = render();
+    const username = el.querySelector<HTMLInputElement>('input[formcontrolname="username"]')!;
+    const name = el.querySelector<HTMLInputElement>('input[formcontrolname="name"]')!;
+
+    expect(username.getAttribute('aria-describedby')).toBeTruthy();
+    expect(name.getAttribute('aria-describedby')).toBeNull();
+  });
+});

--- a/requel-angular/src/app/shared/app-field-group.spec.ts
+++ b/requel-angular/src/app/shared/app-field-group.spec.ts
@@ -1,0 +1,184 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { AppFieldComponent, AppFieldControlDirective } from './app-field';
+import { AppFieldGroupComponent } from './app-field-group';
+
+/** Group with a variable number of rows, so last-row maths can be exercised. */
+@Component({
+  standalone: true,
+  imports: [
+    AppFieldGroupComponent,
+    AppFieldComponent,
+    AppFieldControlDirective,
+    ReactiveFormsModule,
+  ],
+  template: `
+    <form [formGroup]="form">
+      <app-field-group [columns]="columns">
+        @for (name of visible; track name) {
+          <app-field [label]="name" [control]="form.controls[name]">
+            <input appFieldControl [formControl]="form.controls[name]" [attr.data-row]="name" />
+          </app-field>
+        }
+      </app-field-group>
+    </form>
+  `,
+})
+class GroupHostComponent {
+  columns: number | string = 2;
+  visible: Array<'a' | 'b' | 'c' | 'd'> = ['a', 'b', 'c', 'd'];
+  form = new FormGroup({
+    a: new FormControl('', { validators: Validators.required, nonNullable: true }),
+    b: new FormControl('', { nonNullable: true }),
+    c: new FormControl('', { nonNullable: true }),
+    d: new FormControl('', { nonNullable: true }),
+  });
+}
+
+/** A row outside any group — the regression guard for #158's existing callers. */
+@Component({
+  standalone: true,
+  imports: [AppFieldComponent, AppFieldControlDirective, ReactiveFormsModule],
+  template: `
+    <app-field label="Name" [control]="control">
+      <input appFieldControl [formControl]="control" />
+    </app-field>
+  `,
+})
+class UngroupedHostComponent {
+  control = new FormControl('', { validators: Validators.required, nonNullable: true });
+}
+
+describe('AppFieldGroupComponent (issue #172)', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [GroupHostComponent, UngroupedHostComponent] });
+  });
+
+  /**
+   * Host inputs are set BEFORE the first change-detection pass — mutating them
+   * afterwards raises NG0100 under the zoneless TestBed. Same constraint as
+   * app-field.spec.ts; where a test needs a mid-run change it re-creates the
+   * fixture instead.
+   */
+  function render(
+    configure?: (host: GroupHostComponent) => void
+  ): ComponentFixture<GroupHostComponent> {
+    const fixture = TestBed.createComponent(GroupHostComponent);
+    configure?.(fixture.componentInstance);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  const rows = (fixture: ComponentFixture<unknown>) =>
+    Array.from((fixture.nativeElement as HTMLElement).querySelectorAll('app-field'));
+
+  const grid = (fixture: ComponentFixture<unknown>) =>
+    (fixture.nativeElement as HTMLElement).querySelector<HTMLElement>('.app-field-group');
+
+  it('publishes the column count as a custom property for the global grid rule', () => {
+    const fixture = render();
+    expect(grid(fixture)?.style.getPropertyValue('--rq-field-group-columns')).toBe('2');
+  });
+
+  it('coerces a string column count', () => {
+    const fixture = render(host => (host.columns = '3'));
+    expect(grid(fixture)?.style.getPropertyValue('--rq-field-group-columns')).toBe('3');
+  });
+
+  it.each([0, -1, Number.NaN, 'nonsense'])(
+    'falls back to a single column for the invalid value %p',
+    value => {
+      const fixture = render(host => (host.columns = value as number));
+      expect(grid(fixture)?.style.getPropertyValue('--rq-field-group-columns')).toBe('1');
+    }
+  );
+
+  it('tags every projected row as a cell', () => {
+    const fixture = render();
+    expect(rows(fixture)).toHaveLength(4);
+    for (const row of rows(fixture)) {
+      expect(row.classList.contains('rq-field-cell')).toBe(true);
+    }
+  });
+
+  it('suppresses the divider on a full last row and nowhere else', () => {
+    const fixture = render();
+    const lastRow = rows(fixture).map(row => row.classList.contains('rq-field-cell-last-row'));
+    // 4 rows over 2 columns: the final line holds rows 3 and 4.
+    expect(lastRow).toEqual([false, false, true, true]);
+  });
+
+  it('suppresses the divider on a partial last row, so no hairline stops mid-row', () => {
+    const fixture = render(host => (host.visible = ['a', 'b', 'c']));
+    const lastRow = rows(fixture).map(row => row.classList.contains('rq-field-cell-last-row'));
+    // 3 rows over 2 columns: the final line holds row 3 alone.
+    expect(lastRow).toEqual([false, false, true]);
+  });
+
+  it('treats a single row as its own last row', () => {
+    const fixture = render(host => (host.visible = ['a']));
+    expect(rows(fixture)[0].classList.contains('rq-field-cell-last-row')).toBe(true);
+  });
+
+  it('moves the divider boundary when the column count changes', () => {
+    const fixture = render(host => (host.columns = 4));
+    // 4 rows over 4 columns: one line, so every row is a last row.
+    expect(
+      rows(fixture).map(row => row.classList.contains('rq-field-cell-last-row'))
+    ).toEqual([true, true, true, true]);
+  });
+
+  it('re-tags rows when the projected set changes after content init', () => {
+    const fixture = render();
+    fixture.componentInstance.visible = ['a', 'b', 'c'];
+    fixture.detectChanges();
+
+    const lastRow = rows(fixture).map(row => row.classList.contains('rq-field-cell-last-row'));
+    expect(lastRow).toEqual([false, false, true]);
+  });
+
+  it('renders no group markup and stays inert with no rows', () => {
+    const fixture = render(host => (host.visible = []));
+    expect(rows(fixture)).toHaveLength(0);
+    expect(grid(fixture)).not.toBeNull();
+  });
+
+  it('leaves nothing stamped on the rows when the group is destroyed', () => {
+    const fixture = render();
+    const [firstRow] = rows(fixture);
+    expect(firstRow.classList.contains('rq-field-cell')).toBe(true);
+
+    fixture.destroy();
+
+    expect(firstRow.classList.contains('rq-field-cell')).toBe(false);
+    expect(firstRow.classList.contains('rq-field-cell-last-row')).toBe(false);
+  });
+
+  it('owns no label, error or ARIA of its own', () => {
+    const fixture = render();
+    const group = grid(fixture)!;
+    expect(group.getAttribute('role')).toBeNull();
+    expect(group.getAttribute('aria-label')).toBeNull();
+    expect(group.querySelector(':scope > label')).toBeNull();
+    expect(group.querySelector(':scope > [data-testid="field-error"]')).toBeNull();
+  });
+
+  it('leaves each row owning its own label and error', () => {
+    const fixture = render(host => host.form.controls.a.markAsTouched());
+    const [firstRow] = rows(fixture);
+
+    expect(firstRow.querySelector('label')).not.toBeNull();
+    expect(firstRow.querySelector('[data-testid="field-error"]')).not.toBeNull();
+  });
+
+  it('does not change how an ungrouped row renders', () => {
+    const fixture = TestBed.createComponent(UngroupedHostComponent);
+    fixture.detectChanges();
+    const row = (fixture.nativeElement as HTMLElement).querySelector('app-field')!;
+
+    expect(row.classList.contains('rq-field-cell')).toBe(false);
+    expect(row.classList.contains('rq-field-cell-last-row')).toBe(false);
+    expect(row.querySelector('.app-field-bordered')).not.toBeNull();
+  });
+});

--- a/requel-angular/src/app/shared/app-field-group.ts
+++ b/requel-angular/src/app/shared/app-field-group.ts
@@ -1,0 +1,177 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import {
+  AfterContentInit,
+  Component,
+  ContentChildren,
+  ElementRef,
+  Input,
+  OnChanges,
+  OnDestroy,
+  QueryList,
+} from '@angular/core';
+import { Subscription } from 'rxjs';
+import { AppFieldComponent } from './app-field';
+
+/** Marks a projected row so the global `.app-field-group` rules can reach it. */
+const CELL_CLASS = 'rq-field-cell';
+
+/** Marks rows on the final grid line, which draw no divider. */
+const LAST_ROW_CLASS = 'rq-field-cell-last-row';
+
+/**
+ * Multi-column layout wrapper for {@link AppFieldComponent} rows (issue #172).
+ *
+ * `project-editor` and `user-editor` are the two editors on
+ * `grid-template-columns: 1fr 1fr`; migrating them to single-column `app-field`
+ * rows would turn a dense form into a long scroll. This wrapper keeps them dense
+ * without changing anything about `app-field` itself — #158 shipped that primitive
+ * one commit ago and `goal-editor` / `story-editor` depend on its current
+ * behaviour, so this component is purely additive: a group with no rows, or a
+ * row outside a group, behaves exactly as before.
+ *
+ * It is layout only. It owns no label, no error, no ARIA — each `app-field` keeps
+ * its own label/control/error association, so a cell still reads label-left and a
+ * screen reader still resolves exactly one label per control.
+ *
+ * Usage:
+ * ```html
+ * <app-field-group [columns]="2">
+ *   <app-field label="Username" [control]="form.controls.username">
+ *     <input pInputText appFieldControl [formControl]="form.controls.username" />
+ *   </app-field>
+ *   <app-field label="Name" [control]="form.controls.name">
+ *     <input pInputText appFieldControl [formControl]="form.controls.name" />
+ *   </app-field>
+ * </app-field-group>
+ * ```
+ *
+ * Two things live outside this file by necessity:
+ *
+ * - **The grid and divider rules are global** (`src/styles.scss`, keyed on
+ *   `.app-field-group` / `.rq-field-cell`). Projected content carries the *host*
+ *   template's encapsulation attribute rather than this component's, so a
+ *   component-local rule cannot select it. #126 removed the codebase's
+ *   `:host ::ng-deep` blocks for exactly this case and put the styling in
+ *   `styles.scss` behind a class hook; this follows that.
+ * - **The responsive collapse is a container query**, not a TS breakpoint, so the
+ *   group degrades two-column -> one-column -> label-above-control without a
+ *   resize listener. `:host` establishes the query container below.
+ */
+@Component({
+  selector: 'app-field-group',
+  standalone: true,
+  template: `
+    <div class="app-field-group" [style.--rq-field-group-columns]="columnCount">
+      <ng-content />
+    </div>
+  `,
+  styles: [
+    `
+      /* container-type establishes the container the global @container rule targets. */
+      :host {
+        display: block;
+        container-type: inline-size;
+      }
+    `,
+  ],
+})
+export class AppFieldGroupComponent implements AfterContentInit, OnChanges, OnDestroy {
+  /**
+   * Number of columns to lay rows out in. Values below 1, and anything
+   * non-numeric, fall back to a single column rather than producing an invalid
+   * `repeat()`.
+   */
+  @Input() columns: number | string = 2;
+
+  /**
+   * The projected rows, read as elements so the divider hooks can be stamped on
+   * them. Read as `ElementRef` rather than `AppFieldComponent` because nothing
+   * here touches a row's inputs — mutating a child's `divider` from a parent
+   * content hook is what causes NG0100 under the zoneless TestBed, and hiding the
+   * row's own divider through a custom property avoids the whole problem.
+   */
+  @ContentChildren(AppFieldComponent, { read: ElementRef })
+  private cells?: QueryList<ElementRef<HTMLElement>>;
+
+  private subscription?: Subscription;
+
+  /** `columns`, coerced and floored at 1. */
+  get columnCount(): number {
+    const parsed = Math.trunc(Number(this.columns));
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+  }
+
+  ngAfterContentInit(): void {
+    this.markCells();
+    // Rows behind @if / @for arrive and leave after content init.
+    this.subscription = this.cells?.changes.subscribe(() => this.markCells());
+  }
+
+  ngOnChanges(): void {
+    // A `columns` change moves the last grid line, so the divider hooks move too.
+    // Runs before ngAfterContentInit on the first pass, when `cells` is still
+    // undefined; markCells is a no-op then and the content hook does the work.
+    this.markCells();
+  }
+
+  ngOnDestroy(): void {
+    this.subscription?.unsubscribe();
+    // The rows belong to the caller's template and can outlive this group, so
+    // leave nothing of ours on them — same contract app-field keeps for the ARIA
+    // attributes it stamps.
+    this.cells?.forEach(ref => {
+      ref.nativeElement.classList.remove(CELL_CLASS, LAST_ROW_CLASS);
+    });
+  }
+
+  /**
+   * Tags every projected row, and tags the ones on the final grid line so they
+   * draw no divider.
+   *
+   * Suppressing the last row is what keeps a hairline from appearing under a
+   * single cell of a two-cell row: with an odd number of rows the final line
+   * holds one cell, and a border there would stop halfway across the group.
+   *
+   * Known limitation: the row maths uses `columns`, not the *rendered* column
+   * count, so once the container query has collapsed the group to one column the
+   * final `columns`-worth of rows are all treated as the last line and none of
+   * them draws a divider. Correcting that would mean observing the rendered
+   * layout (ResizeObserver) purely for a hairline; the collapsed state reads as a
+   * plain stack either way, so it is left as is.
+   */
+  private markCells(): void {
+    const cells = this.cells?.toArray() ?? [];
+    const count = cells.length;
+    if (!count) {
+      return;
+    }
+
+    const columns = this.columnCount;
+    const firstIndexOfLastRow = Math.floor((count - 1) / columns) * columns;
+
+    cells.forEach((ref, index) => {
+      const element = ref.nativeElement;
+      element.classList.add(CELL_CLASS);
+      element.classList.toggle(LAST_ROW_CLASS, index >= firstIndexOfLastRow);
+    });
+  }
+}

--- a/requel-angular/src/styles.scss
+++ b/requel-angular/src/styles.scss
@@ -106,8 +106,19 @@
   // tokens so app-field introduces no new colour literals — the divider reuses the
   // card border so a stack of rows matches the surface it sits on, and the error /
   // required marker colours read the same red ramp stop as --rq-tag-danger-fg.
-  --rq-field-label-w: 7.5rem;
-  --rq-field-divider: var(--rq-card-border);
+  // The label measure is named twice: --rq-field-label-w is the effective value a
+  // row reads, and the -wide / -compact pair are the two named stops. A group
+  // (#172) rebinds the effective value to the compact stop for its cells and back
+  // to the wide stop once it has collapsed to one column; that round trip needs a
+  // name to return to, which an overridden --rq-field-label-w cannot provide.
+  --rq-field-label-w-wide: 7.5rem;
+  --rq-field-label-w-compact: 6rem;
+  --rq-field-label-w: var(--rq-field-label-w-wide);
+  // Same reason: a group cell hides the row's own divider by rebinding
+  // --rq-field-divider, so the group's replacement hairline reads the base name.
+  --rq-field-divider-base: var(--rq-card-border);
+  --rq-field-divider: var(--rq-field-divider-base);
+  --rq-field-group-gap: var(--rq-space-6);
   --rq-field-error-fg: var(--rq-tag-danger-fg);
   --rq-field-required-fg: var(--rq-tag-danger-fg);
 
@@ -289,6 +300,64 @@ html, body {
 // Entity-selector dialog type filter keeps a stable minimum width.
 .type-filter-select {
   min-width: 130px;
+}
+
+// -------------------------------------------------------------------------
+// Form row group (issue #172)
+//
+// app-field-group lays out app-field rows in columns so the two dense editors
+// (project, user) stay side-by-side instead of collapsing to a long scroll.
+//
+// These rules are global rather than component-local because the rows are
+// PROJECTED content: they carry the host template's encapsulation attribute, not
+// app-field-group's, so an encapsulated rule cannot select them. #126 removed the
+// codebase's `:host ::ng-deep` blocks for exactly this situation and moved the
+// styling here behind a class hook - same approach. app-field-group stamps
+// .rq-field-cell on every projected row and .rq-field-cell-last-row on the rows of
+// the final grid line.
+// -------------------------------------------------------------------------
+
+.app-field-group {
+  display: grid;
+  // minmax(0, 1fr) rather than 1fr: a long unbroken value in one cell would
+  // otherwise widen its track and push the other column out of alignment.
+  grid-template-columns: repeat(var(--rq-field-group-columns, 2), minmax(0, 1fr));
+  column-gap: var(--rq-field-group-gap);
+  // The group owns the row dividers, so rows must butt together vertically.
+  row-gap: 0;
+  // A half-width cell has too little room for the wide label measure.
+  --rq-field-label-w: var(--rq-field-label-w-compact);
+}
+
+.app-field-group > .rq-field-cell {
+  // The row's own hairline is hidden rather than switched off via [divider]:
+  // it keeps occupying its 1px, so every row in the group stays the same height
+  // whether or not it is the one drawing the visible line. Switching the input off
+  // from a parent content hook is also what triggers NG0100 under the zoneless
+  // TestBed.
+  --rq-field-divider: transparent;
+  // Drawn on the cell, so a full row's two borders meet across the column gap and
+  // read as one hairline spanning the group.
+  border-bottom: 1px solid var(--rq-field-divider-base);
+}
+
+// The final grid line draws nothing. With an odd row count that line holds a
+// single cell, and a border there would stop halfway across the group.
+.app-field-group > .rq-field-cell-last-row {
+  border-bottom: none;
+}
+
+// Collapse to one column BEFORE app-field's own 30rem query stacks label above
+// control, so the degradation reads two-column -> one-column -> stacked in that
+// order. Breakpoints are literals because a @container condition cannot read a
+// custom property - the same constraint app-field's 30rem rule documents.
+@container (max-width: 40rem) {
+  .app-field-group {
+    grid-template-columns: minmax(0, 1fr);
+    column-gap: 0;
+    // One column per row means the wide label measure fits again.
+    --rq-field-label-w: var(--rq-field-label-w-wide);
+  }
 }
 
 // -------------------------------------------------------------------------


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/172

app-field-group: two-column row layout for app-field, so the dense editors stay dense

Adds the `app-field-group` layout wrapper split out of #132 (see doc/132-reactive-forms-plan.md
§5 and §9). `project-editor` and `user-editor` are the only two editors on
`grid-template-columns: 1fr 1fr`; migrating them to single-column `app-field` rows would turn a
dense form into a long scroll, so the rows need a multi-column container before those migrations
land. This is the smallest piece of the #132 split and the one that blocks the rest of it.

Purely additive by design. `app-field` shipped one commit ago in #158 and `goal-editor` /
`story-editor` depend on its current behaviour, so nothing here changes an existing caller: a row
outside a group renders exactly as before, and a group with no rows is inert. Covered by a
regression test that renders an ungrouped row and asserts it keeps its own divider and carries
none of the group's hooks.

Closes #172. Blocks #132. Part of the UI/UX remediation epic #124, Phase 3.

New component
- requel-angular/src/app/shared/app-field-group.ts: `app-field-group`, a layout-only wrapper with
  a `columns` input. It owns no label, no error and no ARIA — each `app-field` keeps its own
  label/control/error association, so a cell still reads label-left and a screen reader still
  resolves exactly one label per control. `columns` is coerced and floored at 1 so a bad value
  degrades to a single column instead of emitting an invalid `repeat()`.

  It publishes the column count as `--rq-field-group-columns` and stamps two class hooks on the
  projected rows: `.rq-field-cell` on every row, and `.rq-field-cell-last-row` on the rows of the
  final grid line. Both are removed again on destroy, since the rows belong to the caller's
  template and can outlive the group — the same contract `app-field` keeps for the ARIA attributes
  it stamps.

  Rows are queried with `{ read: ElementRef }` rather than as `AppFieldComponent`, deliberately:
  nothing here touches a row's inputs. Switching a child's `divider` off from a parent content hook
  is what raises NG0100 under the zoneless TestBed, and hiding the row's own hairline through a
  custom property (below) avoids the problem entirely rather than working around it.

Styling lives in styles.scss, not the component
- requel-angular/src/styles.scss: the grid, cell and divider rules are global, keyed on
  `.app-field-group` / `.rq-field-cell`. The rows are PROJECTED content, so they carry the host
  template's encapsulation attribute rather than `app-field-group`'s, and an encapsulated rule
  cannot select them. #126 removed this codebase's `:host ::ng-deep` blocks for exactly this
  situation and moved the styling into styles.scss behind a class hook; this follows that rather
  than reintroducing an encapsulation-piercing selector.

Token change: two measures gain named stops
- `--rq-field-label-w` is now `var(--rq-field-label-w-wide)`, with `--rq-field-label-w-compact`
  alongside it, and `--rq-field-divider` is now `var(--rq-field-divider-base)`. A group rebinds the
  effective value for its cells (compact label, transparent divider) and rebinds it BACK once the
  container query has collapsed it to one column. That round trip needs a name to return to, which
  an overridden custom property cannot provide — hence the base/stop pair. Existing callers read
  the same computed values, which `app-field`'s own specs confirm.

Dividers: hidden, not switched off
- A group cell sets `--rq-field-divider: transparent`, so the row's hairline keeps occupying its
  1px and every row stays the same height whether or not it is the one drawing the visible line.
  The group then draws its own `border-bottom` on each cell, so a full row's two borders meet
  across the column gap and read as one hairline spanning the group instead of a fragment under a
  single cell.
- The final grid line draws nothing. With an odd row count that line holds one cell, and a border
  there would stop halfway across the group — which is the exact defect the group exists to avoid.
  The boundary index is computed from the row count and `columns`, so it is correct for any column
  count, and it is recomputed when rows arrive or leave behind `@if` / `@for`.
- Known limitation, documented in the component: the boundary maths uses `columns`, not the
  RENDERED column count, so once the container query has collapsed the group the final
  `columns`-worth of rows all skip their divider. Correcting it means observing layout with a
  ResizeObserver purely to place a hairline; the collapsed state reads as a plain stack either way.

Responsive collapse is a container query, not a breakpoint
- The group collapses to one column at 40rem, BEFORE `app-field`'s existing 30rem query stacks
  label above control, so the degradation reads two-column -> one-column -> stacked in that order.
  `:host` establishes the query container. The breakpoints are literals because a `@container`
  condition cannot read a custom property — the same constraint `app-field`'s 30rem rule already
  documents.

Tests
- requel-angular/src/app/shared/app-field-group.spec.ts (17 tests): column-count coercion including
  the invalid cases; cell tagging; divider suppression for a full last row, a partial last row, a
  single row, and a single-line group; re-tagging when the projected set changes after content init;
  cleanup on destroy; that the group adds no label, error or ARIA of its own; and the regression
  guard that an ungrouped row is untouched.
- requel-angular/src/app/shared/app-field-group.a11y.spec.ts (7 tests): axe clean pristine, while
  rows are showing validation errors, and once valid; DOM order matches visual order, which is what
  makes reading order and sequential focus follow the grid; every control resolves to exactly one
  label; no landmark or group semantics added; helper text associated with its own control only.

Not verifiable in these suites, and left for review in a real browser: jsdom has no layout engine,
so the collapse ORDER and the continuous-hairline APPEARANCE are asserted structurally — the rules
exist and the hooks land — rather than visually. Nothing consumes the group until #132 migrates
`user-editor` and `edit-account`, which is the first point at which there is something to look at.

Also included
- doc/132-reactive-forms-plan.md: the plan this branch works from, covering the whole #132 split
  (#171 backend constraints, #172 this issue, #132 helpers + rows-only editors, #173 wizards). §5
  is the design for this component and §10.4 its acceptance criteria.

Verification
- cd requel-angular && npm test -- --watch=false: 79 files, 569 tests, all green (24 of them new).
- ng build --configuration production: bundle generation complete.
- No backend module touched, so `mvn clean verify` is not implicated.
