### PR TITLE
132: 3.1 Reactive forms + consistent validation (six rows-only editors + shared validators)

### DIFF
--- a/doc/132-reactive-forms-plan.md
+++ b/doc/132-reactive-forms-plan.md
@@ -270,7 +270,7 @@ Two ways to close it. Do both, in this order:
    `{ entityProperty: controlName }` object living next to that editor's form definition.
    Eleven small maps, most of them empty. Unresolvable names fall through to page-level, so a
    missing entry degrades rather than breaks.
-2. **Follow-up issue:** change `CommandController` to emit input-DTO field names instead of
+2. **Follow-up: #176.** Change `CommandController` to emit input-DTO field names instead of
    entity property names, then delete the maps. One backend change replacing eleven client
    maps. Worth filing now with a pointer back here, but not worth blocking on — the fallback
    path makes #132 correct either way.
@@ -399,7 +399,7 @@ resolves to nothing. Update `UserEditorPage.ts:90` and `account.e2e.ts:56` to
   already exists on the issue, and `add_blocked_by` is idempotent, so the line is a no-op —
   #171 needs adding to the script for the next fresh run.
 - #138 stays blocked by #132, and should gain **#173** as a blocker too.
-- The §4.2 follow-up (backend emits DTO field names) is independent and can land any time
+- **#176** (§4.2, backend emits DTO field names) is independent and can land any time
   after #132.
 
 ## 9. Points and splitting
@@ -535,4 +535,4 @@ Dependency shape after the split:
 - Inline-vs-toast policy and the toast-site audit — **#133** (§4.3).
 - The broader form-labelling sweep — **#138**.
 - Signal/state hygiene beyond the form itself — **#143**.
-- Changing `CommandController` to emit DTO field names — follow-up issue, §4.2.
+- Changing `CommandController` to emit DTO field names — **#176** (§4.2).

--- a/doc/132-reactive-forms-plan.md
+++ b/doc/132-reactive-forms-plan.md
@@ -239,8 +239,18 @@ export function applyCommandErrors(
 - `server` joins `ERROR_PRECEDENCE` last, so a live client-side complaint outranks a stale
   server one.
 - A `server` error must clear on the next change to that control, or the user is stuck staring
-  at an error they've already fixed with a disabled Save. Wire `valueChanges` per control to
-  drop the `server` key.
+  at an error they've already fixed with a disabled Save.
+
+  **Implemented as a validator, not `setErrors` — and this matters more than it looks.**
+  Angular's `updateValueAndValidity` reassigns `errors` from the validator result, so a
+  directly-written key is dropped the next time validation runs. That gives the clear-on-edit
+  behaviour for free, but validation also runs on **render**: `setUpControl` revalidates
+  whenever a `[formControl]` directive initialises. Measured during slice 5 — a server
+  violation mapped onto `user-editor`'s `roleNames` (bound to its role checkboxes via
+  `[formControl]`) read back as `null` after a single `detectChanges()`, i.e. the user would
+  never have seen it. So `applyCommandErrors` attaches a validator closed over a snapshot of
+  the rejected value: it reports while the value is unchanged, returns null once edited, and
+  survives revalidation either way. `clearServerErrors` detaches it.
 - `FieldViolation.field` is nullable; a null field is command-level and goes straight into the
   returned array.
 - Return type is deliberately `string[]` rather than `void`: the caller feeds it to
@@ -357,6 +367,19 @@ Inherits the N5 harness — Vitest via `@angular/build:unit-test`, `TestBed`, an
 
 Existing Playwright e2e driving these forms need selector updates where `app-field` generates
 ids (`rq-field-{n}`). Pass `controlId` to keep stable ids on any control an e2e test targets.
+
+**The concrete list, found while migrating `login`.** `#username` and `#password` are shared
+across three page objects — `e2e/pages/LoginPage.ts:11`, `e2e/pages/UserEditorPage.ts:55,90,128,132`
+and `e2e/account.e2e.ts:31,32,47,56` — so those two ids are a contract, not an implementation
+detail. `login` therefore keeps `controlId="username"` / `controlId="password"` rather than
+taking prefixed ids, and no e2e change was needed.
+
+`user-editor` and `edit-account` (slice 5) have a subtler version of the same problem: today
+`#password` is the **`p-password` host** and the tests reach the real input with
+`.locator('#password').locator('input')`. Once those editors pass `controlId="password"` +
+`inputId="password"`, `#password` becomes the inner input itself and that chained locator
+resolves to nothing. Update `UserEditorPage.ts:90` and `account.e2e.ts:56` to
+`.locator('#password')` in the same PR, or the e2e failure will look like a form bug.
 
 ## 8. Sequencing
 

--- a/requel-angular/e2e/account.e2e.ts
+++ b/requel-angular/e2e/account.e2e.ts
@@ -53,10 +53,11 @@ test.describe('Edit account', () => {
     await pg1.waitForLoadState('domcontentloaded');
 
     // p-password needs pressSequentially to fire per-char input events for Angular's CVA
-    const pwInput = pg1.locator('#password').locator('input');
+    // #password is now the real input, not the p-password host (issue #132).
+    const pwInput = pg1.locator('#password');
     await pwInput.focus();
     await pwInput.pressSequentially(newPassword);
-    const rpwInput = pg1.locator('#repassword').locator('input');
+    const rpwInput = pg1.locator('#repassword');
     await rpwInput.focus();
     await rpwInput.pressSequentially(newPassword);
 

--- a/requel-angular/e2e/pages/TermEditorPage.ts
+++ b/requel-angular/e2e/pages/TermEditorPage.ts
@@ -85,10 +85,26 @@ export class TermEditorPage {
     await expect(this.page.locator('#text')).toHaveValue(text);
   }
 
-  /** Wait for the validation/error <p-message> to render with the given text. */
+  /**
+   * Wait for the PAGE-LEVEL <p-message> to render with the given text. Since #132 this
+   * carries only failures with no field to attach to — a command-level rejection or a
+   * violation whose property does not map to a control. A field's own complaint renders
+   * inline instead; use expectFieldError for those.
+   */
   async expectErrorMessage(message: string | RegExp): Promise<void> {
     await expect(this.page.getByTestId('term-error')).toBeVisible();
     await expect(this.page.getByTestId('term-error')).toContainText(message);
+  }
+
+  /**
+   * Wait for an inline field error under one of the app-field rows (#132). app-field
+   * stamps every one with data-testid="field-error", so this matches the first — the
+   * editor's rows are asserted in order and Term is the first row.
+   */
+  async expectFieldError(message: string | RegExp): Promise<void> {
+    const error = this.page.getByTestId('field-error').first();
+    await expect(error).toBeVisible();
+    await expect(error).toContainText(message);
   }
 
   /**

--- a/requel-angular/e2e/pages/UserEditorPage.ts
+++ b/requel-angular/e2e/pages/UserEditorPage.ts
@@ -87,10 +87,12 @@ export class UserEditorPage {
     // focus() is used instead of click() so that an open p-select dropdown (from org field)
     // does not intercept the action — focus() calls element.focus() directly, bypassing
     // Playwright's overlay intercept check.
-    const pwInput = this.page.locator('#password').locator('input');
+    // #password / #repassword are now the real inputs: app-field puts the caller's
+    // controlId on the inner input rather than the p-password host (issue #132).
+    const pwInput = this.page.locator('#password');
     await pwInput.focus();
     await pwInput.pressSequentially(password);
-    const rpwInput = this.page.locator('#repassword').locator('input');
+    const rpwInput = this.page.locator('#repassword');
     await rpwInput.focus();
     await rpwInput.pressSequentially(password);
   }

--- a/requel-angular/e2e/terms.e2e.ts
+++ b/requel-angular/e2e/terms.e2e.ts
@@ -94,11 +94,17 @@ test.describe('Glossary term management', () => {
   });
 
   test('save with empty name shows validation error and does not save', async ({ adminContext }) => {
-    // Drives the early-return branch in onSave():
-    //   if (!this.name.trim()) { this.errorMessage.set('Term name is required.'); return; }
-    // Also exercises the <p-message data-testid="term-error"> render that was previously
-    // never visible in any covered E2E run. We don't tie a fixture to the test because
-    // no term is created — the save attempt is rejected client-side.
+    // Since #132 this asserts the *user-visible* guard rather than onSave()'s early
+    // return, because that return is no longer reachable from the UI: Save is disabled
+    // while the form is invalid, and Enter does not submit either — implicit submission
+    // goes through the form's default button, which is that same disabled Save. The
+    // early return survives as defence in depth and is covered by term-editor.spec.ts.
+    //
+    // What the user sees instead: a `required` validator rendering INLINE under the Term
+    // row via app-field, with wording from the shared map in form-errors.ts ('This field
+    // is required.', not the old bespoke 'Term name is required.'). The page-level
+    // <p-message data-testid="term-error"> is now reserved for failures with no field to
+    // attach to. No fixture is needed because no term is created.
     const page = await adminContext.newPage();
     const listPage = new TermListPage(page);
     const editorPage = new TermEditorPage(page);
@@ -109,11 +115,14 @@ test.describe('Glossary term management', () => {
     // Definition only — leave the name blank.
     await editorPage.fillText('A term with no name.');
 
-    // Click save without filling Name. saveNew() expects a URL change which won't
-    // happen (the early-return prevents the API call), so we click directly and
-    // assert the inline error instead.
-    await page.getByTestId('term-save').click();
-    await editorPage.expectErrorMessage('Term name is required.');
+    // Touching the empty Term field is what surfaces its error — app-field deliberately
+    // does not shout at a create form nobody has filled in yet.
+    const nameInput = page.locator('#name');
+    await nameInput.click();
+    await nameInput.blur();
+
+    await editorPage.expectFieldError('This field is required.');
+    await expect(page.getByTestId('term-save').locator('button')).toBeDisabled();
 
     // Confirm we stayed on /terms/new (no URL change) — proves the save was blocked
     // before the API was invoked.

--- a/requel-angular/src/app/features/auth/login.a11y.spec.ts
+++ b/requel-angular/src/app/features/auth/login.a11y.spec.ts
@@ -1,0 +1,62 @@
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+import { LoginComponent } from './login';
+import { AuthService } from '../../core/auth.service';
+import { expectNoAxeViolations } from '../../shared/testing/a11y';
+
+describe('LoginComponent accessibility (issue #132)', () => {
+  function render(): { el: HTMLElement; comp: LoginComponent; detect: () => void } {
+    TestBed.configureTestingModule({
+      imports: [LoginComponent],
+      providers: [
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: AuthService, useValue: { login: vi.fn().mockResolvedValue(undefined) } },
+      ],
+    });
+    const fixture = TestBed.createComponent(LoginComponent);
+    fixture.detectChanges();
+    return {
+      el: fixture.nativeElement as HTMLElement,
+      comp: fixture.componentInstance,
+      detect: () => fixture.detectChanges(),
+    };
+  }
+
+  it('has no axe-core violations at rest', async () => {
+    const { el } = render();
+    await expectNoAxeViolations(el);
+  });
+
+  it('has no axe-core violations with both fields in their error state', async () => {
+    const { el, comp, detect } = render();
+    await comp.onLogin();
+    detect();
+
+    expect(el.querySelectorAll('[data-testid="field-error"]')).toHaveLength(2);
+    await expectNoAxeViolations(el);
+  });
+
+  it('has no axe-core violations with a page-level login failure showing', async () => {
+    const { el, comp, detect } = render();
+    comp.errorMessage.set('Invalid credentials');
+    detect();
+    await expectNoAxeViolations(el);
+  });
+
+  it('associates each error with its control via aria-describedby / aria-invalid', async () => {
+    const { el, comp, detect } = render();
+    await comp.onLogin();
+    detect();
+
+    const username = el.querySelector<HTMLInputElement>('#username')!;
+    expect(username.getAttribute('aria-invalid')).toBe('true');
+
+    const describedBy = username.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(el.querySelector(`#${describedBy}`)?.textContent?.trim()).toBe(
+      'This field is required.'
+    );
+  });
+});

--- a/requel-angular/src/app/features/auth/login.spec.ts
+++ b/requel-angular/src/app/features/auth/login.spec.ts
@@ -6,12 +6,10 @@ import { AuthService } from '../../core/auth.service';
 
 describe('LoginComponent', () => {
   let authServiceMock: { login: ReturnType<typeof vi.fn> };
-  let routerNavigateMock: ReturnType<typeof vi.fn>;
   let comp: LoginComponent;
 
   beforeEach(() => {
     authServiceMock = { login: vi.fn().mockResolvedValue(undefined) };
-    routerNavigateMock = vi.fn().mockResolvedValue(true);
 
     TestBed.configureTestingModule({
       imports: [LoginComponent],
@@ -19,11 +17,16 @@ describe('LoginComponent', () => {
         provideNoopAnimations(),
         provideRouter([]),
         { provide: AuthService, useValue: authServiceMock },
-      ]
+      ],
     });
     const fixture = TestBed.createComponent(LoginComponent);
     comp = fixture.componentInstance;
   });
+
+  /** Fills the reactive form the way a user would leave it. */
+  function fill(username: string, password: string): void {
+    comp.form.setValue({ username, password });
+  }
 
   it('renders exactly one <h1> page title and no <h2> (issue #135)', () => {
     const fixture = TestBed.createComponent(LoginComponent);
@@ -35,15 +38,13 @@ describe('LoginComponent', () => {
   });
 
   it('onLogin() calls authService.login with the entered credentials', async () => {
-    comp.username.set('admin');
-    comp.password.set('secret');
+    fill('admin', 'secret');
     await comp.onLogin();
     expect(authServiceMock.login).toHaveBeenCalledWith({ username: 'admin', password: 'secret' });
   });
 
   it('clears errorMessage and sets loading=false after successful login', async () => {
-    comp.username.set('admin');
-    comp.password.set('secret');
+    fill('admin', 'secret');
     await comp.onLogin();
     expect(comp.errorMessage()).toBeNull();
     expect(comp.loading()).toBe(false);
@@ -51,10 +52,105 @@ describe('LoginComponent', () => {
 
   it('sets errorMessage when authService.login throws', async () => {
     authServiceMock.login.mockRejectedValue(new Error('Invalid credentials'));
-    comp.username.set('admin');
-    comp.password.set('wrong');
+    fill('admin', 'wrong');
     await comp.onLogin();
     expect(comp.errorMessage()).toBe('Invalid credentials');
     expect(comp.loading()).toBe(false);
+  });
+
+  describe('reactive form (issue #132)', () => {
+    it('starts invalid with both fields required', () => {
+      expect(comp.form.invalid).toBe(true);
+      expect(comp.form.controls.username.hasError('required')).toBe(true);
+      expect(comp.form.controls.password.hasError('required')).toBe(true);
+    });
+
+    it('becomes valid once both fields have values', () => {
+      fill('admin', 'secret');
+      expect(comp.form.valid).toBe(true);
+    });
+
+    it.each([
+      ['', 'secret'],
+      ['admin', ''],
+      ['', ''],
+    ])('stays invalid for username=%p password=%p', (username, password) => {
+      fill(username, password);
+      expect(comp.form.invalid).toBe(true);
+    });
+
+    it('renders the submit button disabled while the form is invalid', () => {
+      const fixture = TestBed.createComponent(LoginComponent);
+      fixture.detectChanges();
+      const button = (fixture.nativeElement as HTMLElement).querySelector<HTMLButtonElement>(
+        '[data-testid="login-submit"] button'
+      );
+      expect(button?.disabled).toBe(true);
+    });
+
+    /**
+     * A disabled button does not stop Enter from submitting the form, so the guard has
+     * to live in onLogin too — otherwise a blank submit would reach the auth endpoint.
+     */
+    it('does not call the auth service when submitted while invalid', async () => {
+      await comp.onLogin();
+      expect(authServiceMock.login).not.toHaveBeenCalled();
+    });
+
+    it('marks fields touched and submitted on an invalid submit, so errors show', async () => {
+      await comp.onLogin();
+      expect(comp.submitted()).toBe(true);
+      expect(comp.form.controls.username.touched).toBe(true);
+      expect(comp.form.controls.password.touched).toBe(true);
+    });
+
+    it('shows the inline required error after an invalid submit', () => {
+      const fixture = TestBed.createComponent(LoginComponent);
+      fixture.detectChanges();
+      void fixture.componentInstance.onLogin();
+      fixture.detectChanges();
+
+      const errors = (fixture.nativeElement as HTMLElement).querySelectorAll(
+        '[data-testid="field-error"]'
+      );
+      expect(errors).toHaveLength(2);
+      expect(errors[0].textContent?.trim()).toBe('This field is required.');
+    });
+
+    it('shows no inline errors before any interaction', () => {
+      const fixture = TestBed.createComponent(LoginComponent);
+      fixture.detectChanges();
+      expect(
+        (fixture.nativeElement as HTMLElement).querySelectorAll('[data-testid="field-error"]')
+      ).toHaveLength(0);
+    });
+
+    it('re-enables the form after a failed login so the user can retry', async () => {
+      authServiceMock.login.mockRejectedValue(new Error('Invalid credentials'));
+      fill('admin', 'wrong');
+      await comp.onLogin();
+      expect(comp.form.enabled).toBe(true);
+    });
+
+    it('binds each label to its control (issue #138)', () => {
+      const fixture = TestBed.createComponent(LoginComponent);
+      fixture.detectChanges();
+      const el = fixture.nativeElement as HTMLElement;
+
+      const labels = Array.from(el.querySelectorAll('label'));
+      expect(labels.map(l => l.getAttribute('for'))).toEqual(['username', 'password']);
+      expect(el.querySelector('#username')).not.toBeNull();
+    });
+
+    it('keeps the autocomplete hints password managers rely on', () => {
+      const fixture = TestBed.createComponent(LoginComponent);
+      fixture.detectChanges();
+      const el = fixture.nativeElement as HTMLElement;
+
+      expect(el.querySelector('#username')?.getAttribute('autocomplete')).toBe('username');
+      expect(
+        el.querySelector('p-password input')?.getAttribute('autocomplete')
+      ).toBe('current-password');
+    });
   });
 });

--- a/requel-angular/src/app/features/auth/login.ts
+++ b/requel-angular/src/app/features/auth/login.ts
@@ -19,7 +19,7 @@
  *
  */
 import { Component, signal } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { InputText } from 'primeng/inputtext';
 import { Password } from 'primeng/password';
@@ -27,11 +27,21 @@ import { ButtonModule } from 'primeng/button';
 import { MessageModule } from 'primeng/message';
 import { AuthService } from '../../core/auth.service';
 import { AppCardComponent } from '../../shared/app-card';
+import { AppFieldComponent, AppFieldControlDirective } from '../../shared/app-field';
 
 @Component({
   selector: 'app-login',
   standalone: true,
-  imports: [FormsModule, InputText, Password, ButtonModule, MessageModule, AppCardComponent],
+  imports: [
+    ReactiveFormsModule,
+    InputText,
+    Password,
+    ButtonModule,
+    MessageModule,
+    AppCardComponent,
+    AppFieldComponent,
+    AppFieldControlDirective,
+  ],
   template: `
     <div class="login-container">
       <app-card class="login-card">
@@ -42,71 +52,142 @@ import { AppCardComponent } from '../../shared/app-card';
           <p-message severity="error" [text]="errorMessage()!" />
         }
 
-        <form (ngSubmit)="onLogin()">
-          <div class="field">
-            <label for="username">Username</label>
-            <input pInputText id="username" [(ngModel)]="username" name="username"
-                   [disabled]="loading()" autocomplete="username" />
-          </div>
+        <form [formGroup]="form" (ngSubmit)="onLogin()">
+          <!--
+            No dividers: two rows in a login card read as one block, and a hairline
+            between them is chrome this form does not need. The card is 400px, under
+            app-field's 30rem container query, so each row stacks label above control
+            on its own — which is what a login form should look like.
+          -->
+          <app-field
+            label="Username"
+            controlId="username"
+            [control]="form.controls.username"
+            [submitted]="submitted()"
+            [divider]="false"
+          >
+            <input
+              pInputText
+              appFieldControl
+              id="username"
+              formControlName="username"
+              autocomplete="username"
+            />
+          </app-field>
 
-          <div class="field">
-            <label for="password">Password</label>
-            <p-password id="password" [(ngModel)]="password" name="password"
-                        [disabled]="loading()" [feedback]="false" [toggleMask]="true"
-                        autocomplete="current-password" />
-          </div>
+          <app-field
+            label="Password"
+            controlId="password"
+            [control]="form.controls.password"
+            [submitted]="submitted()"
+            [divider]="false"
+          >
+            <p-password
+              appFieldControl
+              inputId="password"
+              formControlName="password"
+              [feedback]="false"
+              [toggleMask]="true"
+              autocomplete="current-password"
+            />
+          </app-field>
 
-          <p-button type="submit" label="Login" [loading]="loading()"
-                    [disabled]="!username() || !password()" styleClass="w-full" />
+          <p-button
+            type="submit"
+            label="Login"
+            data-testid="login-submit"
+            [loading]="loading()"
+            [disabled]="form.invalid || loading()"
+            styleClass="w-full"
+          />
         </form>
       </app-card>
     </div>
   `,
-  styles: [`
-    .login-container {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      min-height: 100vh;
-      background: var(--p-surface-ground);
-    }
-    /* The surface (bg, padding, border, radius, shadow) comes from app-card
-       (issue #156); only the login-specific width constraint stays here. */
-    .login-card {
-      display: block;
-      width: 100%;
-      max-width: 400px;
-    }
-    h1 { margin: 0 0 0.25rem; text-align: center; font-size: 1.5rem; }
-    .subtitle { text-align: center; color: var(--p-text-muted-color); margin: 0 0 1.5rem; }
-    .field { margin-bottom: 1rem; }
-    .field label { display: block; margin-bottom: 0.5rem; font-weight: 500; }
-    .field input, .field p-password { width: 100%; }
-  `]
+  styles: [
+    `
+      .login-container {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        min-height: 100vh;
+        background: var(--p-surface-ground);
+      }
+      /* The surface (bg, padding, border, radius, shadow) comes from app-card
+         (issue #156); only the login-specific width constraint stays here. */
+      .login-card {
+        display: block;
+        width: 100%;
+        max-width: 400px;
+      }
+      h1 {
+        margin: 0 0 var(--rq-space-1);
+        text-align: center;
+        font-size: var(--rq-text-h1-size);
+      }
+      .subtitle {
+        text-align: center;
+        color: var(--p-text-muted-color);
+        margin: 0 0 var(--rq-space-6);
+      }
+      /* The controls are this component's own nodes, projected through app-field, so
+         they still carry this component's encapsulation attribute and an ordinary
+         rule reaches them. app-field owns the row; the caller owns control width. */
+      input,
+      p-password {
+        width: 100%;
+      }
+    `,
+  ],
 })
 export class LoginComponent {
+  /**
+   * Both fields are required, which is the whole client-side contract — the server
+   * decides whether the credentials are *correct*, and that answer arrives as a
+   * page-level error rather than a field one (see {@link onLogin}).
+   */
+  readonly form = new FormGroup({
+    username: new FormControl('', { validators: Validators.required, nonNullable: true }),
+    password: new FormControl('', { validators: Validators.required, nonNullable: true }),
+  });
 
-  readonly username = signal('');
-  readonly password = signal('');
+  readonly submitted = signal(false);
   readonly loading = signal(false);
   readonly errorMessage = signal<string | null>(null);
 
-  constructor(private authService: AuthService, private router: Router) {}
+  constructor(
+    private authService: AuthService,
+    private router: Router
+  ) {}
 
   async onLogin(): Promise<void> {
+    this.submitted.set(true);
+    if (this.form.invalid) {
+      // Submit can still fire on Enter even with the button disabled.
+      this.form.markAllAsTouched();
+      return;
+    }
+
     this.loading.set(true);
     this.errorMessage.set(null);
+    // Disabled rather than left editable mid-request, matching the previous
+    // `[disabled]="loading()"` on each input. Done here instead of in the template
+    // because binding `disabled` on a reactive control is what Angular warns about.
+    this.form.disable({ emitEvent: false });
     try {
-      await this.authService.login({
-        username: this.username(),
-        password: this.password()
-      });
+      const { username, password } = this.form.getRawValue();
+      await this.authService.login({ username, password });
       await this.router.navigate(['/']);
     } catch (err: unknown) {
+      // A failed login is about the credential *pair*, not about one field — there is
+      // no field to attach it to, so it stays page-level. This is also why login does
+      // not use applyCommandErrors: /auth/login is not a command endpoint and returns
+      // no field violations.
       this.errorMessage.set(
         err instanceof Error ? err.message : 'Login failed. Check your credentials.'
       );
     } finally {
+      this.form.enable({ emitEvent: false });
       this.loading.set(false);
     }
   }

--- a/requel-angular/src/app/features/reports/report-editor.a11y.spec.ts
+++ b/requel-angular/src/app/features/reports/report-editor.a11y.spec.ts
@@ -1,0 +1,92 @@
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter, ActivatedRoute, convertToParamMap, Router } from '@angular/router';
+import { BehaviorSubject } from 'rxjs';
+import { MessageService } from 'primeng/api';
+import { ReportEditorComponent } from './report-editor';
+import { ReportService } from '../../core/report.service';
+import { PermissionService } from '../../core/permission.service';
+import { expectNoAxeViolations } from '../../shared/testing/a11y';
+
+const MOCK_REPORT = {
+  id: 7, version: 0, name: 'Requirements Doc', text: '<xsl:stylesheet>...</xsl:stylesheet>'
+};
+
+const flush = () => new Promise(r => setTimeout(r, 0));
+
+/** Same exclusion as term-editor.a11y.spec.ts, for the same reason. */
+const EXCLUDE = ['p-confirmdialog'];
+
+describe('ReportEditorComponent accessibility (issue #132)', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fixture: any;
+  let comp: ReportEditorComponent;
+
+  async function render(reportId = 'new'): Promise<HTMLElement> {
+    const paramMap$ = new BehaviorSubject(convertToParamMap({ name: 'proj1', reportId }));
+    TestBed.configureTestingModule({
+      imports: [ReportEditorComponent],
+      providers: [
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: ActivatedRoute, useValue: { paramMap: paramMap$.asObservable() } },
+        {
+          provide: ReportService,
+          useValue: {
+            getReport: vi.fn().mockResolvedValue(MOCK_REPORT),
+            saveReport: vi.fn().mockResolvedValue({ success: true, entity: MOCK_REPORT }),
+            deleteReport: vi.fn().mockResolvedValue({ success: true }),
+            downloadReport: vi.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: PermissionService,
+          useValue: {
+            loadForProject: vi.fn().mockResolvedValue(undefined),
+            canEdit: vi.fn().mockReturnValue(true),
+            canDelete: vi.fn().mockReturnValue(true),
+          },
+        },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
+    });
+    fixture = TestBed.createComponent(ReportEditorComponent);
+    comp = fixture.componentInstance;
+    vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+    fixture.detectChanges();
+    await flush();
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  it('has no axe-core violations on the create form', async () => {
+    await expectNoAxeViolations(await render('new'), EXCLUDE);
+  });
+
+  it('has no axe-core violations on the edit form', async () => {
+    await expectNoAxeViolations(await render('7'), EXCLUDE);
+  });
+
+  it('has no axe-core violations with the name field in its error state', async () => {
+    const el = await render('new');
+    await comp.onSave();
+    fixture.detectChanges();
+
+    expect(el.querySelector('[data-testid="field-error"]')).not.toBeNull();
+    await expectNoAxeViolations(el, EXCLUDE);
+  });
+
+  /**
+   * The XSLT row projects a textarea *and* the upload button into one control column.
+   * Worth an axe pass of its own: the label must still resolve to the textarea rather
+   * than being ambiguous between the two controls in the cell.
+   */
+  it('labels the textarea, not the upload button beside it', async () => {
+    const el = await render('7');
+    const label = el.querySelector<HTMLLabelElement>('label[for="text"]');
+
+    expect(label?.textContent?.trim()).toContain('XSLT Template');
+    expect(el.querySelector('#text')?.tagName.toLowerCase()).toBe('textarea');
+    await expectNoAxeViolations(el, EXCLUDE);
+  });
+});

--- a/requel-angular/src/app/features/reports/report-editor.spec.ts
+++ b/requel-angular/src/app/features/reports/report-editor.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter, Router, ActivatedRoute, convertToParamMap } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
-import { ConfirmationService, MessageService } from 'primeng/api';
+import { MessageService } from 'primeng/api';
 import { ReportEditorComponent } from './report-editor';
 import { ReportService } from '../../core/report.service';
 import { PermissionService } from '../../core/permission.service';
@@ -59,6 +59,11 @@ describe('ReportEditorComponent', () => {
     vi.spyOn(router, 'navigate').mockResolvedValue(true);
   });
 
+  function fill(name: string, text = ''): void {
+    comp.form.setValue({ name, text });
+    comp.form.markAsDirty();
+  }
+
   it('isNew() is true when reportId param is "new"', async () => {
     fixture.detectChanges();
     await flush();
@@ -73,27 +78,17 @@ describe('ReportEditorComponent', () => {
     expect(reportServiceMock.getReport).toHaveBeenCalledWith('proj1', 7);
     expect(comp.reportName()).toBe('Requirements Doc');
     expect(comp.reportId()).toBe(7);
-    expect(comp.name).toBe('Requirements Doc');
+    expect(comp.form.controls.name.value).toBe('Requirements Doc');
   });
 
   it('onSave calls reportService.saveReport with name and text', async () => {
     fixture.detectChanges();
     await flush();
-    comp.name = 'My Template';
-    comp.text = '<xsl:stylesheet/>';
+    fill('My Template', '<xsl:stylesheet/>');
     await comp.onSave();
     expect(reportServiceMock.saveReport).toHaveBeenCalledWith(
       'proj1', null, 'My Template', '<xsl:stylesheet/>'
     );
-  });
-
-  it('onSave sets errorMessage when name is empty', async () => {
-    fixture.detectChanges();
-    await flush();
-    comp.name = '';
-    await comp.onSave();
-    expect(comp.errorMessage()).toBe('Document name is required.');
-    expect(reportServiceMock.saveReport).not.toHaveBeenCalled();
   });
 
   it('onRun calls reportService.downloadReport', async () => {
@@ -103,5 +98,173 @@ describe('ReportEditorComponent', () => {
     await comp.onRun();
     expect(reportServiceMock.downloadReport).toHaveBeenCalledWith('proj1', 7, 'Requirements Doc');
     expect(comp.running()).toBe(false);
+  });
+
+  describe('reactive form (issue #132)', () => {
+    it('loads the document into the form and leaves it pristine', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', reportId: '7' }));
+      fixture.detectChanges();
+      await flush();
+
+      expect(comp.form.getRawValue()).toEqual({
+        name: 'Requirements Doc',
+        text: '<xsl:stylesheet>...</xsl:stylesheet>',
+      });
+      expect(comp.form.pristine).toBe(true);
+    });
+
+    it('does not save an empty name, and reports it inline rather than page-level', async () => {
+      fixture.detectChanges();
+      await flush();
+      fill('');
+
+      await comp.onSave();
+
+      expect(reportServiceMock.saveReport).not.toHaveBeenCalled();
+      expect(comp.errorMessage()).toBeNull();
+      expect(comp.form.controls.name.hasError('required')).toBe(true);
+      expect(comp.submitted()).toBe(true);
+    });
+
+    it('sends null rather than an empty string for an empty template', async () => {
+      fixture.detectChanges();
+      await flush();
+      fill('Doc', '');
+
+      await comp.onSave();
+
+      expect(reportServiceMock.saveReport).toHaveBeenCalledWith('proj1', null, 'Doc', null);
+    });
+
+    it('hasUnsavedChanges() derives from form.dirty', async () => {
+      fixture.detectChanges();
+      await flush();
+      expect(comp.hasUnsavedChanges()).toBe(false);
+
+      comp.form.controls.text.setValue('changed');
+      comp.form.controls.text.markAsDirty();
+      expect(comp.hasUnsavedChanges()).toBe(true);
+    });
+
+    it('disables Save while pristine', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', reportId: '7' }));
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+
+      const button = (fixture.nativeElement as HTMLElement).querySelector<HTMLButtonElement>(
+        '[data-testid="report-save"] button'
+      );
+      expect(button?.disabled).toBe(true);
+    });
+
+    it('keeps the #name and #text ids the e2e page objects locate', async () => {
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+      const el = fixture.nativeElement as HTMLElement;
+
+      expect(el.querySelector('input#name')).not.toBeNull();
+      expect(el.querySelector('textarea#text')).not.toBeNull();
+    });
+  });
+
+  describe('XSLT upload (issue #132)', () => {
+    /** Minimal FileReader stand-in — jsdom's needs a real Blob and fires async. */
+    function stubFileReader(contents: string): void {
+      class StubReader {
+        result: string | null = null;
+        onload: (() => void) | null = null;
+        readAsText(): void {
+          this.result = contents;
+          this.onload?.();
+        }
+      }
+      vi.stubGlobal('FileReader', StubReader);
+    }
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('puts the uploaded text in the form and marks it dirty so Save enables', async () => {
+      fixture.detectChanges();
+      await flush();
+      stubFileReader('<xsl:stylesheet>uploaded</xsl:stylesheet>');
+
+      comp.onFileUpload(new File([''], 'my-template.xsl'));
+
+      expect(comp.form.controls.text.value).toBe('<xsl:stylesheet>uploaded</xsl:stylesheet>');
+      expect(comp.form.dirty).toBe(true);
+    });
+
+    it('derives the name from the filename only when the name is empty', async () => {
+      fixture.detectChanges();
+      await flush();
+      stubFileReader('<xsl/>');
+
+      comp.onFileUpload(new File([''], 'my-template.xsl'));
+      expect(comp.form.controls.name.value).toBe('my-template');
+    });
+
+    it('leaves an existing name alone', async () => {
+      fixture.detectChanges();
+      await flush();
+      fill('Chosen name');
+      stubFileReader('<xsl/>');
+
+      comp.onFileUpload(new File([''], 'my-template.xsl'));
+      expect(comp.form.controls.name.value).toBe('Chosen name');
+    });
+  });
+
+  describe('command error handling (issue #132)', () => {
+    it('puts a field violation on its control instead of the page message', async () => {
+      reportServiceMock.saveReport.mockResolvedValue({
+        success: false,
+        violations: [{ field: 'name', message: 'A document with that name already exists.' }],
+        error: 'Validation failed',
+      });
+      fixture.detectChanges();
+      await flush();
+      fill('Duplicate');
+
+      await comp.onSave();
+
+      expect(comp.form.controls.name.errors).toEqual({
+        server: 'A document with that name already exists.',
+      });
+      expect(comp.errorMessage()).toBeNull();
+    });
+
+    it('puts a text violation on the template control', async () => {
+      reportServiceMock.saveReport.mockResolvedValue({
+        success: false,
+        violations: [{ field: 'text', message: 'Not well-formed XSLT.' }],
+        error: 'Validation failed',
+      });
+      fixture.detectChanges();
+      await flush();
+      fill('Doc', '<not-xslt>');
+
+      await comp.onSave();
+
+      expect(comp.form.controls.text.errors).toEqual({ server: 'Not well-formed XSLT.' });
+    });
+
+    it('shows a command-level failure page-level', async () => {
+      reportServiceMock.saveReport.mockResolvedValue({
+        success: false,
+        violations: [{ field: null, message: 'Validation failed.' }],
+        error: 'Validation failed',
+      });
+      fixture.detectChanges();
+      await flush();
+      fill('Doc');
+
+      await comp.onSave();
+
+      expect(comp.errorMessage()).toBe('Validation failed.');
+    });
   });
 });

--- a/requel-angular/src/app/features/reports/report-editor.ts
+++ b/requel-angular/src/app/features/reports/report-editor.ts
@@ -24,7 +24,7 @@ import { AppCardComponent } from '../../shared/app-card';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
-import { FormsModule } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
 import { InputText } from 'primeng/inputtext';
 import { TextareaModule } from 'primeng/textarea';
@@ -36,12 +36,35 @@ import { ReportService } from '../../core/report.service';
 import { PermissionService } from '../../core/permission.service';
 import { AnnotationsSectionComponent } from '../../shared/annotations-section';
 import { FileUploadButtonComponent } from '../../shared/file-upload-button';
+import { AppFieldComponent, AppFieldControlDirective } from '../../shared/app-field';
+import { applyCommandErrors, clearServerErrors } from '../../shared/form-errors';
+
+/**
+ * JPA entity property name -> form control name, for {@link applyCommandErrors}.
+ *
+ * Empty because `ReportGeneratorImpl`'s `name` and `text` properties already match the
+ * control names. Declared rather than omitted so the convention is visible: when a
+ * violation arrives for a property this form calls something else, it goes here.
+ */
+const REPORT_FIELD_MAP: Record<string, string> = {};
 
 @Component({
   selector: 'app-report-editor',
   standalone: true,
-  imports: [PageHeaderComponent, AppCardComponent, FormsModule, ButtonModule, InputText, TextareaModule, MessageModule,
-            ConfirmDialogModule, AnnotationsSectionComponent, FileUploadButtonComponent],
+  imports: [
+    PageHeaderComponent,
+    AppCardComponent,
+    ReactiveFormsModule,
+    ButtonModule,
+    InputText,
+    TextareaModule,
+    MessageModule,
+    ConfirmDialogModule,
+    AnnotationsSectionComponent,
+    FileUploadButtonComponent,
+    AppFieldComponent,
+    AppFieldControlDirective,
+  ],
   providers: [ConfirmationService],
   template: `
     <div class="report-editor" data-testid="report-editor">
@@ -66,26 +89,60 @@ import { FileUploadButtonComponent } from '../../shared/file-upload-button';
       }
 
       <app-card>
-        <div class="form-grid">
-          <label for="name">Name</label>
-          <input id="name" pInputText [(ngModel)]="name" placeholder="Template name" />
+        <form [formGroup]="form" (ngSubmit)="onSave()">
+          <!-- controlId "name" / "text": ReportEditorPage and BaseListPage's default
+               readySelector locate #name and #text, so those ids stay stable. -->
+          <app-field
+            label="Name"
+            controlId="name"
+            [control]="form.controls.name"
+            [submitted]="submitted()"
+          >
+            <input
+              id="name"
+              pInputText
+              appFieldControl
+              formControlName="name"
+              placeholder="Template name"
+            />
+          </app-field>
 
-          <label for="text">XSLT Template</label>
-          <div class="xslt-field">
-            <textarea id="text" pTextarea [(ngModel)]="text" rows="20"
-                      placeholder="Paste XSLT stylesheet here..." class="xslt-textarea"></textarea>
-            <div class="upload-row">
-              <app-file-upload-button label="Upload XSLT" [outlined]="true" size="small"
-                                      accept=".xsl,.xslt,.xml" (fileSelected)="onFileUpload($event)" />
-              <span class="upload-hint">Upload a .xsl/.xslt file to replace the template text.</span>
+          <app-field
+            label="XSLT Template"
+            controlId="text"
+            [control]="form.controls.text"
+            [submitted]="submitted()"
+            [divider]="false"
+          >
+            <div class="xslt-field">
+              <textarea
+                id="text"
+                pTextarea
+                appFieldControl
+                formControlName="text"
+                rows="20"
+                placeholder="Paste XSLT stylesheet here..."
+                class="xslt-textarea"
+              ></textarea>
+              <div class="upload-row">
+                <app-file-upload-button label="Upload XSLT" [outlined]="true" size="small"
+                                        accept=".xsl,.xslt,.xml" (fileSelected)="onFileUpload($event)" />
+                <span class="upload-hint">Upload a .xsl/.xslt file to replace the template text.</span>
+              </div>
             </div>
-          </div>
-        </div>
+          </app-field>
 
-        <div class="form-actions">
-          <p-button label="Save" icon="pi pi-check" data-testid="report-save" (onClick)="onSave()" [loading]="saving()"
-                    [disabled]="!isNew() && !isDirty()" />
-        </div>
+          <div class="form-actions">
+            <p-button
+              type="submit"
+              label="Save"
+              icon="pi pi-check"
+              data-testid="report-save"
+              [loading]="saving()"
+              [disabled]="form.invalid || form.pristine || saving()"
+            />
+          </div>
+        </form>
       </app-card>
 
       @if (!isNew()) {
@@ -100,15 +157,15 @@ import { FileUploadButtonComponent } from '../../shared/file-upload-button';
     <p-confirmDialog />
   `,
   styles: [`
-    .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
-    .page-actions { display: flex; gap: 0.5rem; }
-    .form-grid { display: grid; grid-template-columns: 140px 1fr; gap: 0.75rem 1rem; align-items: start; max-width: 900px; margin-bottom: 1rem; }
-    .form-grid label { font-weight: 600; padding-top: 0.4rem; }
-    .xslt-field { display: flex; flex-direction: column; gap: 0.5rem; }
-    .xslt-textarea { width: 100%; font-family: monospace; font-size: 12px; }
-    .upload-row { display: flex; align-items: center; gap: 0.75rem; }
-    .upload-hint { font-size: 12px; color: var(--p-text-secondary-color); }
-    .form-actions { margin-bottom: 1.5rem; }
+    .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--rq-space-4); }
+    .page-actions { display: flex; gap: var(--rq-space-2); }
+    /* The local .form-grid (140px label column) is gone; app-field owns the rows now. */
+    .xslt-field { display: flex; flex-direction: column; gap: var(--rq-space-2); }
+    .xslt-textarea { width: 100%; font-family: monospace; font-size: var(--rq-font-size-xs); }
+    app-field input { width: 100%; }
+    .upload-row { display: flex; align-items: center; gap: var(--rq-space-3); }
+    .upload-hint { font-size: var(--rq-font-size-xs); color: var(--p-text-secondary-color); }
+    .form-actions { margin-block: var(--rq-space-4) var(--rq-space-6); }
   `]
 })
 export class ReportEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
@@ -116,22 +173,19 @@ export class ReportEditorComponent implements OnInit, OnDestroy, DirtyCheckable 
   reportName = signal('');
   reportId = signal<number | null>(null);
   saving = signal(false);
+  submitted = signal(false);
   running = signal(false);
   errorMessage = signal<string | null>(null);
 
-  name = '';
-  text = '';
-
-  private originalName = '';
-  private originalText = '';
+  /** `text` has no maxLength until #171 supplies a real one to mirror. */
+  readonly form = new FormGroup({
+    name: new FormControl('', { validators: Validators.required, nonNullable: true }),
+    text: new FormControl('', { nonNullable: true }),
+  });
 
   projectName = '';
   canEdit = signal(false);
   canDelete = signal(false);
-
-  isDirty(): boolean {
-    return this.name !== this.originalName || this.text !== this.originalText;
-  }
 
   private paramSub?: Subscription;
 
@@ -156,14 +210,11 @@ export class ReportEditorComponent implements OnInit, OnDestroy, DirtyCheckable 
 
       // Reset the form synchronously for the new-report path BEFORE the
       // loadForProject await. Otherwise typing during the yield would later
-      // be clobbered by the reset and Angular change-detection would clear
-      // the input. See term-editor.ts for the same pattern.
+      // be clobbered by the reset. See term-editor.ts for the same pattern.
       if (newIsNew) {
         this.reportId.set(null);
-        this.name = '';
-        this.text = '';
-        this.originalName = '';
-        this.originalText = '';
+        this.submitted.set(false);
+        this.form.reset({ name: '', text: '' });
       }
 
       await this.permissionService.loadForProject(this.projectName);
@@ -176,8 +227,9 @@ export class ReportEditorComponent implements OnInit, OnDestroy, DirtyCheckable 
     });
   }
 
+  /** Derived from the form, so there is no change-tracker to keep in step (#132). */
   hasUnsavedChanges(): boolean {
-    return this.isDirty();
+    return this.form.dirty;
   }
 
   ngOnDestroy(): void {
@@ -190,37 +242,57 @@ export class ReportEditorComponent implements OnInit, OnDestroy, DirtyCheckable 
       this.report.set(r);
       this.reportId.set(r.id);
       this.reportName.set(r.name);
-      this.name = r.name;
-      this.text = r.text ?? '';
-      this.originalName = this.name;
-      this.originalText = this.text;
+      this.form.patchValue({ name: r.name, text: r.text ?? '' });
+      this.form.markAsPristine();
+      this.submitted.set(false);
     } catch {
       this.errorMessage.set('Failed to load document.');
     }
   }
 
   async onSave(): Promise<void> {
-    if (!this.name.trim()) {
-      this.errorMessage.set('Document name is required.');
+    this.submitted.set(true);
+    // Before the validity check, not after: a `server` error from the previous attempt
+    // makes its control invalid, so leaving the clear until later meant a second save
+    // bailed out here and never ran — the form was stuck at that value with Save
+    // disabled and no way to retry. Clearing first re-validates against the client
+    // rules only, and lets the server have another say.
+    clearServerErrors(this.form);
+
+    if (this.form.invalid) {
+      // Replaces the imperative `if (!this.name.trim())` check and its page-level
+      // "Document name is required." message — `required` renders under the field now.
+      this.form.markAllAsTouched();
       return;
     }
+
     this.saving.set(true);
     this.errorMessage.set(null);
+
+    const { name, text } = this.form.getRawValue();
+    const trimmedName = name.trim();
     const result = await this.reportService.saveReport(
-      this.projectName, this.reportId(), this.name.trim(), this.text || null
+      this.projectName, this.reportId(), trimmedName, text || null
     );
     this.saving.set(false);
+
     if (result.success) {
       this.messageService.add({ severity: 'success', summary: 'Document saved', life: 3000 });
       const saved = result.entity as ReportGeneratorDto | null;
       if (this.isNew() && saved?.id) {
-        this.originalName = this.name.trim();
-        this.originalText = this.text;
+        this.form.patchValue({ name: trimmedName });
+        this.form.markAsPristine();
         this.router.navigate(['/projects', this.projectName, 'reports', saved.id], { replaceUrl: true });
       } else {
         await this.loadReport(this.reportId()!);
       }
-    } else {
+      return;
+    }
+
+    const unresolved = applyCommandErrors(this.form, result.violations, REPORT_FIELD_MAP);
+    if (unresolved.length) {
+      this.errorMessage.set(unresolved.join(' '));
+    } else if (!result.violations?.length) {
       this.errorMessage.set(result.error ?? 'Save failed.');
     }
   }
@@ -254,12 +326,19 @@ export class ReportEditorComponent implements OnInit, OnDestroy, DirtyCheckable 
     }
   }
 
+  /**
+   * Replacing the template from a file is a user edit, so the control is marked dirty
+   * explicitly — `patchValue` does not do it, and without this Save would stay disabled
+   * after an upload.
+   */
   onFileUpload(file: File): void {
     const reader = new FileReader();
     reader.onload = () => {
-      this.text = reader.result as string;
-      if (!this.name) {
-        this.name = file.name.replace(/\.[^.]+$/, '');
+      this.form.controls.text.setValue(reader.result as string);
+      this.form.controls.text.markAsDirty();
+      if (!this.form.controls.name.value) {
+        this.form.controls.name.setValue(file.name.replace(/\.[^.]+$/, ''));
+        this.form.controls.name.markAsDirty();
       }
     };
     reader.readAsText(file);

--- a/requel-angular/src/app/features/reports/report-editor.ts
+++ b/requel-angular/src/app/features/reports/report-editor.ts
@@ -291,7 +291,7 @@ export class ReportEditorComponent implements OnInit, OnDestroy, DirtyCheckable 
 
     const unresolved = applyCommandErrors(this.form, result.violations, REPORT_FIELD_MAP);
     if (unresolved.length) {
-      this.errorMessage.set(unresolved.join(' '));
+      this.errorMessage.set(unresolved.join(SEPARATOR));
     } else if (!result.violations?.length) {
       this.errorMessage.set(result.error ?? 'Save failed.');
     }
@@ -348,3 +348,11 @@ export class ReportEditorComponent implements OnInit, OnDestroy, DirtyCheckable 
     this.router.navigate(['/projects', this.projectName, 'reports']);
   }
 }
+
+/**
+ * Separator for several command-level messages sharing the one page-level banner.
+ * Semicolons, not spaces: two sentence fragments run together ("Email is invalid Phone
+ * is required") read as one broken sentence. This is the separator the pre-#132 code
+ * used and e2e/account.e2e.ts asserts.
+ */
+const SEPARATOR = '; ';

--- a/requel-angular/src/app/features/terms/term-editor.a11y.spec.ts
+++ b/requel-angular/src/app/features/terms/term-editor.a11y.spec.ts
@@ -1,0 +1,134 @@
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter, ActivatedRoute, convertToParamMap, Router } from '@angular/router';
+import { BehaviorSubject, EMPTY } from 'rxjs';
+import { MessageService } from 'primeng/api';
+import { TermEditorComponent } from './term-editor';
+import { TermService } from '../../core/term.service';
+import { PermissionService } from '../../core/permission.service';
+import { EventStreamService } from '../../core/event-stream.service';
+import { expectNoAxeViolations } from '../../shared/testing/a11y';
+
+const MOCK_TERM = {
+  id: 2, version: 0, name: 'Goal', text: 'A desired outcome.',
+  canonicalTermId: null, alternateTerms: [], referers: []
+};
+
+const flush = () => new Promise(r => setTimeout(r, 0));
+
+/**
+ * One exclusion, for a defect the page under test does not own:
+ *
+ * - `p-confirmdialog`: PrimeNG marks its host `role="alertdialog"` even when nothing is
+ *   showing, so axe reports an unnamed dialog on any page that mounts one. Belongs with
+ *   #139 — see the note on `expectNoAxeViolations`.
+ *
+ * The `app-annotations-section` heading-order violation these specs first surfaced is
+ * fixed at source instead: its `<h3>Annotations</h3>` is now an
+ * `<h2 class="rq-section-title">`, matching the section headings #158 standardised.
+ */
+const EXCLUDE = ['p-confirmdialog'];
+
+describe('TermEditorComponent accessibility (issue #132)', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fixture: any;
+  let comp: TermEditorComponent;
+
+  async function render(termId = 'new'): Promise<HTMLElement> {
+    const paramMap$ = new BehaviorSubject(convertToParamMap({ name: 'proj1', termId }));
+    TestBed.configureTestingModule({
+      imports: [TermEditorComponent],
+      providers: [
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: ActivatedRoute, useValue: { paramMap: paramMap$.asObservable() } },
+        {
+          provide: TermService,
+          useValue: {
+            listTerms: vi.fn().mockResolvedValue([{ id: 1, name: 'Actor', text: '' }]),
+            getTerm: vi.fn().mockResolvedValue(MOCK_TERM),
+            saveTerm: vi.fn().mockResolvedValue({ success: true, entity: MOCK_TERM }),
+            deleteTerm: vi.fn().mockResolvedValue({ success: true }),
+          },
+        },
+        {
+          provide: PermissionService,
+          useValue: {
+            loadForProject: vi.fn().mockResolvedValue(undefined),
+            canEdit: vi.fn().mockReturnValue(true),
+            canDelete: vi.fn().mockReturnValue(true),
+          },
+        },
+        {
+          provide: EventStreamService,
+          useValue: {
+            events$: EMPTY,
+            addSubscription: vi.fn().mockResolvedValue(undefined),
+            removeSubscription: vi.fn().mockResolvedValue(undefined),
+          },
+        },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
+    });
+    fixture = TestBed.createComponent(TermEditorComponent);
+    comp = fixture.componentInstance;
+    vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+    fixture.detectChanges();
+    await flush();
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  }
+
+
+
+  it('has no axe-core violations on the create form', async () => {
+    await expectNoAxeViolations(await render('new'), EXCLUDE);
+  });
+
+  it('has no axe-core violations on the edit form', async () => {
+    await expectNoAxeViolations(await render('2'), EXCLUDE);
+  });
+
+  it('has no axe-core violations with the name field in its error state', async () => {
+    const el = await render('new');
+    await comp.onSave();
+    fixture.detectChanges();
+
+    expect(el.querySelector('[data-testid="field-error"]')).not.toBeNull();
+    await expectNoAxeViolations(el, EXCLUDE);
+  });
+
+  it('has no axe-core violations with a server error showing on a field', async () => {
+    const el = await render('2');
+    comp.form.controls.name.setErrors({ server: 'A term with that name already exists.' });
+    comp.form.controls.name.markAsTouched();
+    fixture.detectChanges();
+
+    await expectNoAxeViolations(el, EXCLUDE);
+  });
+
+  it('associates each error with its control', async () => {
+    const el = await render('new');
+    await comp.onSave();
+    fixture.detectChanges();
+
+    const name = el.querySelector<HTMLInputElement>('#name')!;
+    expect(name.getAttribute('aria-invalid')).toBe('true');
+    expect(name.getAttribute('aria-required')).toBe('true');
+
+    const describedBy = name.getAttribute('aria-describedby');
+    expect(el.querySelector(`#${describedBy}`)?.textContent?.trim()).toBe(
+      'This field is required.'
+    );
+  });
+
+  it('gives the p-select a real label rather than pointing at the host element', async () => {
+    const el = await render('2');
+    const label = el.querySelector<HTMLLabelElement>('label[for="canonical-term-input"]');
+
+    expect(label?.textContent?.trim()).toContain('Canonical Term');
+    // The old markup put id="canonical" on the p-select host, which is not focusable and
+    // gets no accessible name from a <label for>. app-field targets the inner control.
+    expect(el.querySelector('#canonical-term-input')?.tagName.toLowerCase()).not.toBe('p-select');
+  });
+});

--- a/requel-angular/src/app/features/terms/term-editor.spec.ts
+++ b/requel-angular/src/app/features/terms/term-editor.spec.ts
@@ -1,8 +1,8 @@
 import { TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter, Router, ActivatedRoute, convertToParamMap } from '@angular/router';
-import { BehaviorSubject, EMPTY } from 'rxjs';
-import { ConfirmationService, MessageService } from 'primeng/api';
+import { BehaviorSubject, EMPTY, Subject } from 'rxjs';
+import { MessageService } from 'primeng/api';
 import { TermEditorComponent } from './term-editor';
 import { TermService } from '../../core/term.service';
 import { PermissionService } from '../../core/permission.service';
@@ -23,6 +23,7 @@ const flush = () => new Promise(r => setTimeout(r, 0));
 
 describe('TermEditorComponent', () => {
   let paramMap$: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
+  let events$: Subject<{ targetType: string; targetId: number }>;
   let termServiceMock: {
     listTerms: ReturnType<typeof vi.fn>;
     getTerm: ReturnType<typeof vi.fn>;
@@ -30,7 +31,7 @@ describe('TermEditorComponent', () => {
     deleteTerm: ReturnType<typeof vi.fn>;
   };
   let permissionServiceMock: { loadForProject: ReturnType<typeof vi.fn>; canEdit: ReturnType<typeof vi.fn>; canDelete: ReturnType<typeof vi.fn> };
-  let eventStreamServiceMock: { events$: typeof EMPTY; addSubscription: ReturnType<typeof vi.fn>; removeSubscription: ReturnType<typeof vi.fn> };
+  let eventStreamServiceMock: { events$: unknown; addSubscription: ReturnType<typeof vi.fn>; removeSubscription: ReturnType<typeof vi.fn> };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let fixture: any;
   let comp: TermEditorComponent;
@@ -38,6 +39,7 @@ describe('TermEditorComponent', () => {
 
   beforeEach(() => {
     paramMap$ = new BehaviorSubject(convertToParamMap({ name: 'proj1', termId: 'new' }));
+    events$ = new Subject();
 
     termServiceMock = {
       listTerms: vi.fn().mockResolvedValue(MOCK_TERMS),
@@ -74,6 +76,12 @@ describe('TermEditorComponent', () => {
     vi.spyOn(router, 'navigate').mockResolvedValue(true);
   });
 
+  /** Fills the form the way a user would, leaving it dirty. */
+  function fill(name: string, text = '', canonicalTermId: number | null = null): void {
+    comp.form.setValue({ name, text, canonicalTermId });
+    comp.form.markAsDirty();
+  }
+
   it('isNew() is true when termId param is "new"', async () => {
     fixture.detectChanges();
     await flush();
@@ -85,7 +93,6 @@ describe('TermEditorComponent', () => {
     paramMap$.next(convertToParamMap({ name: 'proj1', termId: '2' }));
     fixture.detectChanges();
     await flush();
-    // term id=2 should be excluded from canonical options
     const options = comp.canonicalOptions();
     expect(options.some(o => o.value === 2)).toBe(false);
     expect(options.length).toBe(MOCK_TERMS.length - 1);
@@ -103,21 +110,278 @@ describe('TermEditorComponent', () => {
   it('onSave calls termService.saveTerm with name and text', async () => {
     fixture.detectChanges();
     await flush();
-    comp.name = 'New Term';
-    comp.text = 'A definition';
-    comp.canonicalTermId = null;
+    fill('New Term', 'A definition');
     await comp.onSave();
     expect(termServiceMock.saveTerm).toHaveBeenCalledWith(
       'proj1', null, 'New Term', 'A definition', null
     );
   });
 
-  it('onSave sets errorMessage when name is empty', async () => {
-    fixture.detectChanges();
-    await flush();
-    comp.name = '';
-    await comp.onSave();
-    expect(comp.errorMessage()).toBe('Term name is required.');
-    expect(termServiceMock.saveTerm).not.toHaveBeenCalled();
+  describe('reactive form (issue #132)', () => {
+    it('loads the term into the form and leaves it pristine', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', termId: '2' }));
+      fixture.detectChanges();
+      await flush();
+
+      expect(comp.form.getRawValue()).toEqual({
+        name: 'Goal',
+        text: 'A desired outcome.',
+        canonicalTermId: null,
+      });
+      expect(comp.form.pristine).toBe(true);
+    });
+
+    it('resets the form for the new-term path', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', termId: '2' }));
+      fixture.detectChanges();
+      await flush();
+
+      paramMap$.next(convertToParamMap({ name: 'proj1', termId: 'new' }));
+      await flush();
+
+      expect(comp.form.getRawValue()).toEqual({ name: '', text: '', canonicalTermId: null });
+      expect(comp.form.pristine).toBe(true);
+    });
+
+    /**
+     * Replaces the imperative `if (!this.name.trim())` guard and its page-level "Term
+     * name is required." message. The complaint now renders under the field, so the
+     * page-level slot is left for things that have no field.
+     */
+    it('does not save an empty name, and reports it inline rather than page-level', async () => {
+      fixture.detectChanges();
+      await flush();
+      fill('');
+
+      await comp.onSave();
+
+      expect(termServiceMock.saveTerm).not.toHaveBeenCalled();
+      expect(comp.errorMessage()).toBeNull();
+      expect(comp.form.controls.name.hasError('required')).toBe(true);
+      expect(comp.form.controls.name.touched).toBe(true);
+      expect(comp.submitted()).toBe(true);
+    });
+
+    it('treats a whitespace-only name as present but trims it before sending', async () => {
+      fixture.detectChanges();
+      await flush();
+      fill('  Spaced  ', 'text');
+
+      await comp.onSave();
+
+      expect(termServiceMock.saveTerm).toHaveBeenCalledWith('proj1', null, 'Spaced', 'text', null);
+    });
+
+    it('sends null rather than an empty string for a blank definition', async () => {
+      fixture.detectChanges();
+      await flush();
+      fill('Term', '');
+
+      await comp.onSave();
+
+      expect(termServiceMock.saveTerm).toHaveBeenCalledWith('proj1', null, 'Term', null, null);
+    });
+
+    it('hasUnsavedChanges() derives from form.dirty', async () => {
+      fixture.detectChanges();
+      await flush();
+      expect(comp.hasUnsavedChanges()).toBe(false);
+
+      comp.form.controls.name.setValue('Changed');
+      comp.form.controls.name.markAsDirty();
+      expect(comp.hasUnsavedChanges()).toBe(true);
+    });
+
+    it('marks the form pristine after a successful save of an existing term', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', termId: '2' }));
+      fixture.detectChanges();
+      await flush();
+      comp.form.controls.text.setValue('Edited');
+      comp.form.controls.text.markAsDirty();
+
+      await comp.onSave();
+      await flush();
+
+      expect(comp.form.pristine).toBe(true);
+    });
+
+    it('disables Save while pristine and enables it once dirty and valid', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', termId: '2' }));
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+
+      const save = () =>
+        (fixture.nativeElement as HTMLElement).querySelector<HTMLButtonElement>(
+          '[data-testid="term-save"] button'
+        );
+      expect(save()?.disabled).toBe(true);
+
+      comp.form.controls.name.setValue('Renamed');
+      comp.form.controls.name.markAsDirty();
+      fixture.detectChanges();
+      expect(save()?.disabled).toBe(false);
+    });
+
+    it('keeps the #name and #text ids the e2e page objects locate', async () => {
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+      const el = fixture.nativeElement as HTMLElement;
+
+      expect(el.querySelector('input#name')).not.toBeNull();
+      expect(el.querySelector('textarea#text')).not.toBeNull();
+      expect(el.querySelector('[data-testid="term-canonical-select"]')).not.toBeNull();
+    });
+  });
+
+  describe('command error handling (issue #132)', () => {
+    it('puts a field violation on its control instead of the page message', async () => {
+      termServiceMock.saveTerm.mockResolvedValue({
+        success: false,
+        violations: [{ field: 'name', message: 'A term with that name already exists.' }],
+        error: 'Validation failed',
+      });
+      fixture.detectChanges();
+      await flush();
+      fill('Duplicate');
+
+      await comp.onSave();
+
+      expect(comp.form.controls.name.errors).toEqual({
+        server: 'A term with that name already exists.',
+      });
+      expect(comp.errorMessage()).toBeNull();
+    });
+
+    it('maps the canonicalTerm entity property onto the canonicalTermId control', async () => {
+      termServiceMock.saveTerm.mockResolvedValue({
+        success: false,
+        violations: [{ field: 'canonicalTerm', message: 'Cannot be its own canonical term.' }],
+        error: 'Validation failed',
+      });
+      fixture.detectChanges();
+      await flush();
+      fill('Term', '', 2);
+
+      await comp.onSave();
+
+      expect(comp.form.controls.canonicalTermId.errors).toEqual({
+        server: 'Cannot be its own canonical term.',
+      });
+    });
+
+    it('shows an unmappable violation page-level rather than dropping it', async () => {
+      termServiceMock.saveTerm.mockResolvedValue({
+        success: false,
+        violations: [{ field: 'somethingElse', message: 'Deeply unexpected.' }],
+        error: 'Validation failed',
+      });
+      fixture.detectChanges();
+      await flush();
+      fill('Term');
+
+      await comp.onSave();
+
+      expect(comp.errorMessage()).toBe('Deeply unexpected.');
+    });
+
+    it('falls back to the page-level error when there are no violations at all', async () => {
+      termServiceMock.saveTerm.mockResolvedValue({
+        success: false,
+        violations: null,
+        error: 'Save failed.',
+      });
+      fixture.detectChanges();
+      await flush();
+      fill('Term');
+
+      await comp.onSave();
+
+      expect(comp.errorMessage()).toBe('Save failed.');
+    });
+
+    /**
+     * A server error makes its control invalid, which is what disables Save until the
+     * user changes something. The trap: if onSave cleared those errors *after* its
+     * validity guard, the guard would see the stale error, bail, and the form would be
+     * stuck at that value forever with no retry and no feedback.
+     */
+    it('clears a previous attempt\'s server error before re-submitting', async () => {
+      termServiceMock.saveTerm.mockResolvedValue({
+        success: false,
+        violations: [{ field: 'name', message: 'Taken.' }],
+        error: 'Validation failed',
+      });
+      fixture.detectChanges();
+      await flush();
+      fill('Duplicate');
+      await comp.onSave();
+      expect(comp.form.controls.name.errors?.['server']).toBe('Taken.');
+
+      // Same value, so no valueChanges to clear it implicitly — onSave must do it.
+      termServiceMock.saveTerm.mockResolvedValue({ success: true, entity: MOCK_TERM });
+      await comp.onSave();
+
+      expect(comp.form.controls.name.errors).toBeNull();
+      expect(termServiceMock.saveTerm).toHaveBeenCalledTimes(2);
+    });
+
+    it('a standing server error disables Save until something changes', async () => {
+      termServiceMock.saveTerm.mockResolvedValue({
+        success: false,
+        violations: [{ field: 'name', message: 'Taken.' }],
+        error: 'Validation failed',
+      });
+      fixture.detectChanges();
+      await flush();
+      fill('Duplicate');
+      await comp.onSave();
+      fixture.detectChanges();
+
+      const save = () =>
+        (fixture.nativeElement as HTMLElement).querySelector<HTMLButtonElement>(
+          '[data-testid="term-save"] button'
+        );
+      expect(save()?.disabled).toBe(true);
+
+      comp.form.controls.name.setValue('Something else');
+      fixture.detectChanges();
+      expect(save()?.disabled).toBe(false);
+    });
+  });
+
+  describe('SSE reload (issue #132)', () => {
+    beforeEach(() => {
+      eventStreamServiceMock.events$ = events$.asObservable();
+    });
+
+    it('does not clobber in-progress edits when a remote change arrives', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', termId: '2' }));
+      fixture.detectChanges();
+      await flush();
+
+      comp.form.controls.text.setValue('My unsaved edit');
+      comp.form.controls.text.markAsDirty();
+      const callsBefore = termServiceMock.getTerm.mock.calls.length;
+
+      events$.next({ targetType: 'GlossaryTerm', targetId: 2 });
+      await flush();
+
+      expect(termServiceMock.getTerm.mock.calls.length).toBe(callsBefore);
+      expect(comp.form.controls.text.value).toBe('My unsaved edit');
+    });
+
+    it('reloads when the form is clean', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', termId: '2' }));
+      fixture.detectChanges();
+      await flush();
+      const callsBefore = termServiceMock.getTerm.mock.calls.length;
+
+      events$.next({ targetType: 'GlossaryTerm', targetId: 2 });
+      await flush();
+
+      expect(termServiceMock.getTerm.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
   });
 });

--- a/requel-angular/src/app/features/terms/term-editor.ts
+++ b/requel-angular/src/app/features/terms/term-editor.ts
@@ -23,7 +23,7 @@ import { PageHeaderComponent } from '../../shared/page-header';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
-import { FormsModule } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
 import { InputText } from 'primeng/inputtext';
 import { TextareaModule } from 'primeng/textarea';
@@ -38,12 +38,39 @@ import { PermissionService } from '../../core/permission.service';
 import { EventStreamService } from '../../core/event-stream.service';
 import { AnnotationsSectionComponent } from '../../shared/annotations-section';
 import { AppCardComponent } from '../../shared/app-card';
+import { AppFieldComponent, AppFieldControlDirective } from '../../shared/app-field';
+import { applyCommandErrors, clearServerErrors } from '../../shared/form-errors';
+
+/**
+ * JPA entity property name -> form control name, for {@link applyCommandErrors}.
+ *
+ * `CommandController` reports violations using entity property names (see
+ * `BeanValidationExceptionAdapter`), which mostly match the control names here.
+ * `canonicalTerm` is the exception: the entity holds the related `GlossaryTerm`, the
+ * form holds its id.
+ */
+const TERM_FIELD_MAP: Record<string, string> = {
+  canonicalTerm: 'canonicalTermId',
+};
 
 @Component({
   selector: 'app-term-editor',
   standalone: true,
-  imports: [PageHeaderComponent, AppCardComponent, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
-            TableModule, MessageModule, ConfirmDialogModule, AnnotationsSectionComponent],
+  imports: [
+    PageHeaderComponent,
+    AppCardComponent,
+    ReactiveFormsModule,
+    ButtonModule,
+    InputText,
+    TextareaModule,
+    SelectModule,
+    TableModule,
+    MessageModule,
+    ConfirmDialogModule,
+    AnnotationsSectionComponent,
+    AppFieldComponent,
+    AppFieldControlDirective,
+  ],
   providers: [ConfirmationService],
   template: `
     <div class="term-editor" data-testid="term-editor">
@@ -64,31 +91,81 @@ import { AppCardComponent } from '../../shared/app-card';
       }
 
       <app-card>
-        <div class="form-grid">
-          <label for="name">Term</label>
-          <input id="name" pInputText [(ngModel)]="name" placeholder="Term name" />
+        <form [formGroup]="form" (ngSubmit)="onSave()">
+          <!--
+            controlId is "name" / "text" on purpose: those ids are an e2e contract, not
+            an implementation detail. TermEditorPage and BaseListPage's default
+            readySelector both locate #name, so letting app-field generate rq-field-{n}
+            here would break navigation in tests that have nothing to do with this form.
+          -->
+          <app-field
+            label="Term"
+            controlId="name"
+            [control]="form.controls.name"
+            [submitted]="submitted()"
+          >
+            <input
+              id="name"
+              pInputText
+              appFieldControl
+              formControlName="name"
+              placeholder="Term name"
+            />
+          </app-field>
 
-          <label for="text">Definition</label>
-          <textarea id="text" pTextarea [(ngModel)]="text" rows="5"
-                    placeholder="Definition of this term"></textarea>
+          <app-field
+            label="Definition"
+            controlId="text"
+            [control]="form.controls.text"
+            [submitted]="submitted()"
+          >
+            <textarea
+              id="text"
+              pTextarea
+              appFieldControl
+              formControlName="text"
+              rows="5"
+              placeholder="Definition of this term"
+            ></textarea>
+          </app-field>
 
-          <label for="canonical">Canonical Term</label>
-          <p-select id="canonical" [options]="canonicalOptions()" [(ngModel)]="canonicalTermId"
-                    optionLabel="label" optionValue="value"
-                    data-testid="term-canonical-select"
-                    placeholder="None (this is a canonical term)" [showClear]="true" />
-        </div>
+          <app-field
+            label="Canonical Term"
+            controlId="canonical-term-input"
+            [control]="form.controls.canonicalTermId"
+            [submitted]="submitted()"
+            [divider]="false"
+          >
+            <p-select
+              appFieldControl
+              inputId="canonical-term-input"
+              data-testid="term-canonical-select"
+              formControlName="canonicalTermId"
+              [options]="canonicalOptions()"
+              optionLabel="label"
+              optionValue="value"
+              placeholder="None (this is a canonical term)"
+              [showClear]="true"
+            />
+          </app-field>
 
-        <div class="form-actions">
-          <p-button label="Save" icon="pi pi-check" data-testid="term-save" (onClick)="onSave()" [loading]="saving()"
-                    [disabled]="!isNew() && !isDirty()" />
-        </div>
+          <div class="form-actions">
+            <p-button
+              type="submit"
+              label="Save"
+              icon="pi pi-check"
+              data-testid="term-save"
+              [loading]="saving()"
+              [disabled]="form.invalid || form.pristine || saving()"
+            />
+          </div>
+        </form>
       </app-card>
 
       <!-- Alternate Terms (terms that point to this as their canonical) -->
       @if (!isNew() && term()?.alternateTerms?.length) {
         <div class="section" data-testid="term-alternate-terms-section">
-          <h3>Alternate Terms</h3>
+          <h2 class="rq-section-title">Alternate Terms</h2>
           <p-table [value]="term()!.alternateTerms!" [rows]="10">
             <ng-template #header>
               <tr>
@@ -108,7 +185,7 @@ import { AppCardComponent } from '../../shared/app-card';
       <!-- Referenced By -->
       @if (!isNew() && term()?.referers?.length) {
         <div class="section" data-testid="term-referenced-by-section">
-          <h3>Referenced By</h3>
+          <h2 class="rq-section-title">Referenced By</h2>
           <p-table [value]="term()!.referers!" [rows]="10">
             <ng-template #header>
               <tr>
@@ -137,14 +214,14 @@ import { AppCardComponent } from '../../shared/app-card';
     <p-confirmDialog />
   `,
   styles: [`
-    .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
-    .page-actions { display: flex; gap: 0.5rem; }
-    .form-grid { display: grid; grid-template-columns: 160px 1fr; gap: 0.75rem 1rem; align-items: start; max-width: 700px; margin-bottom: 1rem; }
-    .form-grid label { font-weight: 600; padding-top: 0.4rem; }
-    .form-grid input, .form-grid textarea, .form-grid p-select { width: 100%; }
-    .form-actions { margin-bottom: 1.5rem; }
-    .section { margin-top: 1.5rem; }
-    .section h3 { margin-bottom: 0.75rem; }
+    .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--rq-space-4); }
+    .page-actions { display: flex; gap: var(--rq-space-2); }
+    /* The rows are app-field's now (issue #132); the local .form-grid that redefined a
+       160px label column is gone. Only control width stays with the caller. */
+    app-field input, app-field textarea, app-field p-select { width: 100%; }
+    .form-actions { margin-block: var(--rq-space-4) var(--rq-space-6); }
+    .section { margin-top: var(--rq-space-6); }
+    .section h2 { margin-bottom: var(--rq-space-3); }
     .clickable-row { cursor: pointer; }
     .clickable-row:hover td { background: var(--p-surface-100); }
   `]
@@ -154,26 +231,24 @@ export class TermEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
   termName = signal('');
   termId = signal<number | null>(null);
   saving = signal(false);
+  submitted = signal(false);
   errorMessage = signal<string | null>(null);
   canonicalOptions = signal<{ label: string; value: number }[]>([]);
 
-  name = '';
-  text = '';
-  canonicalTermId: number | null = null;
-
-  private originalName = '';
-  private originalText = '';
-  private originalCanonicalTermId: number | null = null;
+  /**
+   * `text` carries no maxLength yet — there is no backend `@Size` on it to mirror, and
+   * inventing a client-side cap would reject content the server accepts. #171 adds the
+   * real constraints; the value then comes from `shared/validation-limits.ts`.
+   */
+  readonly form = new FormGroup({
+    name: new FormControl('', { validators: Validators.required, nonNullable: true }),
+    text: new FormControl('', { nonNullable: true }),
+    canonicalTermId: new FormControl<number | null>(null),
+  });
 
   projectName = '';
   canEdit = signal(false);
   canDelete = signal(false);
-
-  isDirty(): boolean {
-    return this.name !== this.originalName
-      || this.text !== this.originalText
-      || this.canonicalTermId !== this.originalCanonicalTermId;
-  }
 
   private paramSub?: Subscription;
   private sseSub?: Subscription;
@@ -202,16 +277,11 @@ export class TermEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
       // The async work below (loadForProject, loadCanonicalOptions) yields the
       // event loop, and any user input — or fast-typing E2E test — that lands
       // during those yields would otherwise be clobbered when the reset
-      // eventually ran. Doing the reset first means subsequent ngModel writes
-      // from typing are preserved.
+      // eventually ran. Doing the reset first means subsequent typing is preserved.
       if (newIsNew) {
         this.termId.set(null);
-        this.name = '';
-        this.text = '';
-        this.canonicalTermId = null;
-        this.originalName = '';
-        this.originalText = '';
-        this.originalCanonicalTermId = null;
+        this.submitted.set(false);
+        this.form.reset({ name: '', text: '', canonicalTermId: null });
       }
 
       await this.permissionService.loadForProject(this.projectName);
@@ -227,8 +297,9 @@ export class TermEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
     });
   }
 
+  /** Derived from the form, so there is no change-tracker to keep in step (#132). */
   hasUnsavedChanges(): boolean {
-    return this.isDirty();
+    return this.form.dirty;
   }
 
   ngOnDestroy(): void {
@@ -259,12 +330,16 @@ export class TermEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
       this.term.set(t);
       this.termId.set(t.id);
       this.termName.set(t.name);
-      this.name = t.name;
-      this.text = t.text ?? '';
-      this.canonicalTermId = t.canonicalTermId ?? null;
-      this.originalName = this.name;
-      this.originalText = this.text;
-      this.originalCanonicalTermId = this.canonicalTermId;
+      // An SSE-driven reload must not throw away what the user is editing. The guard
+      // is on the caller side for the SSE path below; here we only refresh a form the
+      // user has not touched.
+      this.form.patchValue({
+        name: t.name,
+        text: t.text ?? '',
+        canonicalTermId: t.canonicalTermId ?? null,
+      });
+      this.form.markAsPristine();
+      this.submitted.set(false);
     } catch {
       this.errorMessage.set('Failed to load term.');
     }
@@ -272,6 +347,11 @@ export class TermEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
       void this.eventStreamService.addSubscription('GlossaryTerm', id);
       this.sseSub = this.eventStreamService.events$.subscribe(envelope => {
         if (envelope.targetType === 'GlossaryTerm' && envelope.targetId === id) {
+          // Don't clobber in-progress edits with a remote change (same guard the N5
+          // editors use). The user's copy wins until they save or navigate away.
+          if (this.hasUnsavedChanges()) {
+            return;
+          }
           void this.loadTerm(id);
         }
       });
@@ -279,28 +359,50 @@ export class TermEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
   }
 
   async onSave(): Promise<void> {
-    if (!this.name.trim()) {
-      this.errorMessage.set('Term name is required.');
+    this.submitted.set(true);
+    // Before the validity check, not after: a `server` error from the previous attempt
+    // makes its control invalid, so leaving the clear until later meant a second save
+    // bailed out here and never ran — the form was stuck at that value with Save
+    // disabled and no way to retry. Clearing first re-validates against the client
+    // rules only, and lets the server have another say.
+    clearServerErrors(this.form);
+
+    if (this.form.invalid) {
+      // Replaces the imperative `if (!this.name.trim())` check and its page-level
+      // "Term name is required." message — `required` now renders under the field.
+      this.form.markAllAsTouched();
       return;
     }
+
     this.saving.set(true);
     this.errorMessage.set(null);
+
+    const { name, text, canonicalTermId } = this.form.getRawValue();
+    const trimmedName = name.trim();
     const result = await this.termService.saveTerm(
-      this.projectName, this.termId(), this.name.trim(), this.text || null, this.canonicalTermId
+      this.projectName, this.termId(), trimmedName, text || null, canonicalTermId
     );
     this.saving.set(false);
+
     if (result.success) {
       this.messageService.add({ severity: 'success', summary: 'Term saved', life: 3000 });
       const saved = result.entity as GlossaryTermDto | null;
       if (this.isNew() && saved?.id) {
-        this.originalName = this.name.trim();
-        this.originalText = this.text;
-        this.originalCanonicalTermId = this.canonicalTermId;
+        this.form.patchValue({ name: trimmedName });
+        this.form.markAsPristine();
         this.router.navigate(['/projects', this.projectName, 'terms', saved.id], { replaceUrl: true });
       } else {
         await this.loadTerm(this.termId()!);
       }
-    } else {
+      return;
+    }
+
+    // Field violations land on their controls; only what could not be placed becomes a
+    // page-level message, so nothing is dropped and nothing is duplicated.
+    const unresolved = applyCommandErrors(this.form, result.violations, TERM_FIELD_MAP);
+    if (unresolved.length) {
+      this.errorMessage.set(unresolved.join(' '));
+    } else if (!result.violations?.length) {
       this.errorMessage.set(result.error ?? 'Save failed.');
     }
   }

--- a/requel-angular/src/app/features/terms/term-editor.ts
+++ b/requel-angular/src/app/features/terms/term-editor.ts
@@ -53,6 +53,14 @@ const TERM_FIELD_MAP: Record<string, string> = {
   canonicalTerm: 'canonicalTermId',
 };
 
+/**
+ * Separator for several command-level messages sharing the one page-level banner.
+ * Semicolons, not spaces: two sentence fragments run together ("Email is invalid Phone
+ * is required") read as one broken sentence. This is the separator the pre-#132 code
+ * used and e2e/account.e2e.ts asserts.
+ */
+const SEPARATOR = '; ';
+
 @Component({
   selector: 'app-term-editor',
   standalone: true,
@@ -401,7 +409,7 @@ export class TermEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
     // page-level message, so nothing is dropped and nothing is duplicated.
     const unresolved = applyCommandErrors(this.form, result.violations, TERM_FIELD_MAP);
     if (unresolved.length) {
-      this.errorMessage.set(unresolved.join(' '));
+      this.errorMessage.set(unresolved.join(SEPARATOR));
     } else if (!result.violations?.length) {
       this.errorMessage.set(result.error ?? 'Save failed.');
     }

--- a/requel-angular/src/app/features/users/edit-account.a11y.spec.ts
+++ b/requel-angular/src/app/features/users/edit-account.a11y.spec.ts
@@ -1,0 +1,113 @@
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { signal } from '@angular/core';
+import { EditAccountComponent } from './edit-account';
+import { AuthService } from '../../core/auth.service';
+import { CommandService } from '../../core/command.service';
+import { UserService } from '../../core/user.service';
+import { expectNoAxeViolations } from '../../shared/testing/a11y';
+
+const MOCK_USER = {
+  id: 1, version: 0, username: 'admin', name: 'Admin User',
+  emailAddress: 'admin@example.com', phoneNumber: '555-1234',
+  organizationName: 'Acme', roles: ['SystemAdminUserRole'], permissions: [],
+  permissionsByRole: null
+};
+
+describe('EditAccountComponent accessibility (issue #132)', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fixture: any;
+  let comp: EditAccountComponent;
+
+  async function render(): Promise<HTMLElement> {
+    TestBed.configureTestingModule({
+      imports: [EditAccountComponent],
+      providers: [
+        provideNoopAnimations(),
+        { provide: AuthService, useValue: { user: signal(MOCK_USER) } },
+        { provide: CommandService, useValue: { execute: vi.fn().mockResolvedValue({ success: true }) } },
+        {
+          provide: UserService,
+          useValue: { listOrganizations: vi.fn().mockResolvedValue([{ id: 1, name: 'Acme' }]) },
+        },
+      ],
+    });
+    fixture = TestBed.createComponent(EditAccountComponent);
+    comp = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  it('has no axe-core violations at rest', async () => {
+    await expectNoAxeViolations(await render());
+  });
+
+  it('has no axe-core violations with fields in their error state', async () => {
+    const el = await render();
+    comp.form.patchValue({ name: '', emailAddress: 'nope', password: 'a', repassword: 'b' });
+    comp.form.markAsDirty();
+    await comp.onSave();
+    fixture.detectChanges();
+
+    expect(el.querySelectorAll('[data-testid="field-error"]').length).toBeGreaterThan(0);
+    await expectNoAxeViolations(el);
+  });
+
+  it('has no axe-core violations with a page-level save failure showing', async () => {
+    const el = await render();
+    comp.errorMessage.set('Save failed.');
+    fixture.detectChanges();
+    await expectNoAxeViolations(el);
+  });
+
+  /**
+   * The disabled username row still needs a label — a disabled control is exempt from
+   * some axe rules, so this asserts the association directly rather than relying on the
+   * axe pass alone.
+   */
+  it('labels the disabled username row', async () => {
+    const el = await render();
+    const input = el.querySelector<HTMLInputElement>('#username')!;
+
+    expect(input.disabled).toBe(true);
+    expect(el.querySelector('label[for="username"]')?.textContent?.trim()).toContain('Username');
+  });
+
+  /**
+   * The password row's "leave blank to keep current" hint used to be part of the label
+   * text. It is helper text now, linked by aria-describedby, so the accessible NAME stays
+   * short while the explanation is still announced.
+   */
+  it('links the password helper text without putting it in the label', async () => {
+    const el = await render();
+    const password = el.querySelector<HTMLInputElement>('#password')!;
+    const label = el.querySelector('label[for="password"]')!;
+
+    expect(label.textContent?.trim()).toBe('New Password');
+    const describedBy = password.getAttribute('aria-describedby');
+    expect(el.querySelector(`#${describedBy}`)?.textContent?.trim()).toBe(
+      'Leave blank to keep your current password.'
+    );
+  });
+
+  it('puts the mismatch message under the confirm row, where the fix is', async () => {
+    const el = await render();
+    comp.form.patchValue({ password: 'hunter2', repassword: 'hunter3' });
+    comp.form.markAllAsTouched();
+    fixture.detectChanges();
+
+    const repassword = el.querySelector<HTMLInputElement>('#repassword')!;
+    expect(repassword.getAttribute('aria-invalid')).toBe('true');
+
+    const describedBy = repassword.getAttribute('aria-describedby');
+    expect(el.querySelector(`#${describedBy}`)?.textContent?.trim()).toBe(
+      'Passwords do not match.'
+    );
+    // And not on the password row, which the user does not need to change.
+    expect(el.querySelector<HTMLInputElement>('#password')!.getAttribute('aria-invalid')).toBe(
+      'false'
+    );
+  });
+});

--- a/requel-angular/src/app/features/users/edit-account.spec.ts
+++ b/requel-angular/src/app/features/users/edit-account.spec.ts
@@ -41,6 +41,15 @@ describe('EditAccountComponent', () => {
     comp = fixture.componentInstance;
   });
 
+  /** Edit the form the way a user would, leaving it dirty. */
+  function patch(values: Partial<{
+    name: string; emailAddress: string; phoneNumber: string;
+    organizationName: string; password: string; repassword: string;
+  }>): void {
+    comp.form.patchValue(values);
+    comp.form.markAsDirty();
+  }
+
   it('username() is computed from authService.user().username', () => {
     expect(comp.username()).toBe('admin');
   });
@@ -48,10 +57,13 @@ describe('EditAccountComponent', () => {
   it('ngOnInit populates fields from authService.user()', async () => {
     fixture.detectChanges();
     await fixture.whenStable();
-    expect(comp.name()).toBe('Admin User');
-    expect(comp.emailAddress()).toBe('admin@example.com');
-    expect(comp.phoneNumber()).toBe('555-1234');
-    expect(comp.organizationName()).toBe('Acme');
+    expect(comp.form.getRawValue()).toMatchObject({
+      username: 'admin',
+      name: 'Admin User',
+      emailAddress: 'admin@example.com',
+      phoneNumber: '555-1234',
+      organizationName: 'Acme',
+    });
   });
 
   it('ngOnInit calls userService.listOrganizations', async () => {
@@ -62,10 +74,9 @@ describe('EditAccountComponent', () => {
   });
 
   it('onSave calls commandService.execute("EditUser") with username and fields', async () => {
-    comp.name.set('New Name');
-    comp.emailAddress.set('new@example.com');
-    comp.phoneNumber.set('');
-    comp.organizationName.set('Beta');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    patch({ name: 'New Name', emailAddress: 'new@example.com', phoneNumber: '', organizationName: 'Beta' });
     await comp.onSave();
     expect(commandServiceMock.execute).toHaveBeenCalledWith('EditUser', expect.objectContaining({
       username: 'admin',
@@ -75,7 +86,9 @@ describe('EditAccountComponent', () => {
   });
 
   it('onSave sets successMessage on success', async () => {
-    comp.name.set('Updated');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    patch({ name: 'Updated' });
     await comp.onSave();
     expect(comp.successMessage()).toBe('Account updated.');
     expect(comp.saving()).toBe(false);
@@ -83,8 +96,237 @@ describe('EditAccountComponent', () => {
 
   it('onSave sets errorMessage when command fails', async () => {
     commandServiceMock.execute.mockResolvedValue({ success: false, error: 'Permission denied' });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    patch({ name: 'Updated' });
     await comp.onSave();
     expect(comp.errorMessage()).toBe('Permission denied');
     expect(comp.saving()).toBe(false);
+  });
+
+  describe('reactive form (issue #132)', () => {
+    beforeEach(async () => {
+      fixture.detectChanges();
+      await fixture.whenStable();
+    });
+
+    it('starts valid and pristine, so Save is disabled', () => {
+      expect(comp.form.valid).toBe(true);
+      expect(comp.form.pristine).toBe(true);
+      expect(comp.hasUnsavedChanges()).toBe(false);
+    });
+
+    it('keeps username disabled but still sends it', async () => {
+      expect(comp.form.controls.username.disabled).toBe(true);
+      patch({ name: 'Updated' });
+      await comp.onSave();
+      expect(commandServiceMock.execute).toHaveBeenCalledWith(
+        'EditUser',
+        expect.objectContaining({ username: 'admin' })
+      );
+    });
+
+    it('requires a name', () => {
+      patch({ name: '' });
+      expect(comp.form.controls.name.hasError('required')).toBe(true);
+      expect(comp.form.invalid).toBe(true);
+    });
+
+    it('rejects a malformed email', () => {
+      patch({ emailAddress: 'not-an-email' });
+      expect(comp.form.controls.emailAddress.hasError('email')).toBe(true);
+    });
+
+    it('accepts an empty email', () => {
+      patch({ emailAddress: '' });
+      expect(comp.form.controls.emailAddress.valid).toBe(true);
+    });
+
+    it('hasUnsavedChanges() derives from form.dirty', () => {
+      patch({ phoneNumber: '555-9999' });
+      expect(comp.hasUnsavedChanges()).toBe(true);
+    });
+
+    it('marks pristine and clears the password rows after a successful save', async () => {
+      patch({ name: 'Updated', password: 'hunter2', repassword: 'hunter2' });
+      await comp.onSave();
+
+      expect(comp.form.controls.password.value).toBe('');
+      expect(comp.form.controls.repassword.value).toBe('');
+      expect(comp.form.pristine).toBe(true);
+    });
+
+    it('does not save an invalid form', async () => {
+      patch({ name: '' });
+      await comp.onSave();
+      expect(commandServiceMock.execute).not.toHaveBeenCalled();
+      expect(comp.submitted()).toBe(true);
+    });
+
+    it('disables Save while pristine and enables it once dirty', () => {
+      const save = () =>
+        (fixture.nativeElement as HTMLElement).querySelector<HTMLButtonElement>(
+          '[data-testid="account-save"] button'
+        );
+      fixture.detectChanges();
+      expect(save()?.disabled).toBe(true);
+
+      patch({ name: 'Changed' });
+      fixture.detectChanges();
+      expect(save()?.disabled).toBe(false);
+    });
+
+    it('keeps the ids the e2e page objects locate, with #password on the real input', () => {
+      fixture.detectChanges();
+      const el = fixture.nativeElement as HTMLElement;
+
+      expect(el.querySelector('input#username')).not.toBeNull();
+      expect(el.querySelector('input#name')).not.toBeNull();
+      expect(el.querySelector('input#email')).not.toBeNull();
+      // The id lands on the inner input, not the p-password host — the e2e locators
+      // changed from .locator('#password').locator('input') to .locator('#password').
+      expect(el.querySelector('#password')?.tagName.toLowerCase()).toBe('input');
+      expect(el.querySelector('#repassword')?.tagName.toLowerCase()).toBe('input');
+    });
+  });
+
+  describe('optional password (issue #132)', () => {
+    beforeEach(async () => {
+      fixture.detectChanges();
+      await fixture.whenStable();
+    });
+
+    /**
+     * "Leave blank to keep current" needs no conditional branch: Angular's minLength
+     * returns null for an empty value, and passwordsMatch is satisfied when both rows
+     * are empty. This asserts that reading of the semantics, since it is the reason
+     * there is no isNew-style flag here.
+     */
+    it('is valid with both password rows blank', () => {
+      patch({ name: 'Updated' });
+      expect(comp.form.valid).toBe(true);
+    });
+
+    it('omits password from the payload when blank', async () => {
+      patch({ name: 'Updated' });
+      await comp.onSave();
+
+      const input = commandServiceMock.execute.mock.calls[0][1] as Record<string, unknown>;
+      expect('password' in input).toBe(false);
+      expect('repassword' in input).toBe(false);
+    });
+
+    it('includes password and repassword when set', async () => {
+      patch({ name: 'Updated', password: 'hunter2', repassword: 'hunter2' });
+      await comp.onSave();
+
+      expect(commandServiceMock.execute).toHaveBeenCalledWith(
+        'EditUser',
+        expect.objectContaining({ password: 'hunter2', repassword: 'hunter2' })
+      );
+    });
+
+    it('reports a mismatch on the confirm row and blocks the save', async () => {
+      patch({ name: 'Updated', password: 'hunter2', repassword: 'hunter3' });
+
+      expect(comp.form.controls.repassword.hasError('passwordMismatch')).toBe(true);
+      expect(comp.form.invalid).toBe(true);
+
+      await comp.onSave();
+      expect(commandServiceMock.execute).not.toHaveBeenCalled();
+    });
+
+    it('clears the mismatch when the confirm row catches up', () => {
+      patch({ password: 'hunter2', repassword: 'hunter3' });
+      comp.form.controls.repassword.setValue('hunter2');
+      expect(comp.form.controls.repassword.errors).toBeNull();
+    });
+
+    it('re-flags a mismatch when the password changes after confirming', () => {
+      patch({ name: 'Updated', password: 'hunter2', repassword: 'hunter2' });
+      expect(comp.form.valid).toBe(true);
+
+      comp.form.controls.password.setValue('hunter3');
+      expect(comp.form.controls.repassword.hasError('passwordMismatch')).toBe(true);
+    });
+
+    it('rejects a password over the server maximum', () => {
+      patch({ password: 'x'.repeat(129), repassword: 'x'.repeat(129) });
+      expect(comp.form.controls.password.hasError('maxlength')).toBe(true);
+    });
+
+    it('accepts a password at exactly the server maximum', () => {
+      const pw = 'x'.repeat(128);
+      patch({ name: 'Updated', password: pw, repassword: pw });
+      expect(comp.form.controls.password.valid).toBe(true);
+    });
+  });
+
+  describe('command error handling (issue #132)', () => {
+    beforeEach(async () => {
+      fixture.detectChanges();
+      await fixture.whenStable();
+    });
+
+    it('puts a field violation on its control instead of the page message', async () => {
+      commandServiceMock.execute.mockResolvedValue({
+        success: false,
+        violations: [{ field: 'emailAddress', message: 'That address is already in use.' }],
+        error: 'Validation failed',
+      });
+      patch({ name: 'Updated' });
+
+      await comp.onSave();
+
+      expect(comp.form.controls.emailAddress.errors).toEqual({
+        server: 'That address is already in use.',
+      });
+      expect(comp.errorMessage()).toBeNull();
+    });
+
+    it('maps encryptedPassword onto the password control', async () => {
+      commandServiceMock.execute.mockResolvedValue({
+        success: false,
+        violations: [{ field: 'encryptedPassword', message: 'Password is not acceptable.' }],
+        error: 'Validation failed',
+      });
+      patch({ name: 'Updated', password: 'hunter2', repassword: 'hunter2' });
+
+      await comp.onSave();
+
+      expect(comp.form.controls.password.errors).toEqual({
+        server: 'Password is not acceptable.',
+      });
+    });
+
+    it('shows an unmappable violation page-level rather than dropping it', async () => {
+      commandServiceMock.execute.mockResolvedValue({
+        success: false,
+        violations: [{ field: 'somethingElse', message: 'Unexpected.' }],
+        error: 'Validation failed',
+      });
+      patch({ name: 'Updated' });
+
+      await comp.onSave();
+
+      expect(comp.errorMessage()).toBe('Unexpected.');
+    });
+
+    it('lets a second save through after a server error, rather than deadlocking', async () => {
+      commandServiceMock.execute.mockResolvedValue({
+        success: false,
+        violations: [{ field: 'emailAddress', message: 'Taken.' }],
+        error: 'Validation failed',
+      });
+      patch({ name: 'Updated' });
+      await comp.onSave();
+      expect(comp.form.controls.emailAddress.errors?.['server']).toBe('Taken.');
+
+      commandServiceMock.execute.mockResolvedValue({ success: true });
+      await comp.onSave();
+
+      expect(comp.form.controls.emailAddress.errors).toBeNull();
+      expect(commandServiceMock.execute).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/requel-angular/src/app/features/users/edit-account.spec.ts
+++ b/requel-angular/src/app/features/users/edit-account.spec.ts
@@ -299,6 +299,42 @@ describe('EditAccountComponent', () => {
       });
     });
 
+    /**
+     * Several command-level messages share the one banner, so the separator matters.
+     * Regression: #132 briefly joined with a space, which turned two fragments into one
+     * broken sentence ("Email is invalid Phone is required") — caught by
+     * e2e/account.e2e.ts, not by any unit test, hence this one.
+     */
+    it('joins several command-level violations readably', async () => {
+      commandServiceMock.execute.mockResolvedValue({
+        success: false,
+        violations: [
+          { field: null, message: 'Email is invalid' },
+          { field: null, message: 'Phone is required' },
+        ],
+        error: null,
+      });
+      patch({ name: 'Updated' });
+
+      await comp.onSave();
+
+      expect(comp.errorMessage()).toBe('Email is invalid; Phone is required');
+    });
+
+    it('treats a violation with no field at all as command-level', async () => {
+      // The server omits `field` entirely rather than sending null — same handling.
+      commandServiceMock.execute.mockResolvedValue({
+        success: false,
+        violations: [{ message: 'Email is invalid' }, { message: 'Phone is required' }],
+        error: null,
+      });
+      patch({ name: 'Updated' });
+
+      await comp.onSave();
+
+      expect(comp.errorMessage()).toBe('Email is invalid; Phone is required');
+    });
+
     it('shows an unmappable violation page-level rather than dropping it', async () => {
       commandServiceMock.execute.mockResolvedValue({
         success: false,

--- a/requel-angular/src/app/features/users/edit-account.ts
+++ b/requel-angular/src/app/features/users/edit-account.ts
@@ -45,6 +45,14 @@ const ACCOUNT_FIELD_MAP: Record<string, string> = {
 };
 
 /**
+ * Separator for several command-level messages sharing the one page-level banner.
+ * Semicolons, not spaces: two sentence fragments run together ("Email is invalid Phone
+ * is required") read as one broken sentence. This is the separator the pre-#132 code
+ * used and e2e/account.e2e.ts asserts.
+ */
+const SEPARATOR = '; ';
+
+/**
  * Edit Account page — allows the current user to update their own profile.
  * Non-admin users can only change name, email, phone, password.
  * Role/permission editing is restricted to the admin user editor.
@@ -293,7 +301,7 @@ export class EditAccountComponent implements OnInit, DirtyCheckable {
 
       const unresolved = applyCommandErrors(this.form, result.violations, ACCOUNT_FIELD_MAP);
       if (unresolved.length) {
-        this.errorMessage.set(unresolved.join(' '));
+        this.errorMessage.set(unresolved.join(SEPARATOR));
       } else if (!result.violations?.length) {
         this.errorMessage.set(result.error ?? 'Save failed.');
       }

--- a/requel-angular/src/app/features/users/edit-account.ts
+++ b/requel-angular/src/app/features/users/edit-account.ts
@@ -18,9 +18,9 @@
  * along with Requel. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import { Component, OnInit, signal, computed, ViewChild } from '@angular/core';
+import { Component, OnInit, signal, computed } from '@angular/core';
 import { PageHeaderComponent } from '../../shared/page-header';
-import { FormsModule, NgForm } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
 import { InputText } from 'primeng/inputtext';
 import { Password } from 'primeng/password';
@@ -30,6 +30,19 @@ import { MessageModule } from 'primeng/message';
 import { AuthService } from '../../core/auth.service';
 import { CommandService } from '../../core/command.service';
 import { UserService } from '../../core/user.service';
+import { AppFieldComponent, AppFieldControlDirective } from '../../shared/app-field';
+import { applyCommandErrors, clearServerErrors, passwordsMatch } from '../../shared/form-errors';
+import { PASSWORD_MAX_LENGTH } from '../../shared/validation-limits';
+
+/**
+ * JPA entity property name -> form control name, for {@link applyCommandErrors}.
+ *
+ * `UserImpl` stores the hash, so a password constraint arrives as `encryptedPassword`;
+ * the form calls that field `password`. `emailAddress` and the rest already match.
+ */
+const ACCOUNT_FIELD_MAP: Record<string, string> = {
+  encryptedPassword: 'password',
+};
 
 /**
  * Edit Account page — allows the current user to update their own profile.
@@ -39,7 +52,17 @@ import { UserService } from '../../core/user.service';
 @Component({
   selector: 'app-edit-account',
   standalone: true,
-  imports: [PageHeaderComponent, FormsModule, InputText, Password, SelectModule, ButtonModule, MessageModule],
+  imports: [
+    PageHeaderComponent,
+    ReactiveFormsModule,
+    InputText,
+    Password,
+    SelectModule,
+    ButtonModule,
+    MessageModule,
+    AppFieldComponent,
+    AppFieldControlDirective,
+  ],
   template: `
     <div class="edit-account" data-testid="account-editor">
       <app-page-header title="Edit Account" />
@@ -51,97 +74,175 @@ import { UserService } from '../../core/user.service';
         <p-message severity="success" [text]="successMessage()!" />
       }
 
-      <form #accountForm="ngForm" (ngSubmit)="onSave()">
-        <div class="field">
-          <label for="username">Username</label>
-          <input pInputText id="username" [ngModel]="username()" name="username" disabled />
-        </div>
+      <form [formGroup]="form" (ngSubmit)="onSave()">
+        <!--
+          controlId values match the ids the e2e page objects locate (#username, #name,
+          #email, #password, #repassword). For the two p-password rows that means the id
+          now lands on the INNER input rather than the p-password host, so the page
+          objects' .locator('#password').locator('input') became .locator('#password') —
+          updated in e2e/pages/UserEditorPage.ts and e2e/account.e2e.ts.
+        -->
+        <app-field label="Username" controlId="username" [control]="form.controls.username">
+          <input pInputText appFieldControl id="username" formControlName="username" autocomplete="username" />
+        </app-field>
 
-        <div class="field">
-          <label for="name">Name</label>
-          <input pInputText id="name" [(ngModel)]="name" name="name" />
-        </div>
+        <app-field
+          label="Name"
+          controlId="name"
+          [control]="form.controls.name"
+          [submitted]="submitted()"
+        >
+          <input pInputText appFieldControl id="name" formControlName="name" autocomplete="name" />
+        </app-field>
 
-        <div class="field">
-          <label for="email">Email</label>
-          <input pInputText id="email" [(ngModel)]="emailAddress" name="email" type="email" />
-        </div>
+        <app-field
+          label="Email"
+          controlId="email"
+          [control]="form.controls.emailAddress"
+          [submitted]="submitted()"
+        >
+          <input pInputText appFieldControl id="email" type="email" formControlName="emailAddress"
+                 autocomplete="email" />
+        </app-field>
 
-        <div class="field">
-          <label for="phone">Phone</label>
-          <input pInputText id="phone" [(ngModel)]="phoneNumber" name="phone" />
-        </div>
+        <app-field
+          label="Phone"
+          controlId="phone"
+          [control]="form.controls.phoneNumber"
+          [submitted]="submitted()"
+        >
+          <input pInputText appFieldControl id="phone" formControlName="phoneNumber" autocomplete="tel" />
+        </app-field>
 
-        <div class="field">
-          <label for="org">Organization</label>
-          <p-select id="org" [(ngModel)]="organizationName" name="org"
-                    [options]="orgOptions()" [editable]="true"
-                    placeholder="Select or type organization" />
-        </div>
+        <app-field
+          label="Organization"
+          controlId="account-org-input"
+          [control]="form.controls.organizationName"
+          [submitted]="submitted()"
+        >
+          <p-select
+            appFieldControl
+            inputId="account-org-input"
+            data-testid="account-organization"
+            formControlName="organizationName"
+            [options]="orgOptions()"
+            [editable]="true"
+            placeholder="Select or type organization"
+          />
+        </app-field>
 
-        <div class="field">
-          <label for="password">New Password (leave blank to keep current)</label>
-          <p-password id="password" [(ngModel)]="password" name="password"
-                      [feedback]="false" [toggleMask]="true" />
-        </div>
+        <app-field
+          label="New Password"
+          helper="Leave blank to keep your current password."
+          controlId="password"
+          [control]="form.controls.password"
+          [submitted]="submitted()"
+        >
+          <p-password
+            appFieldControl
+            inputId="password"
+            formControlName="password"
+            [feedback]="false"
+            [toggleMask]="true"
+            autocomplete="new-password"
+          />
+        </app-field>
 
-        <div class="field">
-          <label for="repassword">Confirm New Password</label>
-          <p-password id="repassword" [(ngModel)]="repassword" name="repassword"
-                      [feedback]="false" [toggleMask]="true" />
-        </div>
+        <app-field
+          label="Confirm New Password"
+          controlId="repassword"
+          [control]="form.controls.repassword"
+          [submitted]="submitted()"
+          [divider]="false"
+        >
+          <p-password
+            appFieldControl
+            inputId="repassword"
+            formControlName="repassword"
+            [feedback]="false"
+            [toggleMask]="true"
+            autocomplete="new-password"
+          />
+        </app-field>
 
         <div class="actions">
           <p-button type="submit" label="Save" icon="pi pi-check" data-testid="account-save"
-                    [loading]="saving()" [disabled]="!accountForm.dirty" />
+                    [loading]="saving()"
+                    [disabled]="form.invalid || form.pristine || saving()" />
         </div>
       </form>
     </div>
   `,
   styles: [`
     .edit-account { max-width: 500px; }
-    .field { margin-bottom: 1rem; display: flex; flex-direction: column; gap: 0.5rem; }
-    .field label { font-weight: 500; }
-    .field input, .field p-password, .field p-select { width: 100%; }
-    .actions { margin-top: 1rem; }
+    /* app-field owns the rows (issue #132); the caller keeps control width. */
+    app-field input, app-field p-password, app-field p-select { width: 100%; }
+    .actions { margin-top: var(--rq-space-4); }
   `]
 })
 export class EditAccountComponent implements OnInit, DirtyCheckable {
 
-  @ViewChild('accountForm') private viewAccountForm?: NgForm;
-
   readonly saving = signal(false);
+  readonly submitted = signal(false);
   readonly errorMessage = signal<string | null>(null);
   readonly successMessage = signal<string | null>(null);
 
   readonly username = computed(() => this.authService.user()?.username ?? '');
-  readonly name = signal('');
-  readonly emailAddress = signal('');
-  readonly phoneNumber = signal('');
-  readonly organizationName = signal('');
-  readonly password = signal('');
-  readonly repassword = signal('');
 
   readonly organizations = signal<{label: string; value: string}[]>([]);
   readonly orgOptions = computed(() => this.organizations());
+
+  /**
+   * The password rows are optional here — blank means "keep the current one" — and the
+   * validators express that without a conditional branch: Angular's `minLength` returns
+   * null for an empty value, so `minLength(1)` only bites once something is typed, and
+   * `passwordsMatch` is satisfied when both rows are empty. `maxLength` mirrors
+   * `UserImpl.MAX_PASSWORD_LENGTH`, the only password bound the server enforces.
+   *
+   * `username` is disabled rather than read-only, matching the previous markup and the
+   * e2e assertion that it is disabled. Disabled controls are excluded from `form.value`,
+   * so the save path reads `getRawValue()`.
+   */
+  readonly form = new FormGroup(
+    {
+      username: new FormControl('', { nonNullable: true }),
+      name: new FormControl('', { validators: Validators.required, nonNullable: true }),
+      emailAddress: new FormControl('', { validators: Validators.email, nonNullable: true }),
+      phoneNumber: new FormControl('', { nonNullable: true }),
+      organizationName: new FormControl('', { nonNullable: true }),
+      password: new FormControl('', {
+        validators: [Validators.minLength(1), Validators.maxLength(PASSWORD_MAX_LENGTH)],
+        nonNullable: true,
+      }),
+      repassword: new FormControl('', { nonNullable: true }),
+    },
+    { validators: passwordsMatch('password', 'repassword') }
+  );
 
   constructor(
     private authService: AuthService,
     private commandService: CommandService,
     private userService: UserService
-  ) {}
+  ) {
+    this.form.controls.username.disable();
+  }
 
+  /** Derived from the form, so there is no NgForm ViewChild to reach through (#132). */
   hasUnsavedChanges(): boolean {
-    return this.viewAccountForm?.dirty ?? false;
+    return this.form.dirty;
   }
 
   async ngOnInit(): Promise<void> {
     const user = this.authService.user();
     if (user) {
-      this.name.set(user.name ?? '');
-      this.emailAddress.set(user.emailAddress ?? '');
-      this.phoneNumber.set(user.phoneNumber ?? '');
-      this.organizationName.set(user.organizationName ?? '');
+      this.form.patchValue({
+        username: user.username ?? '',
+        name: user.name ?? '',
+        emailAddress: user.emailAddress ?? '',
+        phoneNumber: user.phoneNumber ?? '',
+        organizationName: user.organizationName ?? '',
+      });
+      this.form.markAsPristine();
     }
     try {
       const orgs = await this.userService.listOrganizations();
@@ -152,33 +253,48 @@ export class EditAccountComponent implements OnInit, DirtyCheckable {
   }
 
   async onSave(): Promise<void> {
+    this.submitted.set(true);
+    // Before the validity check: a server error from the last attempt makes its control
+    // invalid, so clearing afterwards would leave the form permanently unsubmittable.
+    clearServerErrors(this.form);
+
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
     this.saving.set(true);
     this.errorMessage.set(null);
     this.successMessage.set(null);
 
     try {
+      const value = this.form.getRawValue();
       const input: Record<string, unknown> = {
         username: this.username(),
-        name: this.name(),
-        emailAddress: this.emailAddress(),
-        phoneNumber: this.phoneNumber(),
-        organizationName: this.organizationName() || null
+        name: value.name,
+        emailAddress: value.emailAddress,
+        phoneNumber: value.phoneNumber,
+        organizationName: value.organizationName || null
       };
 
-      if (this.password()) {
-        input['password'] = this.password();
-        input['repassword'] = this.repassword();
+      if (value.password) {
+        input['password'] = value.password;
+        input['repassword'] = value.repassword;
       }
 
       const result = await this.commandService.execute('EditUser', input);
       if (result.success) {
         this.successMessage.set('Account updated.');
-        this.password.set('');
-        this.repassword.set('');
-        this.viewAccountForm?.form.markAsPristine();
-      } else if (result.violations?.length) {
-        this.errorMessage.set(result.violations.map(v => v.message).join('; '));
-      } else {
+        this.form.patchValue({ password: '', repassword: '' });
+        this.form.markAsPristine();
+        this.submitted.set(false);
+        return;
+      }
+
+      const unresolved = applyCommandErrors(this.form, result.violations, ACCOUNT_FIELD_MAP);
+      if (unresolved.length) {
+        this.errorMessage.set(unresolved.join(' '));
+      } else if (!result.violations?.length) {
         this.errorMessage.set(result.error ?? 'Save failed.');
       }
     } catch (err: unknown) {

--- a/requel-angular/src/app/features/users/settings.a11y.spec.ts
+++ b/requel-angular/src/app/features/users/settings.a11y.spec.ts
@@ -1,0 +1,79 @@
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { SettingsComponent } from './settings';
+import { PreferencesService } from '../../core/preferences.service';
+import { expectNoAxeViolations } from '../../shared/testing/a11y';
+
+describe('SettingsComponent accessibility (issue #132)', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fixture: any;
+  let comp: SettingsComponent;
+
+  async function render(): Promise<HTMLElement> {
+    TestBed.configureTestingModule({
+      imports: [SettingsComponent],
+      providers: [
+        provideNoopAnimations(),
+        {
+          provide: PreferencesService,
+          useValue: {
+            load: vi
+              .fn()
+              .mockResolvedValue({ sidebarProjectLimit: 5, sidebarProjectStaleness: 'ONE_MONTH' }),
+            save: vi.fn().mockResolvedValue({
+              sidebarProjectLimit: 5,
+              sidebarProjectStaleness: 'ONE_MONTH',
+            }),
+          },
+        },
+      ],
+    });
+    fixture = TestBed.createComponent(SettingsComponent);
+    comp = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  it('has no axe-core violations at rest', async () => {
+    await expectNoAxeViolations(await render());
+  });
+
+  it('has no axe-core violations with a field in its error state', async () => {
+    const el = await render();
+    comp.form.controls.sidebarProjectLimit.setValue(0);
+    comp.form.controls.sidebarProjectLimit.markAsTouched();
+    fixture.detectChanges();
+
+    expect(el.querySelector('[data-testid="field-error"]')).not.toBeNull();
+    await expectNoAxeViolations(el);
+  });
+
+  it('has no axe-core violations with a page-level save failure showing', async () => {
+    const el = await render();
+    comp.errorMessage.set('Failed to save preferences.');
+    fixture.detectChanges();
+    await expectNoAxeViolations(el);
+  });
+
+  /**
+   * The helper text under each label used to be a bare `<small>` with no programmatic
+   * link to its control, so a screen-reader user never heard it. app-field wires it
+   * through aria-describedby, and the error joins the same list rather than replacing it.
+   */
+  it('keeps helper text and the error both described by the control', async () => {
+    const el = await render();
+    comp.form.controls.sidebarProjectLimit.setValue(0);
+    comp.form.controls.sidebarProjectLimit.markAsTouched();
+    fixture.detectChanges();
+
+    const input = el.querySelector<HTMLInputElement>('#settings-project-limit-input')!;
+    const ids = (input.getAttribute('aria-describedby') ?? '').split(' ').filter(Boolean);
+    expect(ids).toHaveLength(2);
+
+    const texts = ids.map(id => el.querySelector(`#${id}`)?.textContent?.trim());
+    expect(texts).toContain('Maximum number of projects shown in the sidebar.');
+    expect(texts).toContain('Must be 1 or more.');
+  });
+});

--- a/requel-angular/src/app/features/users/settings.spec.ts
+++ b/requel-angular/src/app/features/users/settings.spec.ts
@@ -14,8 +14,8 @@ describe('SettingsComponent', () => {
       imports: [SettingsComponent],
       providers: [
         provideNoopAnimations(),
-        { provide: PreferencesService, useValue: preferencesServiceMock }
-      ]
+        { provide: PreferencesService, useValue: preferencesServiceMock },
+      ],
     });
     fixture = TestBed.createComponent(SettingsComponent);
     comp = fixture.componentInstance;
@@ -23,8 +23,12 @@ describe('SettingsComponent', () => {
 
   beforeEach(() => {
     preferencesServiceMock = {
-      load: vi.fn().mockResolvedValue({ sidebarProjectLimit: 5, sidebarProjectStaleness: 'ONE_MONTH' }),
-      save: vi.fn().mockResolvedValue({ sidebarProjectLimit: 10, sidebarProjectStaleness: 'THREE_MONTHS' })
+      load: vi
+        .fn()
+        .mockResolvedValue({ sidebarProjectLimit: 5, sidebarProjectStaleness: 'ONE_MONTH' }),
+      save: vi
+        .fn()
+        .mockResolvedValue({ sidebarProjectLimit: 10, sidebarProjectStaleness: 'THREE_MONTHS' }),
     };
     setup();
   });
@@ -33,8 +37,8 @@ describe('SettingsComponent', () => {
     fixture.detectChanges();
     await fixture.whenStable();
     expect(preferencesServiceMock.load).toHaveBeenCalled();
-    expect(comp.sidebarProjectLimit).toBe(5);
-    expect(comp.sidebarProjectStaleness).toBe('ONE_MONTH');
+    expect(comp.form.controls.sidebarProjectLimit.value).toBe(5);
+    expect(comp.form.controls.sidebarProjectStaleness.value).toBe('ONE_MONTH');
   });
 
   it('ngOnInit sets errorMessage when load fails', async () => {
@@ -45,12 +49,11 @@ describe('SettingsComponent', () => {
   });
 
   it('onSave calls preferencesService.save with current values', async () => {
-    comp.sidebarProjectLimit = 20;
-    comp.sidebarProjectStaleness = 'SIX_MONTHS';
+    comp.form.setValue({ sidebarProjectLimit: 20, sidebarProjectStaleness: 'SIX_MONTHS' });
     await comp.onSave();
     expect(preferencesServiceMock.save).toHaveBeenCalledWith({
       sidebarProjectLimit: 20,
-      sidebarProjectStaleness: 'SIX_MONTHS'
+      sidebarProjectStaleness: 'SIX_MONTHS',
     });
   });
 
@@ -65,5 +68,138 @@ describe('SettingsComponent', () => {
     await comp.onSave();
     expect(comp.errorMessage()).toBe('Failed to save preferences.');
     expect(comp.saving()).toBe(false);
+  });
+
+  it('onReset restores the defaults and saves them', async () => {
+    comp.form.setValue({ sidebarProjectLimit: 42, sidebarProjectStaleness: 'ALWAYS' });
+    await comp.onReset();
+    expect(preferencesServiceMock.save).toHaveBeenCalledWith({
+      sidebarProjectLimit: 10,
+      sidebarProjectStaleness: 'THREE_MONTHS',
+    });
+  });
+
+  describe('reactive form (issue #132)', () => {
+    const limit = () => comp.form.controls.sidebarProjectLimit;
+
+    it('starts valid with the default values', () => {
+      expect(comp.form.valid).toBe(true);
+      expect(limit().value).toBe(10);
+    });
+
+    it('requires the project limit', () => {
+      limit().setValue(null);
+      expect(limit().hasError('required')).toBe(true);
+      expect(comp.form.invalid).toBe(true);
+    });
+
+    it.each([
+      [0, 'min'],
+      [-3, 'min'],
+      [101, 'max'],
+      [2.5, 'integer'],
+    ])('rejects a project limit of %p with the %s error', (value, error) => {
+      limit().setValue(value as number);
+      expect(limit().hasError(error)).toBe(true);
+    });
+
+    it.each([1, 10, 100])('accepts a project limit of %p', value => {
+      limit().setValue(value);
+      expect(limit().valid).toBe(true);
+    });
+
+    it('requires a staleness threshold', () => {
+      comp.form.controls.sidebarProjectStaleness.setValue('');
+      expect(comp.form.controls.sidebarProjectStaleness.hasError('required')).toBe(true);
+    });
+
+    it('does not save an invalid form', async () => {
+      limit().setValue(0);
+      await comp.onSave();
+      expect(preferencesServiceMock.save).not.toHaveBeenCalled();
+      expect(comp.submitted()).toBe(true);
+    });
+
+    it('marks the form pristine after a successful save', async () => {
+      comp.form.markAsDirty();
+      await comp.onSave();
+      expect(comp.form.pristine).toBe(true);
+    });
+
+    it('marks the form pristine after loading, so Save starts disabled', async () => {
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(comp.form.pristine).toBe(true);
+    });
+
+    it('leaves the form dirty when a save fails, so the user can retry', async () => {
+      preferencesServiceMock.save.mockRejectedValue(new Error('Server error'));
+      comp.form.markAsDirty();
+      await comp.onSave();
+      expect(comp.form.dirty).toBe(true);
+    });
+
+    it('disables Save while the form is pristine', async () => {
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const button = (fixture.nativeElement as HTMLElement).querySelector<HTMLButtonElement>(
+        '[data-testid="settings-save"] button'
+      );
+      expect(button?.disabled).toBe(true);
+    });
+
+    it('keeps Reset enabled while the form is pristine', async () => {
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const button = (fixture.nativeElement as HTMLElement).querySelector<HTMLButtonElement>(
+        '[data-testid="settings-reset"] button'
+      );
+      expect(button?.disabled).toBe(false);
+    });
+
+    it('shows the inline min error under the field, not as a page message', async () => {
+      fixture.detectChanges();
+      await fixture.whenStable();
+      limit().setValue(0);
+      limit().markAsTouched();
+      fixture.detectChanges();
+
+      const el = fixture.nativeElement as HTMLElement;
+      const error = el.querySelector('[data-testid="field-error"]');
+      expect(error?.textContent?.trim()).toBe('Must be 1 or more.');
+      expect(comp.errorMessage()).toBe('');
+    });
+
+    it('keeps the e2e test hooks on the same elements', () => {
+      fixture.detectChanges();
+      const el = fixture.nativeElement as HTMLElement;
+      for (const id of [
+        'settings-page',
+        'settings-project-limit',
+        'settings-staleness',
+        'settings-save',
+        'settings-reset',
+      ]) {
+        expect(el.querySelector(`[data-testid="${id}"]`), id).not.toBeNull();
+      }
+    });
+
+    it('binds each label to its control, and links the helper text (issue #138)', () => {
+      fixture.detectChanges();
+      const el = fixture.nativeElement as HTMLElement;
+
+      const labels = Array.from(el.querySelectorAll('label'));
+      expect(labels.map(l => l.getAttribute('for'))).toEqual([
+        'settings-project-limit-input',
+        'settings-staleness-input',
+      ]);
+
+      const numberInput = el.querySelector('#settings-project-limit-input');
+      expect(numberInput?.getAttribute('aria-describedby')).toBeTruthy();
+    });
   });
 });

--- a/requel-angular/src/app/features/users/settings.ts
+++ b/requel-angular/src/app/features/users/settings.ts
@@ -18,9 +18,9 @@
  * along with Requel. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import { ChangeDetectorRef, Component, OnInit, signal } from '@angular/core';
+import { Component, OnInit, signal } from '@angular/core';
 import { PageHeaderComponent } from '../../shared/page-header';
-import { FormsModule } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
 import { InputNumberModule } from 'primeng/inputnumber';
 import { SelectModule } from 'primeng/select';
@@ -29,12 +29,29 @@ import { PreferencesService } from '../../core/preferences.service';
 import { AuthService } from '../../core/auth.service';
 import { UserPreferencesDto, STALENESS_OPTIONS } from '../../models/preferences';
 import { ApiTokensComponent } from './api-tokens';
+import { AppFieldComponent, AppFieldControlDirective } from '../../shared/app-field';
+import { integer } from '../../shared/form-errors';
+
+/** The sidebar project limit the reset button restores, and the widget's own bounds. */
+const PROJECT_LIMIT_DEFAULT = 10;
+const PROJECT_LIMIT_MIN = 1;
+const PROJECT_LIMIT_MAX = 100;
+const STALENESS_DEFAULT = 'THREE_MONTHS';
 
 @Component({
   selector: 'app-settings',
   standalone: true,
-  imports: [PageHeaderComponent, FormsModule, ButtonModule, InputNumberModule, SelectModule, MessageModule,
-    ApiTokensComponent],
+  imports: [
+    PageHeaderComponent,
+    ReactiveFormsModule,
+    ButtonModule,
+    InputNumberModule,
+    SelectModule,
+    MessageModule,
+    ApiTokensComponent,
+    AppFieldComponent,
+    AppFieldControlDirective,
+  ],
   template: `
     <div class="settings" data-testid="settings-page">
       <div class="page-header">
@@ -48,62 +65,133 @@ import { ApiTokensComponent } from './api-tokens';
         <p-message severity="error" [text]="errorMessage()" />
       }
 
-      <div class="settings-form">
-        <div class="field">
-          <label for="projectLimit">Sidebar Project Limit</label>
-          <p-inputNumber id="projectLimit" inputId="projectLimitInput"
-                         data-testid="settings-project-limit" [(ngModel)]="sidebarProjectLimit"
-                         [min]="1" [max]="100" [showButtons]="true" />
-          <small>Maximum number of projects shown in the sidebar.</small>
-        </div>
+      <form class="settings-form" [formGroup]="form" (ngSubmit)="onSave()">
+        <app-field
+          label="Sidebar Project Limit"
+          helper="Maximum number of projects shown in the sidebar."
+          controlId="settings-project-limit-input"
+          [control]="form.controls.sidebarProjectLimit"
+          [submitted]="submitted()"
+        >
+          <p-inputNumber
+            appFieldControl
+            inputId="settings-project-limit-input"
+            data-testid="settings-project-limit"
+            formControlName="sidebarProjectLimit"
+            [min]="projectLimitMin"
+            [max]="projectLimitMax"
+            [showButtons]="true"
+          />
+        </app-field>
 
-        <div class="field">
-          <label for="staleness">Project Staleness Threshold</label>
-          <p-select id="staleness" inputId="stalenessInput"
-                    data-testid="settings-staleness" [(ngModel)]="sidebarProjectStaleness"
-                    [options]="stalenessOptions" optionLabel="label" optionValue="value"
-                    placeholder="Select staleness threshold" />
-          <small>Hide projects with no activity older than this threshold.</small>
-        </div>
+        <app-field
+          label="Project Staleness Threshold"
+          helper="Hide projects with no activity older than this threshold."
+          controlId="settings-staleness-input"
+          [control]="form.controls.sidebarProjectStaleness"
+          [submitted]="submitted()"
+          [divider]="false"
+        >
+          <p-select
+            appFieldControl
+            inputId="settings-staleness-input"
+            data-testid="settings-staleness"
+            formControlName="sidebarProjectStaleness"
+            [options]="stalenessOptions"
+            optionLabel="label"
+            optionValue="value"
+            placeholder="Select staleness threshold"
+          />
+        </app-field>
 
         <div class="form-actions">
-          <p-button label="Save" icon="pi pi-check" data-testid="settings-save"
-                    (onClick)="onSave()" [loading]="saving()" />
-          <p-button label="Reset to Defaults" icon="pi pi-refresh" severity="secondary"
-                    data-testid="settings-reset"
-                    [outlined]="true" (onClick)="onReset()" [loading]="saving()" />
+          <p-button
+            type="submit"
+            label="Save"
+            icon="pi pi-check"
+            data-testid="settings-save"
+            [loading]="saving()"
+            [disabled]="form.invalid || form.pristine || saving()"
+          />
+          <p-button
+            type="button"
+            label="Reset to Defaults"
+            icon="pi pi-refresh"
+            severity="secondary"
+            data-testid="settings-reset"
+            [outlined]="true"
+            (onClick)="onReset()"
+            [loading]="saving()"
+          />
         </div>
-      </div>
+      </form>
 
       @if (canManageTokens()) {
         <app-api-tokens />
       }
     </div>
   `,
-  styles: [`
-    .settings { max-width: 600px; }
-    .page-header { margin-bottom: 1.5rem; }
-    .settings-form { display: flex; flex-direction: column; gap: 1.5rem; }
-    .field { display: flex; flex-direction: column; gap: 0.25rem; }
-    .field label { font-weight: 600; }
-    .field small { color: var(--p-text-muted-color); }
-    .form-actions { margin-top: 0.5rem; }
-  `]
+  styles: [
+    `
+      .settings {
+        max-width: 600px;
+      }
+      .page-header {
+        margin-bottom: var(--rq-space-6);
+      }
+      /* app-field owns each row's internal layout and the hairline between rows, so
+         the form only needs to space the action bar off the last row. */
+      .settings-form {
+        display: block;
+      }
+      .form-actions {
+        margin-top: var(--rq-space-4);
+        display: flex;
+        gap: var(--rq-space-2);
+      }
+      /* Projected through app-field, so still this component's nodes to size. */
+      p-inputnumber,
+      p-select {
+        width: 100%;
+      }
+    `,
+  ],
 })
 export class SettingsComponent implements OnInit {
-
   readonly stalenessOptions = STALENESS_OPTIONS;
+  readonly projectLimitMin = PROJECT_LIMIT_MIN;
+  readonly projectLimitMax = PROJECT_LIMIT_MAX;
+
   readonly saving = signal(false);
+  readonly submitted = signal(false);
   readonly successMessage = signal('');
   readonly errorMessage = signal('');
 
-  sidebarProjectLimit = 10;
-  sidebarProjectStaleness = 'THREE_MONTHS';
+  /**
+   * `min`/`max` mirror the `p-inputNumber` bounds so the form cannot hold a value the
+   * widget would not produce, and `integer()` covers the typed case — PrimeNG's
+   * decimal mode will accept a fractional entry that the preference has no meaning
+   * for. These are UI bounds, not backend constraints: preferences are not validated
+   * server-side, so unlike the artifact name/text limits they do not wait on #171.
+   */
+  readonly form = new FormGroup({
+    sidebarProjectLimit: new FormControl<number | null>(PROJECT_LIMIT_DEFAULT, {
+      validators: [
+        Validators.required,
+        Validators.min(PROJECT_LIMIT_MIN),
+        Validators.max(PROJECT_LIMIT_MAX),
+        integer(),
+      ],
+    }),
+    sidebarProjectStaleness: new FormControl(STALENESS_DEFAULT, {
+      validators: Validators.required,
+      nonNullable: true,
+    }),
+  });
 
   constructor(
     private preferencesService: PreferencesService,
-    private authService: AuthService,
-    private cdr: ChangeDetectorRef
+    private authService: AuthService
   ) {}
 
   /**
@@ -117,35 +205,52 @@ export class SettingsComponent implements OnInit {
   async ngOnInit(): Promise<void> {
     try {
       const prefs = await this.preferencesService.load();
-      this.sidebarProjectLimit = prefs.sidebarProjectLimit;
-      this.sidebarProjectStaleness = prefs.sidebarProjectStaleness;
-      // Plain class properties don't guarantee that zone.js schedules a change detection
-      // cycle before PrimeNG's p-select reads its ngModel value. detectChanges() forces
-      // the component tree to update synchronously so the select displays the loaded value.
-      this.cdr.detectChanges();
+      // patchValue notifies each control's value accessor directly, so p-select and
+      // p-inputNumber pick the loaded values up without the ChangeDetectorRef.
+      // detectChanges() the ngModel version needed — plain class properties gave
+      // zone.js no reason to run a cycle before PrimeNG read them.
+      this.form.patchValue(prefs);
+      this.form.markAsPristine();
     } catch {
       this.errorMessage.set('Failed to load preferences.');
     }
   }
 
+  /**
+   * Restores the defaults and saves immediately, as before. Marked dirty explicitly
+   * because `setValue` does not do it, and the save path treats a pristine form as
+   * nothing to do.
+   */
   async onReset(): Promise<void> {
-    this.sidebarProjectLimit = 10;
-    this.sidebarProjectStaleness = 'THREE_MONTHS';
+    this.form.setValue({
+      sidebarProjectLimit: PROJECT_LIMIT_DEFAULT,
+      sidebarProjectStaleness: STALENESS_DEFAULT,
+    });
+    this.form.markAsDirty();
     await this.onSave();
   }
 
   async onSave(): Promise<void> {
+    this.submitted.set(true);
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
     this.saving.set(true);
     this.successMessage.set('');
     this.errorMessage.set('');
     try {
+      const value = this.form.getRawValue();
       const prefs: UserPreferencesDto = {
-        sidebarProjectLimit: this.sidebarProjectLimit,
-        sidebarProjectStaleness: this.sidebarProjectStaleness
+        // Non-null by validation: `required` blocks the invalid path above.
+        sidebarProjectLimit: value.sidebarProjectLimit!,
+        sidebarProjectStaleness: value.sidebarProjectStaleness,
       };
       const updated = await this.preferencesService.save(prefs);
-      this.sidebarProjectLimit = updated.sidebarProjectLimit;
-      this.sidebarProjectStaleness = updated.sidebarProjectStaleness;
+      this.form.patchValue(updated);
+      this.form.markAsPristine();
+      this.submitted.set(false);
       this.successMessage.set('Preferences saved.');
     } catch {
       this.errorMessage.set('Failed to save preferences.');

--- a/requel-angular/src/app/features/users/user-editor.a11y.spec.ts
+++ b/requel-angular/src/app/features/users/user-editor.a11y.spec.ts
@@ -1,0 +1,152 @@
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter, ActivatedRoute, convertToParamMap, Router } from '@angular/router';
+import { BehaviorSubject } from 'rxjs';
+import { UserEditorComponent } from './user-editor';
+import { UserService } from '../../core/user.service';
+import { CommandService } from '../../core/command.service';
+import { expectNoAxeViolations } from '../../shared/testing/a11y';
+
+const MOCK_ROLES = [
+  { roleName: 'ProjectUserRole', displayName: 'Project User',
+    availablePermissions: [{ name: 'editGoals' }, { name: 'deleteGoals' }] },
+  { roleName: 'SystemAdminUserRole', displayName: 'System Admin', availablePermissions: [] }
+];
+
+const MOCK_USER = {
+  id: 1, version: 0, username: 'bob', name: 'Bob Smith',
+  emailAddress: 'bob@example.com', phoneNumber: null, organizationName: 'Acme',
+  roles: ['ProjectUserRole'], permissions: ['editGoals'],
+  permissionsByRole: { ProjectUserRole: ['editGoals'] }
+};
+
+const flush = () => new Promise(r => setTimeout(r, 0));
+
+describe('UserEditorComponent accessibility (issue #132)', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fixture: any;
+  let comp: UserEditorComponent;
+
+  async function render(username = 'new'): Promise<HTMLElement> {
+    const paramMap$ = new BehaviorSubject(convertToParamMap({ username }));
+    TestBed.configureTestingModule({
+      imports: [UserEditorComponent],
+      providers: [
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: ActivatedRoute, useValue: { paramMap: paramMap$.asObservable() } },
+        {
+          provide: UserService,
+          useValue: {
+            listRoles: vi.fn().mockResolvedValue(MOCK_ROLES),
+            listOrganizations: vi.fn().mockResolvedValue([{ id: 1, name: 'Acme' }]),
+            getUser: vi.fn().mockResolvedValue(MOCK_USER),
+          },
+        },
+        { provide: CommandService, useValue: { execute: vi.fn().mockResolvedValue({ success: true }) } },
+      ],
+    });
+    fixture = TestBed.createComponent(UserEditorComponent);
+    comp = fixture.componentInstance;
+    vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+    fixture.detectChanges();
+    await flush();
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  it('has no axe-core violations on the create form', async () => {
+    await expectNoAxeViolations(await render('new'));
+  });
+
+  it('has no axe-core violations on the edit form, with a role expanded', async () => {
+    const el = await render('bob');
+    // A selected role reveals its permission checkboxes, which is the denser state.
+    expect(el.querySelectorAll('.permissions p-checkbox').length).toBeGreaterThan(0);
+    await expectNoAxeViolations(el);
+  });
+
+  it('has no axe-core violations with every field in its error state', async () => {
+    const el = await render('new');
+    comp.form.patchValue({
+      username: '',
+      name: '',
+      emailAddress: 'nope',
+      password: 'a',
+      repassword: 'b',
+      roleNames: [],
+    });
+    comp.form.markAsDirty();
+    await comp.onSave();
+    fixture.detectChanges();
+
+    expect(el.querySelectorAll('[data-testid="field-error"]').length).toBeGreaterThan(0);
+    expect(el.querySelector('[data-testid="user-roles-error"]')).not.toBeNull();
+    await expectNoAxeViolations(el);
+  });
+
+  it('has no axe-core violations in the loading state', async () => {
+    const el = await render('bob');
+    comp.loading.set(true);
+    fixture.detectChanges();
+    await expectNoAxeViolations(el);
+  });
+
+  /**
+   * The two-column group must not reorder anything: DOM order is what both the screen
+   * reader and sequential focus follow, so it has to match the visual grid order.
+   */
+  it('keeps reading order matching the visual two-column order', async () => {
+    const el = await render('new');
+    const labels = Array.from(el.querySelectorAll('.app-field-group app-field label')).map(l =>
+      l.textContent?.trim().replace(/\*$/, '').trim()
+    );
+
+    expect(labels).toEqual([
+      'Username',
+      'Name',
+      'Email',
+      'Phone',
+      'Organization',
+      'Password',
+      'Confirm Password',
+    ]);
+  });
+
+  it('gives every identity control exactly one label', async () => {
+    const el = await render('new');
+    const controls = Array.from(
+      el.querySelectorAll<HTMLElement>('.app-field-group app-field input')
+    ).filter(c => c.id);
+
+    expect(controls.length).toBeGreaterThanOrEqual(7);
+    for (const control of controls) {
+      expect(el.querySelectorAll(`label[for="${control.id}"]`).length, control.id).toBe(1);
+    }
+  });
+
+  /**
+   * The roles error is group-level — there is no single control for it to sit under — so
+   * it renders next to the checkboxes with role="alert" rather than being swallowed into
+   * the page-level message where it would lose its association with the checkbox list.
+   */
+  it('announces the roles error as an alert beside the checkboxes', async () => {
+    const el = await render('new');
+    comp.submitted.set(true);
+    comp.form.controls.roleNames.setValue([]);
+    fixture.detectChanges();
+
+    const error = el.querySelector('[data-testid="user-roles-error"]')!;
+    expect(error.getAttribute('role')).toBe('alert');
+    expect(el.querySelector('[data-testid="user-roles-section"]')!.contains(error)).toBe(true);
+  });
+
+  it('renders the roles heading as an h2 so the page heading order is unbroken', async () => {
+    const el = await render('bob');
+    const headings = Array.from(el.querySelectorAll('h1,h2,h3,h4,h5,h6')).map(h => h.tagName);
+
+    expect(headings[0]).toBe('H1');
+    expect(headings).toContain('H2');
+    expect(headings).not.toContain('H3');
+  });
+});

--- a/requel-angular/src/app/features/users/user-editor.spec.ts
+++ b/requel-angular/src/app/features/users/user-editor.spec.ts
@@ -64,6 +64,20 @@ describe('UserEditorComponent', () => {
     vi.spyOn(router, 'navigate').mockResolvedValue(true);
   });
 
+  /** A complete, valid create-mode form. */
+  function fillNewUser(overrides: Record<string, unknown> = {}): void {
+    comp.form.patchValue({
+      username: 'newuser',
+      name: 'New User',
+      emailAddress: 'new@example.com',
+      password: 'hunter2',
+      repassword: 'hunter2',
+      roleNames: ['ProjectUserRole'],
+      ...overrides,
+    });
+    comp.form.markAsDirty();
+  }
+
   it('isNew() is true when username param is "new"', async () => {
     fixture.detectChanges();
     await flush();
@@ -84,19 +98,19 @@ describe('UserEditorComponent', () => {
     fixture.detectChanges();
     await flush();
     expect(userServiceMock.getUser).toHaveBeenCalledWith('bob');
-    expect(comp.username).toBe('bob');
-    expect(comp.name).toBe('Bob Smith');
-    expect(comp.selectedRoleNames).toContain('ProjectUserRole');
+    expect(comp.form.getRawValue().username).toBe('bob');
+    expect(comp.form.controls.name.value).toBe('Bob Smith');
+    expect(comp.form.controls.roleNames.value).toContain('ProjectUserRole');
   });
 
   it('onSave calls commandService.execute("EditUser") with roles and permissions', async () => {
     fixture.detectChanges();
     await flush();
-    comp.username = 'newuser';
-    comp.name = 'New User';
-    comp.selectedRoleNames = ['ProjectUserRole'];
-    comp.selectedPermissions = { ProjectUserRole: ['editGoals'] };
+    fillNewUser();
+    comp.permissionsControl('ProjectUserRole').setValue(['editGoals']);
+
     await comp.onSave();
+
     expect(commandServiceMock.execute).toHaveBeenCalledWith('EditUser', expect.objectContaining({
       username: 'newuser',
       name: 'New User',
@@ -108,7 +122,7 @@ describe('UserEditorComponent', () => {
   it('onSave sets successMessage when save succeeds', async () => {
     fixture.detectChanges();
     await flush();
-    comp.username = 'testuser';
+    fillNewUser();
     await comp.onSave();
     expect(comp.successMessage()).toBe('User saved successfully.');
     expect(comp.saving()).toBe(false);
@@ -117,8 +131,391 @@ describe('UserEditorComponent', () => {
   it('onSave navigates to /users/:username for new user after success', async () => {
     fixture.detectChanges();
     await flush();
-    comp.username = 'brandnewuser';
+    fillNewUser({ username: 'brandnewuser' });
     await comp.onSave();
     expect(router.navigate).toHaveBeenCalledWith(['/users', 'brandnewuser']);
+  });
+
+  describe('reactive form (issue #132)', () => {
+    it('starts invalid on create, so Save is disabled', async () => {
+      fixture.detectChanges();
+      await flush();
+      expect(comp.form.invalid).toBe(true);
+      expect(comp.form.pristine).toBe(true);
+    });
+
+    it('is valid once every required field is filled', async () => {
+      fixture.detectChanges();
+      await flush();
+      fillNewUser();
+      expect(comp.form.valid).toBe(true);
+    });
+
+    it.each(['username', 'name'] as const)('requires %s', async field => {
+      fixture.detectChanges();
+      await flush();
+      fillNewUser({ [field]: '' });
+      expect(comp.form.controls[field].hasError('required')).toBe(true);
+    });
+
+    it('rejects a malformed email', async () => {
+      fixture.detectChanges();
+      await flush();
+      fillNewUser({ emailAddress: 'nope' });
+      expect(comp.form.controls.emailAddress.hasError('email')).toBe(true);
+    });
+
+    it('requires at least one role', async () => {
+      fixture.detectChanges();
+      await flush();
+      fillNewUser({ roleNames: [] });
+      expect(comp.form.controls.roleNames.hasError('atLeastOne')).toBe(true);
+      expect(comp.form.invalid).toBe(true);
+    });
+
+    it('loads an existing user pristine, so Save starts disabled', async () => {
+      paramMap$.next(convertToParamMap({ username: 'bob' }));
+      fixture.detectChanges();
+      await flush();
+      expect(comp.form.pristine).toBe(true);
+      expect(comp.hasUnsavedChanges()).toBe(false);
+    });
+
+    it('hasUnsavedChanges() derives from form.dirty', async () => {
+      paramMap$.next(convertToParamMap({ username: 'bob' }));
+      fixture.detectChanges();
+      await flush();
+
+      comp.form.controls.phoneNumber.setValue('555-1111');
+      comp.form.controls.phoneNumber.markAsDirty();
+      expect(comp.hasUnsavedChanges()).toBe(true);
+    });
+
+    it('does not save an invalid form', async () => {
+      fixture.detectChanges();
+      await flush();
+      fillNewUser({ name: '' });
+      await comp.onSave();
+      expect(commandServiceMock.execute).not.toHaveBeenCalled();
+      expect(comp.submitted()).toBe(true);
+    });
+
+    it('disables username on edit but still sends it', async () => {
+      paramMap$.next(convertToParamMap({ username: 'bob' }));
+      fixture.detectChanges();
+      await flush();
+      expect(comp.form.controls.username.disabled).toBe(true);
+
+      comp.form.controls.name.setValue('Bob Renamed');
+      comp.form.markAsDirty();
+      await comp.onSave();
+
+      expect(commandServiceMock.execute).toHaveBeenCalledWith(
+        'EditUser',
+        expect.objectContaining({ username: 'bob' })
+      );
+    });
+
+    it('leaves username enabled on create', async () => {
+      fixture.detectChanges();
+      await flush();
+      expect(comp.form.controls.username.enabled).toBe(true);
+    });
+
+    it('marks pristine after a successful save', async () => {
+      paramMap$.next(convertToParamMap({ username: 'bob' }));
+      fixture.detectChanges();
+      await flush();
+      comp.form.controls.name.setValue('Renamed');
+      comp.form.markAsDirty();
+
+      await comp.onSave();
+
+      expect(comp.form.pristine).toBe(true);
+    });
+  });
+
+  describe('password rules (issue #132)', () => {
+    it('requires a password when creating', async () => {
+      fixture.detectChanges();
+      await flush();
+      fillNewUser({ password: '', repassword: '' });
+      expect(comp.form.controls.password.hasError('required')).toBe(true);
+    });
+
+    /**
+     * Editing must not force a password change — blank means "keep the current one",
+     * matching edit-account and the existing "only include password if set" payload.
+     */
+    it('does not require a password when editing', async () => {
+      paramMap$.next(convertToParamMap({ username: 'bob' }));
+      fixture.detectChanges();
+      await flush();
+      expect(comp.form.controls.password.hasError('required')).toBe(false);
+      expect(comp.form.valid).toBe(true);
+    });
+
+    it('omits the password from the payload when blank on edit', async () => {
+      paramMap$.next(convertToParamMap({ username: 'bob' }));
+      fixture.detectChanges();
+      await flush();
+      comp.form.controls.name.setValue('Renamed');
+      comp.form.markAsDirty();
+
+      await comp.onSave();
+
+      const input = commandServiceMock.execute.mock.calls[0][1] as Record<string, unknown>;
+      expect('password' in input).toBe(false);
+    });
+
+    it('reports a mismatch on the confirm row', async () => {
+      fixture.detectChanges();
+      await flush();
+      fillNewUser({ repassword: 'different' });
+      expect(comp.form.controls.repassword.hasError('passwordMismatch')).toBe(true);
+      expect(comp.form.invalid).toBe(true);
+    });
+
+    it('rejects a password over the server maximum', async () => {
+      fixture.detectChanges();
+      await flush();
+      const pw = 'x'.repeat(129);
+      fillNewUser({ password: pw, repassword: pw });
+      expect(comp.form.controls.password.hasError('maxlength')).toBe(true);
+    });
+  });
+
+  describe('roles and permissions (issue #132)', () => {
+    it('creates a permission control per role once roles load', async () => {
+      fixture.detectChanges();
+      await flush();
+      for (const role of MOCK_ROLES) {
+        expect(comp.permissionsControl(role.roleName)).toBeDefined();
+      }
+    });
+
+    it('seeds per-role permissions from the loaded user', async () => {
+      paramMap$.next(convertToParamMap({ username: 'bob' }));
+      fixture.detectChanges();
+      await flush();
+      expect(comp.permissionsControl('ProjectUserRole').value).toEqual(['editGoals']);
+    });
+
+    /**
+     * The permission controls live INSIDE the form for exactly this reason: with the
+     * checkboxes outside it, a permission-only change would not mark the form dirty and
+     * Save would stay disabled with unsaved work on screen.
+     */
+    it('marks the form dirty when only a permission changes', async () => {
+      paramMap$.next(convertToParamMap({ username: 'bob' }));
+      fixture.detectChanges();
+      await flush();
+      expect(comp.form.dirty).toBe(false);
+
+      const permissions = comp.permissionsControl('ProjectUserRole');
+      permissions.setValue(['editGoals', 'deleteGoals']);
+      permissions.markAsDirty();
+
+      expect(comp.form.dirty).toBe(true);
+      expect(comp.hasUnsavedChanges()).toBe(true);
+    });
+
+    it('isRoleSelected() reads the roleNames control', async () => {
+      fixture.detectChanges();
+      await flush();
+      comp.form.controls.roleNames.setValue(['SystemAdminUserRole']);
+      expect(comp.isRoleSelected('SystemAdminUserRole')).toBe(true);
+      expect(comp.isRoleSelected('ProjectUserRole')).toBe(false);
+    });
+
+    it('sends permissions only for the selected roles', async () => {
+      fixture.detectChanges();
+      await flush();
+      fillNewUser();
+      comp.permissionsControl('ProjectUserRole').setValue(['editGoals']);
+      // Left over from a role the user ticked and then unticked.
+      comp.permissionsControl('SystemAdminUserRole').setValue(['somethingStale']);
+
+      await comp.onSave();
+
+      const input = commandServiceMock.execute.mock.calls[0][1] as Record<string, unknown>;
+      expect(input['userRolePermissionNames']).toEqual({ ProjectUserRole: ['editGoals'] });
+    });
+
+    it('shows the roles error only after a submit attempt', async () => {
+      fixture.detectChanges();
+      await flush();
+      expect(comp.showRolesError()).toBe(false);
+
+      fillNewUser({ roleNames: [] });
+      await comp.onSave();
+
+      expect(comp.showRolesError()).toBe(true);
+      fixture.detectChanges();
+      const el = fixture.nativeElement as HTMLElement;
+      const error = el.querySelector('[data-testid="user-roles-error"]');
+      expect(error).not.toBeNull();
+      // Wording comes from the shared map, not from the component.
+      expect(error?.textContent?.trim()).toBe('Select at least one.');
+    });
+
+    it('keeps a mapped server violation on the roles control across a render', async () => {
+      fixture.detectChanges();
+      await flush();
+      fillNewUser();
+      commandServiceMock.execute.mockResolvedValue({
+        success: false,
+        violations: [{ field: 'roles', message: 'Role assignment was rejected.' }],
+        error: 'Validation failed',
+      });
+
+      await comp.onSave();
+      // The roles checkboxes bind via [formControl], so a render revalidates the control.
+      // A setErrors-written server error was nulled here; a validator-backed one survives.
+      fixture.detectChanges();
+
+      expect(comp.form.controls.roleNames.errors).toEqual({
+        server: 'Role assignment was rejected.',
+      });
+      expect(
+        (fixture.nativeElement as HTMLElement)
+          .querySelector('[data-testid="user-roles-error"]')?.textContent?.trim()
+      ).toBe('Role assignment was rejected.');
+    });
+
+    it('drops that server violation once the roles selection changes', async () => {
+      fixture.detectChanges();
+      await flush();
+      fillNewUser();
+      commandServiceMock.execute.mockResolvedValue({
+        success: false,
+        violations: [{ field: 'roles', message: 'Role assignment was rejected.' }],
+        error: 'Validation failed',
+      });
+      await comp.onSave();
+
+      comp.form.controls.roleNames.setValue(['SystemAdminUserRole']);
+
+      expect(comp.form.controls.roleNames.errors).toBeNull();
+    });
+
+    it('keeps the roles-section test hooks', async () => {
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+      const el = fixture.nativeElement as HTMLElement;
+
+      expect(el.querySelector('[data-testid="user-roles-section"]')).not.toBeNull();
+      expect(el.querySelectorAll('[data-testid="user-role-group"]').length).toBe(2);
+      expect(el.querySelectorAll('[data-testid="user-role-label"]').length).toBe(2);
+    });
+  });
+
+  describe('two-column layout (issue #172)', () => {
+    it('lays the identity fields out in an app-field-group', async () => {
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+      const el = fixture.nativeElement as HTMLElement;
+
+      const group = el.querySelector<HTMLElement>('.app-field-group');
+      expect(group).not.toBeNull();
+      expect(group?.style.getPropertyValue('--rq-field-group-columns')).toBe('2');
+      expect(el.querySelectorAll('.app-field-group > app-field').length).toBe(7);
+    });
+
+    /** Seven rows over two columns: the final row holds one cell and draws no divider. */
+    it('suppresses the divider on the partial final row', async () => {
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+      const rows = Array.from(
+        (fixture.nativeElement as HTMLElement).querySelectorAll('.app-field-group > app-field')
+      );
+
+      const lastRow = rows.map(r => r.classList.contains('rq-field-cell-last-row'));
+      expect(lastRow).toEqual([false, false, false, false, false, false, true]);
+    });
+  });
+
+  describe('command error handling (issue #132)', () => {
+    it('puts a field violation on its control instead of the page message', async () => {
+      commandServiceMock.execute.mockResolvedValue({
+        success: false,
+        violations: [{ field: 'username', message: 'That username is taken.' }],
+        error: 'Validation failed',
+      });
+      fixture.detectChanges();
+      await flush();
+      fillNewUser();
+
+      await comp.onSave();
+
+      expect(comp.form.controls.username.errors).toEqual({ server: 'That username is taken.' });
+      expect(comp.errorMessage()).toBeNull();
+    });
+
+    it('maps roles onto the roleNames control', async () => {
+      commandServiceMock.execute.mockResolvedValue({
+        success: false,
+        violations: [{ field: 'roles', message: 'At least one role is required.' }],
+        error: 'Validation failed',
+      });
+      fixture.detectChanges();
+      await flush();
+      fillNewUser();
+
+      await comp.onSave();
+
+      expect(comp.form.controls.roleNames.errors).toEqual({
+        server: 'At least one role is required.',
+      });
+    });
+
+    it('shows an unmappable violation page-level rather than dropping it', async () => {
+      commandServiceMock.execute.mockResolvedValue({
+        success: false,
+        violations: [{ field: 'mystery', message: 'Unexpected.' }],
+        error: 'Validation failed',
+      });
+      fixture.detectChanges();
+      await flush();
+      fillNewUser();
+
+      await comp.onSave();
+
+      expect(comp.errorMessage()).toBe('Unexpected.');
+    });
+
+    it('lets a second save through after a server error', async () => {
+      commandServiceMock.execute.mockResolvedValue({
+        success: false,
+        violations: [{ field: 'username', message: 'Taken.' }],
+        error: 'Validation failed',
+      });
+      fixture.detectChanges();
+      await flush();
+      fillNewUser();
+      await comp.onSave();
+      expect(comp.form.controls.username.errors?.['server']).toBe('Taken.');
+
+      commandServiceMock.execute.mockResolvedValue({ success: true });
+      await comp.onSave();
+
+      expect(comp.form.controls.username.errors).toBeNull();
+      expect(commandServiceMock.execute).toHaveBeenCalledTimes(2);
+    });
+
+    it('still surfaces a load failure through the retryable error state', async () => {
+      userServiceMock.listRoles.mockRejectedValue(new Error('Network down'));
+      fixture.detectChanges();
+      await flush();
+
+      expect(comp.loadError()).toBe('Network down');
+      fixture.detectChanges();
+      expect(
+        (fixture.nativeElement as HTMLElement).querySelector('[data-testid="user-editor-load-error"]')
+      ).not.toBeNull();
+    });
   });
 });

--- a/requel-angular/src/app/features/users/user-editor.ts
+++ b/requel-angular/src/app/features/users/user-editor.ts
@@ -18,12 +18,12 @@
  * along with Requel. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import { ChangeDetectorRef, Component, OnDestroy, OnInit, signal, computed, ViewChild } from '@angular/core';
+import { Component, OnDestroy, OnInit, signal, computed } from '@angular/core';
 import { PageHeaderComponent } from '../../shared/page-header';
 import { AppCardComponent } from '../../shared/app-card';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
-import { FormsModule, NgForm } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
 import { InputText } from 'primeng/inputtext';
 import { Password } from 'primeng/password';
@@ -37,14 +37,51 @@ import { UserService } from '../../core/user.service';
 import { CommandService } from '../../core/command.service';
 import { LoadingStateComponent } from '../../shared/loading-state';
 import { ErrorStateComponent } from '../../shared/error-state';
+import { AppFieldComponent, AppFieldControlDirective } from '../../shared/app-field';
+import { AppFieldGroupComponent } from '../../shared/app-field-group';
+import {
+  applyCommandErrors,
+  atLeastOne,
+  clearServerErrors,
+  firstErrorMessage,
+  passwordsMatch,
+} from '../../shared/form-errors';
+import { PASSWORD_MAX_LENGTH } from '../../shared/validation-limits';
+
+/**
+ * JPA entity property name -> form control name, for {@link applyCommandErrors}.
+ *
+ * `UserImpl` stores a hash (`encryptedPassword`) and holds `roles`, while the form calls
+ * those `password` and `roleNames`. Everything else already matches.
+ */
+const USER_FIELD_MAP: Record<string, string> = {
+  encryptedPassword: 'password',
+  roles: 'roleNames',
+  userRoleNames: 'roleNames',
+};
 
 @Component({
   selector: 'app-user-editor',
   standalone: true,
-  imports: [PageHeaderComponent, AppCardComponent, FormsModule, InputText, Password, ButtonModule, CheckboxModule, SelectModule, MessageModule, LoadingStateComponent, ErrorStateComponent],
+  imports: [
+    PageHeaderComponent,
+    AppCardComponent,
+    ReactiveFormsModule,
+    InputText,
+    Password,
+    ButtonModule,
+    CheckboxModule,
+    SelectModule,
+    MessageModule,
+    LoadingStateComponent,
+    ErrorStateComponent,
+    AppFieldComponent,
+    AppFieldControlDirective,
+    AppFieldGroupComponent,
+  ],
   template: `
     <div class="user-editor" data-testid="user-editor">
-      <app-page-header [title]="isNew() ? 'New User' : 'Edit User: ' + username" />
+      <app-page-header [title]="isNew() ? 'New User' : 'Edit User: ' + form.controls.username.value" />
 
       @if (errorMessage()) {
         <p-message severity="error" [text]="errorMessage()!" />
@@ -62,67 +99,77 @@ import { ErrorStateComponent } from '../../shared/error-state';
                          (retry)="retryLoad()" />
       } @else {
       <app-card>
-        <form #userForm="ngForm" (ngSubmit)="onSave()">
-          <div class="form-grid">
-            <div class="field">
-              <label for="username">Username</label>
-              <input pInputText id="username" [(ngModel)]="username" name="username"
-                     [disabled]="!isNew()" />
-            </div>
+        <form [formGroup]="form" (ngSubmit)="onSave()">
+          <!--
+            The two-column group from issue #172 keeps this form dense; migrating seven
+            fields to single-column rows would have turned it into a long scroll. Seven
+            rows over two columns leaves a partial final row, which is exactly the case
+            app-field-group suppresses the trailing divider for.
 
-            <div class="field">
-              <label for="name">Name</label>
-              <input pInputText id="name" [(ngModel)]="name" name="name" />
-            </div>
+            controlId values match the ids the e2e page objects locate. For #password and
+            #repassword the id now lands on the INNER input rather than the p-password
+            host, so UserEditorPage's .locator('#password').locator('input') became
+            .locator('#password').
+          -->
+          <app-field-group [columns]="2">
+            <app-field label="Username" controlId="username" [control]="form.controls.username"
+                       [submitted]="submitted()">
+              <input pInputText appFieldControl id="username" formControlName="username" />
+            </app-field>
 
-            <div class="field">
-              <label for="email">Email</label>
-              <input pInputText id="email" [(ngModel)]="emailAddress" name="email" type="email" />
-            </div>
+            <app-field label="Name" controlId="name" [control]="form.controls.name"
+                       [submitted]="submitted()">
+              <input pInputText appFieldControl id="name" formControlName="name" />
+            </app-field>
 
-            <div class="field">
-              <label for="phone">Phone</label>
-              <input pInputText id="phone" [(ngModel)]="phoneNumber" name="phone" />
-            </div>
+            <app-field label="Email" controlId="email" [control]="form.controls.emailAddress"
+                       [submitted]="submitted()">
+              <input pInputText appFieldControl id="email" type="email" formControlName="emailAddress" />
+            </app-field>
 
-            <div class="field">
-              <label for="org">Organization</label>
-              <p-select id="org" inputId="userOrgInput" data-testid="user-organization"
-                        [(ngModel)]="organizationName" name="org"
-                        [options]="orgOptions()" [editable]="true"
-                        appendTo="body"
+            <app-field label="Phone" controlId="phone" [control]="form.controls.phoneNumber"
+                       [submitted]="submitted()">
+              <input pInputText appFieldControl id="phone" formControlName="phoneNumber" />
+            </app-field>
+
+            <app-field label="Organization" controlId="userOrgInput"
+                       [control]="form.controls.organizationName" [submitted]="submitted()">
+              <p-select appFieldControl inputId="userOrgInput" data-testid="user-organization"
+                        formControlName="organizationName"
+                        [options]="orgOptions()" [editable]="true" appendTo="body"
                         placeholder="Select or type organization" />
-            </div>
+            </app-field>
 
-            <div class="field">
-              <label for="password">Password</label>
-              <p-password id="password" [(ngModel)]="password" name="password"
-                          [feedback]="false" [toggleMask]="true" />
-            </div>
+            <app-field label="Password" controlId="password" [control]="form.controls.password"
+                       [submitted]="submitted()"
+                       [helper]="isNew() ? '' : 'Leave blank to keep the current password.'">
+              <p-password appFieldControl inputId="password" formControlName="password"
+                          [feedback]="false" [toggleMask]="true" autocomplete="new-password" />
+            </app-field>
 
-            <div class="field">
-              <label for="repassword">Confirm Password</label>
-              <p-password id="repassword" [(ngModel)]="repassword" name="repassword"
-                          [feedback]="false" [toggleMask]="true" />
-            </div>
-          </div>
+            <app-field label="Confirm Password" controlId="repassword"
+                       [control]="form.controls.repassword" [submitted]="submitted()">
+              <p-password appFieldControl inputId="repassword" formControlName="repassword"
+                          [feedback]="false" [toggleMask]="true" autocomplete="new-password" />
+            </app-field>
+          </app-field-group>
 
           <div class="roles-section" data-testid="user-roles-section">
-            <h3>Roles &amp; Permissions</h3>
+            <!-- h2, not h3: sibling of the section headings #158 standardised, and an h3
+                 straight after the page h1 is an axe heading-order violation. -->
+            <h2 class="rq-section-title">Roles &amp; Permissions</h2>
+
             @for (role of availableRoles(); track role.roleName) {
               <div class="role-group" data-testid="user-role-group" [attr.data-role-name]="role.roleName">
                 <label class="checkbox-label" data-testid="user-role-label">
-                  <p-checkbox [(ngModel)]="selectedRoleNames" [name]="'role_' + role.roleName"
-                              [value]="role.roleName" />
+                  <p-checkbox [formControl]="form.controls.roleNames" [value]="role.roleName" />
                   {{ role.displayName }}
                 </label>
                 @if (isRoleSelected(role.roleName)) {
                   <div class="permissions">
                     @for (perm of role.availablePermissions; track perm.name) {
                       <label class="checkbox-label">
-                        <p-checkbox [(ngModel)]="selectedPermissions[role.roleName]"
-                                    [name]="'perm_' + role.roleName + '_' + perm.name"
-                                    [value]="perm.name" />
+                        <p-checkbox [formControl]="permissionsControl(role.roleName)" [value]="perm.name" />
                         {{ perm.name }}
                       </label>
                     }
@@ -130,12 +177,24 @@ import { ErrorStateComponent } from '../../shared/error-state';
                 }
               </div>
             }
+
+            <!--
+              The roles error has no single control to sit under — it is about the group —
+              so it renders here, next to the checkboxes it concerns, with the same
+              role="alert" treatment an app-field error gets.
+            -->
+            @if (showRolesError()) {
+              <p class="roles-error" role="alert" data-testid="user-roles-error">
+                {{ rolesErrorMessage() }}
+              </p>
+            }
           </div>
 
           <div class="actions">
             <p-button type="submit" label="Save" icon="pi pi-check" data-testid="user-save"
-                      [loading]="saving()" [disabled]="!userForm.dirty" />
-            <p-button label="Cancel" icon="pi pi-times" severity="secondary"
+                      [loading]="saving()"
+                      [disabled]="form.invalid || form.pristine || saving()" />
+            <p-button type="button" label="Cancel" icon="pi pi-times" severity="secondary"
                       (onClick)="onCancel()" [outlined]="true" />
           </div>
         </form>
@@ -145,25 +204,29 @@ import { ErrorStateComponent } from '../../shared/error-state';
   `,
   styles: [`
     .user-editor { max-width: 800px; }
-    .form-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1.5rem; }
-    .field { display: flex; flex-direction: column; gap: 0.5rem; }
-    .field label { font-weight: 500; }
-    .field input, .field p-password, .field p-select { width: 100%; }
-    .roles-section { margin-bottom: 1.5rem; }
-    .roles-section h3 { margin: 0 0 0.75rem; }
-    .role-group { margin-bottom: 0.75rem; }
-    .checkbox-label { display: inline-flex; align-items: center; gap: 0.5rem; cursor: pointer; }
-    .permissions { margin-left: 2rem; margin-top: 0.25rem; display: flex; flex-wrap: wrap; gap: 0.5rem; }
-    .actions { display: flex; gap: 0.5rem; }
+    /* The local .form-grid { 1fr 1fr } is gone — app-field-group owns the columns now
+       (issue #172), and app-field owns each row. */
+    app-field input, app-field p-password, app-field p-select { width: 100%; }
+    .roles-section { margin-block: var(--rq-space-6); }
+    .roles-section h2 { margin: 0 0 var(--rq-space-3); }
+    .role-group { margin-bottom: var(--rq-space-3); }
+    .checkbox-label { display: inline-flex; align-items: center; gap: var(--rq-space-2); cursor: pointer; }
+    .permissions { margin-left: var(--rq-space-8); margin-top: var(--rq-space-1); display: flex; flex-wrap: wrap; gap: var(--rq-space-2); }
+    .roles-error {
+      margin: var(--rq-space-1) 0 0;
+      color: var(--rq-field-error-fg);
+      font-size: var(--rq-text-helper-size);
+      line-height: var(--rq-text-helper-line);
+    }
+    .actions { display: flex; gap: var(--rq-space-2); }
   `]
 })
 export class UserEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
 
-  @ViewChild('userForm') private viewUserForm?: NgForm;
-
   readonly isNew = signal(true);
   readonly loading = signal(true);
   readonly saving = signal(false);
+  readonly submitted = signal(false);
   readonly errorMessage = signal<string | null>(null);
   readonly successMessage = signal<string | null>(null);
   // Load failures tracked separately from save/inline errors so the retryable
@@ -171,24 +234,36 @@ export class UserEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
   readonly loadError = signal<string | null>(null);
   private lastUsernameParam: string | null = null;
 
-  // Form fields — plain properties so [(ngModel)] two-way binding works correctly.
-  // readonly signals don't update via the (ngModelChange)="name=$event" write path.
-  username = '';
-  name = '';
-  emailAddress = '';
-  phoneNumber = '';
-  organizationName = '';
-  password = '';
-  repassword = '';
+  /**
+   * `permissions` is a nested group with one `string[]` control per role, filled in once
+   * the role list arrives. Keeping it inside the form is what makes ticking a permission
+   * mark the form dirty — with the checkboxes outside the form, Save would have stayed
+   * disabled after a permission-only change.
+   *
+   * Password is required on create and optional on edit; {@link applyPasswordRules} sets
+   * that once `isNew` is known. `minLength(1)` is a no-op on an empty value, so the edit
+   * case needs no conditional branch beyond dropping `required`.
+   */
+  readonly form = new FormGroup(
+    {
+      username: new FormControl('', { validators: Validators.required, nonNullable: true }),
+      name: new FormControl('', { validators: Validators.required, nonNullable: true }),
+      emailAddress: new FormControl('', { validators: Validators.email, nonNullable: true }),
+      phoneNumber: new FormControl('', { nonNullable: true }),
+      organizationName: new FormControl('', { nonNullable: true }),
+      password: new FormControl('', { nonNullable: true }),
+      repassword: new FormControl('', { nonNullable: true }),
+      roleNames: new FormControl<string[]>([], { validators: atLeastOne(), nonNullable: true }),
+      permissions: new FormGroup<Record<string, FormControl<string[]>>>({}),
+    },
+    { validators: passwordsMatch('password', 'repassword') }
+  );
 
   // Identity for optimistic locking
   private userId: number | null = null;
   private userVersion: number = 0;
 
-  // Roles & permissions
   readonly availableRoles = signal<RoleDto[]>([]);
-  selectedRoleNames: string[] = [];
-  selectedPermissions: Record<string, string[]> = {};
 
   // Organization dropdown
   readonly organizations = signal<{label: string; value: string}[]>([]);
@@ -200,8 +275,7 @@ export class UserEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
     private route: ActivatedRoute,
     private router: Router,
     private userService: UserService,
-    private commandService: CommandService,
-    private cdr: ChangeDetectorRef
+    private commandService: CommandService
   ) {}
 
   ngOnInit(): void {
@@ -212,8 +286,9 @@ export class UserEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
     });
   }
 
+  /** Derived from the form, so there is no NgForm ViewChild to reach through (#132). */
   hasUnsavedChanges(): boolean {
-    return this.viewUserForm?.dirty ?? false;
+    return this.form.dirty;
   }
 
   ngOnDestroy(): void {
@@ -225,12 +300,64 @@ export class UserEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
     void this.loadData(this.lastUsernameParam);
   }
 
+  /** The per-role permission control, created lazily so the template can bind it. */
+  permissionsControl(roleName: string): FormControl<string[]> {
+    const group = this.form.controls.permissions;
+    let control = group.controls[roleName];
+    if (!control) {
+      control = new FormControl<string[]>([], { nonNullable: true });
+      group.addControl(roleName, control);
+    }
+    return control;
+  }
+
+  /**
+   * Whether to show the "select at least one role" message. Same visibility rule
+   * `app-field` applies to a control-level error: only after the user has engaged, or
+   * after a save attempt — never on a create form nobody has filled in yet.
+   */
+  showRolesError(): boolean {
+    const control = this.form.controls.roleNames;
+    return control.invalid && (control.touched || this.submitted());
+  }
+
+  /**
+   * The roles message, resolved through the shared map rather than written here — the
+   * wording for `atLeastOne` (and for a `server` violation mapped onto this control)
+   * lives in form-errors.ts with every other validation message.
+   */
+  rolesErrorMessage(): string | null {
+    return firstErrorMessage(this.form.controls.roleNames);
+  }
+
+  private applyPasswordRules(): void {
+    const password = this.form.controls.password;
+    password.setValidators(
+      this.isNew()
+        ? [Validators.required, Validators.maxLength(PASSWORD_MAX_LENGTH)]
+        : [Validators.minLength(1), Validators.maxLength(PASSWORD_MAX_LENGTH)]
+    );
+    password.updateValueAndValidity({ emitEvent: false });
+  }
+
   private async loadData(usernameParam: string | null): Promise<void> {
     this.loading.set(true);
     this.loadError.set(null);
+    this.submitted.set(false);
     this.lastUsernameParam = usernameParam;
     this.userId = null;
     this.userVersion = 0;
+
+    // Username is the identity of an existing user and cannot be changed; disabling the
+    // control both matches the previous [disabled]="!isNew()" markup and keeps it out of
+    // the validity calculation, which getRawValue() then reads past.
+    if (this.isNew()) {
+      this.form.controls.username.enable({ emitEvent: false });
+    } else {
+      this.form.controls.username.disable({ emitEvent: false });
+    }
+    this.applyPasswordRules();
+
     try {
       // Load reference data in parallel
       const [roles, orgs] = await Promise.all([
@@ -240,21 +367,20 @@ export class UserEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
       this.availableRoles.set(roles);
       this.organizations.set(orgs.map(o => ({ label: o.name, value: o.name })));
 
-      // Initialize permissions map
+      // A control per role, so a permission tick is a form change like any other.
       for (const role of roles) {
-        this.selectedPermissions[role.roleName] = [];
+        this.permissionsControl(role.roleName).setValue([], { emitEvent: false });
       }
 
       // Load existing user if editing
       if (!this.isNew() && usernameParam) {
         const user = await this.userService.getUser(usernameParam);
         this.populateForm(user);
-        // Force CD so the @if(isRoleSelected) block and p-checkbox components
-        // initialize from the already-populated values in a single pass.
-        // Without this, PrimeNG checkboxes can initialize from the empty
-        // selectedPermissions set by the init loop above before populateForm runs.
-        this.cdr.detectChanges();
       }
+      // The ChangeDetectorRef.detectChanges() that used to be needed here is gone: the
+      // p-checkbox and p-select value accessors are written to directly by setValue, so
+      // they no longer race the empty-then-populate sequence that plain properties had.
+      this.form.markAsPristine();
     } catch (err: unknown) {
       // Previously uncaught: a failed load left a blank form with no feedback.
       this.loadError.set(err instanceof Error ? err.message : 'Failed to load user.');
@@ -264,44 +390,62 @@ export class UserEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
   }
 
   isRoleSelected(roleName: string): boolean {
-    return this.selectedRoleNames.includes(roleName);
+    return this.form.controls.roleNames.value.includes(roleName);
   }
 
   async onSave(): Promise<void> {
+    this.submitted.set(true);
+    // Before the validity check — see term-editor: a standing server error would
+    // otherwise make the form permanently unsubmittable.
+    clearServerErrors(this.form);
+
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
     this.saving.set(true);
     this.errorMessage.set(null);
     this.successMessage.set(null);
 
     try {
+      const value = this.form.getRawValue();
       const input: Record<string, unknown> = {
         id: this.userId,
         version: this.userVersion,
-        username: this.username,
-        name: this.name,
-        emailAddress: this.emailAddress,
-        phoneNumber: this.phoneNumber,
-        organizationName: this.organizationName,
+        username: value.username,
+        name: value.name,
+        emailAddress: value.emailAddress,
+        phoneNumber: value.phoneNumber,
+        organizationName: value.organizationName,
         editable: true,
-        userRoleNames: this.selectedRoleNames,
-        userRolePermissionNames: this.selectedPermissions
+        userRoleNames: value.roleNames,
+        // Only the selected roles' permissions, so a deselected role does not ship a
+        // stale permission list the server would have to ignore.
+        userRolePermissionNames: this.selectedPermissionsPayload(value.roleNames),
       };
 
       // Only include password if set
-      if (this.password) {
-        input['password'] = this.password;
-        input['repassword'] = this.repassword;
+      if (value.password) {
+        input['password'] = value.password;
+        input['repassword'] = value.repassword;
       }
 
       const result = await this.commandService.execute('EditUser', input);
       if (result.success) {
         this.successMessage.set('User saved successfully.');
-        this.viewUserForm?.form.markAsPristine();
+        this.form.markAsPristine();
+        this.submitted.set(false);
         if (this.isNew()) {
-          await this.router.navigate(['/users', this.username]);
+          await this.router.navigate(['/users', value.username]);
         }
-      } else if (result.violations?.length) {
-        this.errorMessage.set(result.violations.map(v => v.message).join('; '));
-      } else {
+        return;
+      }
+
+      const unresolved = applyCommandErrors(this.form, result.violations, USER_FIELD_MAP);
+      if (unresolved.length) {
+        this.errorMessage.set(unresolved.join(' '));
+      } else if (!result.violations?.length) {
         this.errorMessage.set(result.error ?? 'Save failed.');
       }
     } catch (err: unknown) {
@@ -311,6 +455,15 @@ export class UserEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
     }
   }
 
+  /** `{ roleName: permissionName[] }` for the selected roles only. */
+  private selectedPermissionsPayload(roleNames: string[]): Record<string, string[]> {
+    const payload: Record<string, string[]> = {};
+    for (const roleName of roleNames) {
+      payload[roleName] = this.permissionsControl(roleName).value;
+    }
+    return payload;
+  }
+
   onCancel(): void {
     this.router.navigate(['/users']);
   }
@@ -318,15 +471,22 @@ export class UserEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
   private populateForm(user: UserDto): void {
     this.userId = user.id ?? null;
     this.userVersion = user.version ?? 0;
-    this.username = user.username;
-    this.name = user.name ?? '';
-    this.emailAddress = user.emailAddress ?? '';
-    this.phoneNumber = user.phoneNumber ?? '';
-    this.organizationName = user.organizationName ?? '';
-    this.selectedRoleNames = [...user.roles];
+    this.form.patchValue(
+      {
+        username: user.username,
+        name: user.name ?? '',
+        emailAddress: user.emailAddress ?? '',
+        phoneNumber: user.phoneNumber ?? '',
+        organizationName: user.organizationName ?? '',
+        roleNames: [...user.roles],
+      },
+      { emitEvent: false }
+    );
     // Seed per-role permissions from the server's permissionsByRole map
     for (const roleName of user.roles) {
-      this.selectedPermissions[roleName] = [...(user.permissionsByRole?.[roleName] ?? [])];
+      this.permissionsControl(roleName).setValue([...(user.permissionsByRole?.[roleName] ?? [])], {
+        emitEvent: false,
+      });
     }
   }
 }

--- a/requel-angular/src/app/features/users/user-editor.ts
+++ b/requel-angular/src/app/features/users/user-editor.ts
@@ -60,6 +60,14 @@ const USER_FIELD_MAP: Record<string, string> = {
   userRoleNames: 'roleNames',
 };
 
+/**
+ * Separator for several command-level messages sharing the one page-level banner.
+ * Semicolons, not spaces: two sentence fragments run together ("Email is invalid Phone
+ * is required") read as one broken sentence. This is the separator the pre-#132 code
+ * used and e2e/account.e2e.ts asserts.
+ */
+const SEPARATOR = '; ';
+
 @Component({
   selector: 'app-user-editor',
   standalone: true,
@@ -444,7 +452,7 @@ export class UserEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
 
       const unresolved = applyCommandErrors(this.form, result.violations, USER_FIELD_MAP);
       if (unresolved.length) {
-        this.errorMessage.set(unresolved.join(' '));
+        this.errorMessage.set(unresolved.join(SEPARATOR));
       } else if (!result.violations?.length) {
         this.errorMessage.set(result.error ?? 'Save failed.');
       }

--- a/requel-angular/src/app/shared/annotations-section.ts
+++ b/requel-angular/src/app/shared/annotations-section.ts
@@ -42,7 +42,15 @@ import { RqTone, supportLevelIcon, supportLevelTone } from './severity';
       <div class="annotations-section" data-testid="annotations-section">
         <app-card>
         <div class="section-header">
-          <h3>Annotations</h3>
+          <!--
+            h2, not h3: this is a top-level page section, a sibling of the "Referenced By"
+            and "Relations" sections that issue #158 standardised on h2.rq-section-title.
+            As an h3 directly under the page h1 it produced an axe heading-order violation
+            on every editor that mounts it, whenever the editor's own optional h2 sections
+            happened to be empty. Found and fixed under issue #132.
+            NB: no backticks in this comment - the template is a TS template literal.
+          -->
+          <h2 class="rq-section-title">Annotations</h2>
           @if (canEdit) {
             <div class="action-buttons">
               <p-button label="Add Note" icon="pi pi-comment" size="small" severity="secondary"
@@ -230,7 +238,7 @@ import { RqTone, supportLevelIcon, supportLevelTone } from './severity';
   styles: [`
     .annotations-section { margin-top: 1.5rem; }
     .section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.75rem; }
-    .section-header h3 { margin: 0; }
+    .section-header h2 { margin: 0; }
     .action-buttons { display: flex; gap: 0.5rem; }
 
     .add-form { background: var(--p-surface-50, #f8f9fa); border: 1px solid var(--p-surface-200); border-radius: 6px; padding: 0.75rem; margin-bottom: 0.75rem; }

--- a/requel-angular/src/app/shared/form-errors.spec.ts
+++ b/requel-angular/src/app/shared/form-errors.spec.ts
@@ -1,9 +1,20 @@
-import { FormControl, Validators } from '@angular/forms';
 import {
+  AbstractControl,
+  FormArray,
+  FormControl,
+  FormGroup,
+  Validators,
+} from '@angular/forms';
+import {
+  applyCommandErrors,
+  atLeastOne,
+  clearServerErrors,
   DEFAULT_FORM_ERRORS,
   firstErrorMessage,
   isRequired,
+  passwordsMatch,
   resolveErrorMessage,
+  SERVER_ERROR_KEY,
 } from './form-errors';
 
 describe('form-errors (issue #158)', () => {
@@ -111,5 +122,341 @@ describe('form-errors (issue #158)', () => {
       expect(isRequired(new FormControl(''))).toBe(false);
       expect(isRequired(null)).toBe(false);
     });
+  });
+});
+
+describe('passwordsMatch (issue #132)', () => {
+  function group() {
+    return new FormGroup(
+      {
+        password: new FormControl('', { nonNullable: true }),
+        repassword: new FormControl('', { nonNullable: true }),
+      },
+      { validators: passwordsMatch('password', 'repassword') }
+    );
+  }
+
+  it('passes when both controls are empty', () => {
+    expect(group().errors).toBeNull();
+  });
+
+  it('passes when the values match', () => {
+    const form = group();
+    form.setValue({ password: 'hunter2', repassword: 'hunter2' });
+    expect(form.errors).toBeNull();
+  });
+
+  it('reports passwordMismatch on the group when the values differ', () => {
+    const form = group();
+    form.setValue({ password: 'hunter2', repassword: 'hunter3' });
+    expect(form.errors).toEqual({ passwordMismatch: true });
+  });
+
+  /**
+   * The reason the validator stamps the child as well as returning a group error:
+   * `app-field.showError` reads `control.invalid`, and a group error does not mark
+   * children invalid, so without this the form would refuse to submit while showing
+   * no message anywhere.
+   */
+  it('also stamps the error on the confirm control, so app-field can render it', () => {
+    const form = group();
+    form.setValue({ password: 'hunter2', repassword: 'hunter3' });
+
+    expect(form.controls.repassword.errors).toEqual({ passwordMismatch: true });
+    expect(form.controls.repassword.invalid).toBe(true);
+    expect(firstErrorMessage(form.controls.repassword)).toBe('Passwords do not match.');
+  });
+
+  it('leaves the password control alone', () => {
+    const form = group();
+    form.setValue({ password: 'hunter2', repassword: 'hunter3' });
+    expect(form.controls.password.errors).toBeNull();
+  });
+
+  it('clears the stamped error once the values match again', () => {
+    const form = group();
+    form.setValue({ password: 'hunter2', repassword: 'hunter3' });
+    form.controls.repassword.setValue('hunter2');
+
+    expect(form.errors).toBeNull();
+    expect(form.controls.repassword.errors).toBeNull();
+    expect(form.controls.repassword.valid).toBe(true);
+  });
+
+  /**
+   * A validator on the confirm control alone would go stale here: the user confirms,
+   * then edits the password. A group validator re-runs on either child's change.
+   */
+  it('re-evaluates when the password changes after the confirm was entered', () => {
+    const form = group();
+    form.setValue({ password: 'hunter2', repassword: 'hunter2' });
+    expect(form.errors).toBeNull();
+
+    form.controls.password.setValue('hunter3');
+
+    expect(form.errors).toEqual({ passwordMismatch: true });
+    expect(form.controls.repassword.errors).toEqual({ passwordMismatch: true });
+  });
+
+  it('preserves other errors on the confirm control', () => {
+    const form = new FormGroup(
+      {
+        password: new FormControl('', { nonNullable: true }),
+        repassword: new FormControl('', {
+          validators: Validators.minLength(4),
+          nonNullable: true,
+        }),
+      },
+      { validators: passwordsMatch('password', 'repassword') }
+    );
+
+    form.setValue({ password: 'hunter2', repassword: 'abc' });
+
+    expect(form.controls.repassword.errors).toMatchObject({ passwordMismatch: true });
+    expect(form.controls.repassword.errors?.['minlength']).toBeTruthy();
+    // minlength outranks passwordMismatch, so the user is told the fixable thing first.
+    expect(firstErrorMessage(form.controls.repassword)).toBe('Must be at least 4 characters.');
+  });
+
+  it('stays silent when either control is missing rather than blocking the form', () => {
+    const form = new FormGroup(
+      { password: new FormControl('', { nonNullable: true }) },
+      { validators: passwordsMatch('password', 'repassword') }
+    );
+    expect(form.errors).toBeNull();
+    expect(form.valid).toBe(true);
+  });
+});
+
+describe('atLeastOne (issue #132)', () => {
+  const validate = (value: unknown) =>
+    atLeastOne()(new FormControl(value) as AbstractControl);
+
+  it.each([null, undefined, '', [], new Set()])('reports atLeastOne for %p', value => {
+    expect(validate(value)).toEqual({ atLeastOne: true });
+  });
+
+  it.each([['admin'], ['admin', 'user'], new Set(['admin']), 'admin', 0, false])(
+    'passes for %p',
+    value => {
+      expect(validate(value)).toBeNull();
+    }
+  );
+
+  it('renders the shared message', () => {
+    const control = new FormControl<string[]>([], { validators: atLeastOne() });
+    expect(firstErrorMessage(control)).toBe('Select at least one.');
+  });
+});
+
+describe('applyCommandErrors (issue #132)', () => {
+  function form() {
+    return new FormGroup({
+      name: new FormControl('', { nonNullable: true }),
+      email: new FormControl('', { nonNullable: true }),
+      password: new FormControl('', { nonNullable: true }),
+    });
+  }
+
+  it('returns an empty list and touches nothing for no violations', () => {
+    const f = form();
+    expect(applyCommandErrors(f, null)).toEqual([]);
+    expect(applyCommandErrors(f, undefined)).toEqual([]);
+    expect(applyCommandErrors(f, [])).toEqual([]);
+    expect(f.touched).toBe(false);
+  });
+
+  it('sets a server error on the control a violation names', () => {
+    const f = form();
+    const unresolved = applyCommandErrors(f, [{ field: 'name', message: 'Name already exists.' }]);
+
+    expect(unresolved).toEqual([]);
+    expect(f.controls.name.errors).toEqual({ server: 'Name already exists.' });
+    expect(firstErrorMessage(f.controls.name)).toBe('Name already exists.');
+  });
+
+  it('marks the control touched so the message shows on a field never focused', () => {
+    const f = form();
+    applyCommandErrors(f, [{ field: 'name', message: 'Name already exists.' }]);
+    expect(f.controls.name.touched).toBe(true);
+  });
+
+  it('returns a violation whose field does not resolve, instead of dropping it', () => {
+    const f = form();
+    const unresolved = applyCommandErrors(f, [
+      { field: 'noSuchProperty', message: 'Something about a field we do not have.' },
+    ]);
+
+    expect(unresolved).toEqual(['Something about a field we do not have.']);
+  });
+
+  it('returns a command-level violation with a null field', () => {
+    const f = form();
+    const unresolved = applyCommandErrors(f, [{ field: null, message: 'Validation failed.' }]);
+
+    expect(unresolved).toEqual(['Validation failed.']);
+    expect(f.touched).toBe(false);
+  });
+
+  it('maps an entity property name onto a differently-named control', () => {
+    const f = form();
+    const unresolved = applyCommandErrors(
+      f,
+      [{ field: 'emailAddress', message: 'Not a valid address.' }],
+      { emailAddress: 'email' }
+    );
+
+    expect(unresolved).toEqual([]);
+    expect(f.controls.email.errors).toEqual({ server: 'Not a valid address.' });
+  });
+
+  it('falls back to the last segment of a dotted, indexed path', () => {
+    const f = form();
+    const unresolved = applyCommandErrors(f, [
+      { field: 'roles[0].name', message: 'Role name is invalid.' },
+    ]);
+
+    expect(unresolved).toEqual([]);
+    expect(f.controls.name.errors).toEqual({ server: 'Role name is invalid.' });
+  });
+
+  it('applies several violations at once', () => {
+    const f = form();
+    const unresolved = applyCommandErrors(f, [
+      { field: 'name', message: 'Name is required.' },
+      { field: 'email', message: 'Email is malformed.' },
+      { field: 'mystery', message: 'Unmapped.' },
+    ]);
+
+    expect(f.controls.name.errors).toEqual({ server: 'Name is required.' });
+    expect(f.controls.email.errors).toEqual({ server: 'Email is malformed.' });
+    expect(unresolved).toEqual(['Unmapped.']);
+  });
+
+  /**
+   * The behaviour the "fix the field and the error goes away" requirement rests on.
+   * Angular's `updateValueAndValidity` reassigns `errors` from the validator result on
+   * every value change, and no validator produces `server` — so the key drops on its
+   * own. Asserted rather than assumed: if this ever stopped holding, editors would
+   * strand users behind a stale error with Save disabled.
+   */
+  it('drops the server error on the next edit to that control', () => {
+    const f = form();
+    applyCommandErrors(f, [{ field: 'name', message: 'Name already exists.' }]);
+    expect(f.controls.name.errors).toEqual({ server: 'Name already exists.' });
+
+    f.controls.name.setValue('A different name');
+
+    expect(f.controls.name.errors).toBeNull();
+    expect(f.controls.name.valid).toBe(true);
+  });
+
+  it('drops the server error on edit even when the control has its own validators', () => {
+    const f = new FormGroup({
+      name: new FormControl('', { validators: Validators.required, nonNullable: true }),
+    });
+    applyCommandErrors(f, [{ field: 'name', message: 'Name already exists.' }]);
+
+    f.controls.name.setValue('A different name');
+
+    expect(f.controls.name.errors).toBeNull();
+  });
+
+  it('leaves a live client-side error winning over a server one', () => {
+    const f = new FormGroup({
+      name: new FormControl('', { validators: Validators.required, nonNullable: true }),
+    });
+    // Empty and required, so `required` is live; the server also complained.
+    applyCommandErrors(f, [{ field: 'name', message: 'Name already exists.' }]);
+
+    expect(f.controls.name.errors).toMatchObject({ required: true, server: 'Name already exists.' });
+    expect(firstErrorMessage(f.controls.name)).toBe('This field is required.');
+  });
+
+  it('preserves an existing error when adding a server one', () => {
+    const f = new FormGroup({
+      name: new FormControl('', { validators: Validators.minLength(5), nonNullable: true }),
+    });
+    f.controls.name.setValue('abc');
+    applyCommandErrors(f, [{ field: 'name', message: 'Name already exists.' }]);
+
+    expect(f.controls.name.errors?.['minlength']).toBeTruthy();
+    expect(f.controls.name.errors?.['server']).toBe('Name already exists.');
+  });
+});
+
+describe('clearServerErrors (issue #132)', () => {
+  it('removes server errors across a nested form and leaves others alone', () => {
+    const f = new FormGroup({
+      name: new FormControl('', { validators: Validators.required, nonNullable: true }),
+      nested: new FormGroup({
+        email: new FormControl('', { nonNullable: true }),
+      }),
+      roles: new FormArray([new FormControl('', { nonNullable: true })]),
+    });
+
+    applyCommandErrors(f, [
+      { field: 'name', message: 'Name already exists.' },
+      { field: 'nested.email', message: 'Email in use.' },
+    ]);
+    expect(f.controls.name.errors?.['server']).toBe('Name already exists.');
+
+    clearServerErrors(f);
+
+    // `required` is a live client error and survives; the server keys are gone.
+    expect(f.controls.name.errors).toEqual({ required: true });
+    expect(f.controls.nested.controls.email.errors).toBeNull();
+  });
+
+  it('is a no-op when there is nothing to clear', () => {
+    const f = new FormGroup({ name: new FormControl('a', { nonNullable: true }) });
+    clearServerErrors(f);
+    expect(f.controls.name.errors).toBeNull();
+    expect(f.valid).toBe(true);
+  });
+});
+
+describe('SERVER_ERROR_KEY precedence (issue #132)', () => {
+  it('renders a server message when it is the only error', () => {
+    const control = new FormControl('x', { nonNullable: true });
+    control.setErrors({ [SERVER_ERROR_KEY]: 'Server said no.' });
+    expect(firstErrorMessage(control)).toBe('Server said no.');
+  });
+
+  it('loses to every client-side validator error', () => {
+    const control = new FormControl('', { nonNullable: true });
+
+    control.setErrors({ [SERVER_ERROR_KEY]: 'Server said no.', required: true });
+    expect(firstErrorMessage(control)).toBe('This field is required.');
+
+    control.setErrors({ [SERVER_ERROR_KEY]: 'Server said no.', email: true });
+    expect(firstErrorMessage(control)).toBe('Enter a valid email address.');
+
+    control.setErrors({ [SERVER_ERROR_KEY]: 'Server said no.', passwordMismatch: true });
+    expect(firstErrorMessage(control)).toBe('Passwords do not match.');
+  });
+
+  it('falls back rather than rendering a non-string payload', () => {
+    const control = new FormControl('x', { nonNullable: true });
+    control.setErrors({ [SERVER_ERROR_KEY]: { unexpected: true } });
+    expect(firstErrorMessage(control)).toBe('This value is not valid.');
+  });
+
+  it('honours a per-field override', () => {
+    const control = new FormControl('x', { nonNullable: true });
+    control.setErrors({ [SERVER_ERROR_KEY]: 'Server said no.' });
+    expect(firstErrorMessage(control, { server: 'Overridden.' })).toBe('Overridden.');
+  });
+});
+
+describe('min / max messages (issue #132)', () => {
+  it('renders the min bound for the settings project limit', () => {
+    const control = new FormControl(0, { validators: Validators.min(1) });
+    expect(firstErrorMessage(control)).toBe('Must be 1 or more.');
+  });
+
+  it('renders the max bound', () => {
+    const control = new FormControl(9, { validators: Validators.max(5) });
+    expect(firstErrorMessage(control)).toBe('Must be 5 or less.');
   });
 });

--- a/requel-angular/src/app/shared/form-errors.ts
+++ b/requel-angular/src/app/shared/form-errors.ts
@@ -18,7 +18,8 @@
  * along with Requel. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import { AbstractControl, ValidationErrors } from '@angular/forms';
+import { AbstractControl, FormArray, FormGroup, ValidationErrors, ValidatorFn } from '@angular/forms';
+import { FieldViolation } from '../models/command';
 
 /**
  * Shared validation-message map (issue #158, the N5-sized slice of #132's "unified
@@ -32,6 +33,12 @@ import { AbstractControl, ValidationErrors } from '@angular/forms';
  * #132 extends this during rollout (cross-field, password confirmation). Keep
  * additions here rather than in components.
  */
+
+/**
+ * Error key used for a message that came back from the server rather than from a
+ * client-side validator. Exported as {@link SERVER_ERROR_KEY} below.
+ */
+const SERVER_ERROR_KEY_INTERNAL = 'server';
 
 /** Builds a message from a validation error's payload (e.g. `minlength`'s lengths). */
 export type FormErrorMessageFactory = (error: unknown) => string;
@@ -47,7 +54,21 @@ export type FormErrorOverrides = Record<string, string>;
  *
  * `required` comes first because an empty field's other complaints are noise.
  */
-const ERROR_PRECEDENCE = ['required', 'minlength', 'maxlength', 'email', 'pattern'] as const;
+const ERROR_PRECEDENCE = [
+  'required',
+  'minlength',
+  'maxlength',
+  'email',
+  'pattern',
+  'min',
+  'max',
+  'integer',
+  'atLeastOne',
+  'passwordMismatch',
+  // Last on purpose. A server complaint is about the value the user already sent, so
+  // any live client-side error is newer information and outranks it.
+  SERVER_ERROR_KEY_INTERNAL,
+] as const;
 
 /** Default wording for the built-in Angular validators. */
 export const DEFAULT_FORM_ERRORS: Record<string, FormErrorMessageFactory> = {
@@ -66,6 +87,19 @@ export const DEFAULT_FORM_ERRORS: Record<string, FormErrorMessageFactory> = {
   },
   email: () => 'Enter a valid email address.',
   pattern: () => 'Value is not in the expected format.',
+  min: error => {
+    const min = (error as { min?: number } | null)?.min;
+    return min != null ? `Must be ${min} or more.` : 'Value is too small.';
+  },
+  max: error => {
+    const max = (error as { max?: number } | null)?.max;
+    return max != null ? `Must be ${max} or less.` : 'Value is too large.';
+  },
+  integer: () => 'Enter a whole number.',
+  atLeastOne: () => 'Select at least one.',
+  passwordMismatch: () => 'Passwords do not match.',
+  // The server sends the wording; the payload IS the message.
+  [SERVER_ERROR_KEY_INTERNAL]: error => (typeof error === 'string' ? error : FALLBACK_MESSAGE),
 };
 
 /** Last-resort text for a validator we have no wording for. Never shows a raw key. */
@@ -135,4 +169,299 @@ export function isRequired(control: AbstractControl | null | undefined): boolean
   }
   const result = validator({ value: null } as AbstractControl);
   return !!result?.['required'];
+}
+
+/**
+ * Error key for a message that came back from the server rather than from a
+ * client-side validator. See {@link applyCommandErrors}.
+ */
+export const SERVER_ERROR_KEY = SERVER_ERROR_KEY_INTERNAL;
+
+/**
+ * Cross-field validator: the confirm control must equal the password control.
+ * Error key: `passwordMismatch`.
+ *
+ * **Attach this to the group, not to the confirm control.** Two reasons:
+ *
+ * - A group validator re-runs when *either* control changes. A validator on the
+ *   confirm control alone would go stale the moment the user edited the password
+ *   field after confirming it, leaving a valid form showing a mismatch (or worse, an
+ *   invalid one showing nothing).
+ * - The group is where the relationship lives; neither control owns it.
+ *
+ * It then *also* stamps the error onto the confirm control, because
+ * `app-field.showError` reads `control.invalid` and a group-level error does not
+ * mark its children invalid — without this the message would render nowhere at all
+ * while the form sat there refusing to submit. The confirm field is where the user
+ * has to act, so that is where the message belongs.
+ *
+ * Only the `passwordMismatch` key is added or removed; any other error on the
+ * confirm control is preserved.
+ */
+export function passwordsMatch(passwordKey: string, confirmKey: string): ValidatorFn {
+  return group => {
+    const password = group.get(passwordKey);
+    const confirm = group.get(confirmKey);
+
+    // A group missing either control is a wiring mistake, not a mismatch — staying
+    // silent here beats blocking a form the user cannot fix.
+    if (!password || !confirm) {
+      return null;
+    }
+
+    const mismatch = password.value !== confirm.value;
+    setErrorKey(confirm, 'passwordMismatch', mismatch ? true : null);
+    return mismatch ? { passwordMismatch: true } : null;
+  };
+}
+
+/**
+ * Validator for numeric controls that must be whole numbers. Error key: `integer`.
+ *
+ * Empty is left to `required` — a validator that also complained about blankness
+ * would produce two messages for one mistake, and `required` outranks this in
+ * {@link ERROR_PRECEDENCE} anyway.
+ */
+export function integer(): ValidatorFn {
+  return control => {
+    const value = control.value;
+    if (value == null || value === '') {
+      return null;
+    }
+    const parsed = Number(value);
+    return Number.isInteger(parsed) ? null : { integer: true };
+  };
+}
+
+/**
+ * Validator for multi-select / checkbox-group controls: the value must hold at least
+ * one selection. Error key: `atLeastOne`.
+ *
+ * Mirrors `UserImpl`'s `@Size(min = 1)` on roles — the one bean-validation size
+ * constraint the backend already enforces — so the form refuses a save the server
+ * would reject anyway.
+ *
+ * Counts arrays and Sets by size and treats `null` / `undefined` / `''` as empty.
+ * Any other non-empty value counts as one selection, so a single-select control
+ * bound to the same validator behaves sensibly.
+ */
+export function atLeastOne(): ValidatorFn {
+  return control => (isEmptySelection(control.value) ? { atLeastOne: true } : null);
+}
+
+/**
+ * Maps a failed command's field violations onto the controls of `form`.
+ *
+ * Each violation whose field resolves to a control sets `{ server: message }` on
+ * that control, so the server's complaint renders inline under the field it is
+ * about — the same place a client-side error appears — instead of being
+ * semicolon-joined into one page-level string, which is what
+ * `project-editor` / `user-editor` / `edit-account` do today.
+ *
+ * **Anything that does not resolve is returned rather than dropped.** Feed the
+ * return value to the editor's page-level error so a violation is never silently
+ * swallowed:
+ *
+ * ```ts
+ * const unresolved = applyCommandErrors(this.form, result.violations, USER_FIELD_MAP);
+ * this.errorMessage.set(unresolved.join(' ') || null);
+ * ```
+ *
+ * Field names need mapping because `CommandController` builds them from
+ * `BeanValidationException.getEntityPropertyNames()`, which is
+ * `ConstraintViolation.getPropertyPath()` — **JPA entity property names**, not the
+ * input DTO's. They coincide often (`name`, `text`) and diverge exactly where it
+ * matters (`emailAddress` vs an `email` control, `encryptedPassword` vs
+ * `password`). Pass `map` as `{ entityProperty: controlName }` for the divergent
+ * ones; a missing entry degrades to page-level display rather than losing the
+ * message. The longer-term fix is to have `CommandController` emit DTO field names
+ * and delete the maps — see `doc/132-reactive-forms-plan.md` §4.2.
+ *
+ * A dotted or indexed path (`roles[0].name`) is tried whole, then with indices
+ * stripped, then as its last segment, so a nested constraint still finds its
+ * control when the form is flat.
+ *
+ * Controls receiving an error are marked touched, so the message shows even on a
+ * field the user never focused — a save they triggered is engagement enough.
+ *
+ * **The error is attached as a validator, not written with `setErrors`.** That is not a
+ * stylistic choice. Angular's `updateValueAndValidity` reassigns `errors` from the
+ * validator result, so anything written directly is dropped the next time validation
+ * runs — and validation runs on *render*, not just on edit: `setUpControl` revalidates
+ * whenever a `[formControl]` directive initialises. A control bound that way (user-editor
+ * binds its role and permission checkboxes to shared controls exactly like this) would
+ * lose the server's complaint on the very next change-detection pass, before the user
+ * ever saw it. As a validator it survives revalidation, and still self-clears the moment
+ * the value changes, because the validator compares against a snapshot of the value the
+ * server rejected.
+ */
+export function applyCommandErrors(
+  form: FormGroup,
+  violations: FieldViolation[] | null | undefined,
+  map?: Record<string, string>
+): string[] {
+  const unresolved: string[] = [];
+  if (!violations?.length) {
+    return unresolved;
+  }
+
+  for (const violation of violations) {
+    // A null field is a command-level failure, not a field one.
+    const control = violation.field ? resolveViolationControl(form, violation.field, map) : null;
+    if (!control) {
+      unresolved.push(violation.message);
+      continue;
+    }
+    setServerError(control, violation.message);
+  }
+
+  return unresolved;
+}
+
+/**
+ * Clears every `server` error under `root`.
+ *
+ * Angular drops these on its own as soon as a control's value changes —
+ * `updateValueAndValidity` reassigns `errors` from the validator result, which never
+ * includes `server` — so an editor does not need to wire anything up for the
+ * "error goes away once I fix the field" behaviour. This is for the other case:
+ * clearing stale server errors *before* re-submitting, so a second save attempt
+ * starts from a clean slate rather than showing last attempt's complaints next to
+ * this attempt's.
+ */
+export function clearServerErrors(root: AbstractControl): void {
+  for (const control of leafControls(root)) {
+    clearServerError(control);
+  }
+}
+
+/**
+ * The server-error validator currently attached to a control, if any, so a later call can
+ * take it off again. A WeakMap rather than a field on the control: nothing of ours should
+ * outlive the control or need cleaning up when a form is discarded.
+ */
+const serverValidators = new WeakMap<AbstractControl, ValidatorFn>();
+
+/** Stable comparison key for a control value, covering the array-valued controls too. */
+function valueSnapshot(value: unknown): string {
+  return JSON.stringify(value ?? null);
+}
+
+/**
+ * Attaches `{ server: message }` to a control as a validator bound to the value the
+ * server rejected. It reports while the value is unchanged and returns null once the user
+ * edits, which is the "fix the field and the message goes" behaviour — implemented so it
+ * also survives the revalidation that a render triggers.
+ */
+function setServerError(control: AbstractControl, message: string): void {
+  clearServerError(control);
+
+  const rejected = valueSnapshot(control.value);
+  const validator: ValidatorFn = candidate =>
+    valueSnapshot(candidate.value) === rejected ? { [SERVER_ERROR_KEY]: message } : null;
+
+  serverValidators.set(control, validator);
+  control.addValidators(validator);
+  control.updateValueAndValidity({ emitEvent: false });
+  control.markAsTouched();
+}
+
+/** Removes the server-error validator from a control, if it has one. */
+function clearServerError(control: AbstractControl): void {
+  const existing = serverValidators.get(control);
+  if (!existing) {
+    return;
+  }
+  serverValidators.delete(control);
+  control.removeValidators(existing);
+  control.updateValueAndValidity({ emitEvent: false });
+}
+
+/**
+ * Adds or removes a single key on a control's error object, leaving its other errors
+ * alone. Passing `null` removes the key; removing the last key resets `errors` to
+ * `null`, which is what Angular expects for a valid control.
+ */
+function setErrorKey(control: AbstractControl, key: string, value: unknown): void {
+  const current = control.errors;
+  const hasKey = current?.[key] != null;
+
+  if (value == null) {
+    if (!hasKey) {
+      return;
+    }
+    const next = { ...current };
+    delete next[key];
+    control.setErrors(Object.keys(next).length ? next : null);
+    return;
+  }
+
+  if (current?.[key] === value) {
+    return;
+  }
+  control.setErrors({ ...(current ?? {}), [key]: value });
+}
+
+/** Whether a selection-style value holds nothing. */
+function isEmptySelection(value: unknown): boolean {
+  if (value == null || value === '') {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+  if (value instanceof Set || value instanceof Map) {
+    return value.size === 0;
+  }
+  return false;
+}
+
+/**
+ * Resolves a violation's field name to a control, trying the explicit map first and
+ * then progressively looser forms of the path.
+ */
+function resolveViolationControl(
+  form: FormGroup,
+  field: string,
+  map?: Record<string, string>
+): AbstractControl | null {
+  const withoutIndices = field.replace(/\[\d+\]/g, '');
+  const leaf = withoutIndices.split('.').pop() ?? withoutIndices;
+
+  const candidates = [
+    map?.[field],
+    map?.[withoutIndices],
+    map?.[leaf],
+    field,
+    withoutIndices,
+    leaf,
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate) {
+      continue;
+    }
+    const control = form.get(candidate);
+    if (control) {
+      return control;
+    }
+  }
+  return null;
+}
+
+/** Every control under `root` that is not itself a group or array. */
+function* leafControls(root: AbstractControl): Generator<AbstractControl> {
+  if (root instanceof FormGroup) {
+    for (const child of Object.values(root.controls)) {
+      yield* leafControls(child);
+    }
+    return;
+  }
+  if (root instanceof FormArray) {
+    for (const child of root.controls) {
+      yield* leafControls(child);
+    }
+    return;
+  }
+  yield root;
 }

--- a/requel-angular/src/app/shared/validation-limits.ts
+++ b/requel-angular/src/app/shared/validation-limits.ts
@@ -1,0 +1,59 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Client-side validation bounds, each one mirroring a constraint the server actually
+ * enforces (issue #132).
+ *
+ * The rule for this file: **every entry names its backend source.** A client-side cap
+ * with no server-side counterpart rejects input the server would have accepted, which
+ * is worse than no cap at all — the user is blocked by a rule that does not exist. So
+ * a bound only appears here once something in `modules/` enforces it, and the comment
+ * says where, so the next person can diff this against the annotations instead of
+ * guessing which numbers are real.
+ *
+ * What is deliberately ABSENT: max lengths for artifact `name` and `text`. As of this
+ * writing there is exactly one bean-validation size constraint in all of
+ * `modules/*&#47;src/main/java` — `UserImpl`'s `@Size(min = 1)` on roles — and no `@Size`
+ * or `@Column(length=…)` on any artifact name or text field. **#171** adds them; the
+ * corresponding entries land here when it merges, and the editors read them from here
+ * rather than hard-coding their own.
+ */
+
+/**
+ * Maximum password length.
+ *
+ * Source: `UserImpl.MAX_PASSWORD_LENGTH` (user-jpa). `UserImpl.isValidPassword` accepts
+ * a password that is non-blank and no longer than this, and that is the *only* password
+ * rule the server applies — no complexity requirement, no minimum beyond non-blank. The
+ * client mirrors exactly that, so a password the user is allowed to set is never
+ * rejected by the form first. A real password policy is a product decision, not
+ * something to invent here.
+ */
+export const PASSWORD_MAX_LENGTH = 128;
+
+/**
+ * Minimum number of roles a user must hold.
+ *
+ * Source: `UserImpl:385`, `@Size(min = 1)` on the roles collection — the one size
+ * constraint the backend already had before #171.
+ */
+export const USER_ROLES_MIN = 1;


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/132

3.1 Reactive forms + consistent validation: migrate the six rows-only editors and build the shared validation helpers

Rolls the N5 pattern (#158) out to the six form surfaces that stay single-page rows, and adds
the shared validation pieces #132 owns: two cross-field validators, an integer validator, and
the command-error adapter that puts a server's field violations under the fields they are
about. Plan and the decisions behind it: doc/132-reactive-forms-plan.md.

The five create-flow wizards are #173 and the two-column primitive was #172 (merged as #174) —
see §9 of the plan for the split. #171 still owns the backend @Size/@Email constraints, which
is why no artifact name/text max-length appears here yet.

Closes #132. Blocks #173, #138, #143. Part of the UI/UX remediation epic #124, Phase 3.

Shared validation helpers (requel-angular/src/app/shared/form-errors.ts)
- passwordsMatch(passwordKey, confirmKey): a GROUP validator that also stamps
  `passwordMismatch` onto the confirm control. Group-level because a validator on the confirm
  control alone goes stale the moment the user edits the password *after* confirming it; the
  child stamp is needed because app-field.showError reads control.invalid and a group error
  does not mark children invalid — without it the form refused to submit while showing no
  message anywhere.
- atLeastOne(): arrays and Sets by size, null/'' empty, any other value counts as one
  selection. Mirrors UserImpl:385's @Size(min = 1) on roles.
- integer(): whole-number check for the settings project limit; leaves blankness to
  `required` so one mistake never produces two messages.
- applyCommandErrors(form, violations, map?): maps a failed CommandResult's field violations
  onto controls and RETURNS whatever it could not place, so nothing is silently swallowed.
  Field resolution tries the caller's map, then the raw path, then the path with array
  indices stripped, then its last segment — BeanValidationExceptionAdapter uses
  ConstraintViolation.getPropertyPath().toString(), so `roles[0].name` is a real shape, not
  just flat `name`.
- clearServerErrors(root): detaches server errors before a re-submit.
- ERROR_PRECEDENCE gains min, max, integer, atLeastOne, passwordMismatch and server, with
  `server` last so a live client-side complaint always outranks a stale server one.

Server errors are validator-backed, not written with setErrors — the important detail here
- Angular's updateValueAndValidity reassigns `errors` from the validator result, so anything
  written directly is dropped the next time validation runs. That gives clear-on-edit for
  free, but validation also runs on RENDER: setUpControl revalidates whenever a [formControl]
  directive initialises. Measured while migrating user-editor — a violation mapped onto
  roleNames (bound to the role checkboxes via [formControl]) read back as null after a single
  detectChanges(), meaning the user would never have seen it.
- So applyCommandErrors attaches a validator closed over a snapshot of the rejected value: it
  reports while the value is unchanged, returns null once edited, and survives revalidation
  either way. Regression tests cover both the survives-a-render and clears-on-edit halves.
- Related trap, fixed in all four editors that call the adapter: clearServerErrors runs BEFORE
  onSave's validity guard, not after. A standing server error makes its control invalid, so
  clearing afterwards meant the second save attempt bailed at the guard and never ran — the
  form was stuck at that value with Save disabled and no feedback.

New constants module (requel-angular/src/app/shared/validation-limits.ts)
- PASSWORD_MAX_LENGTH (UserImpl.MAX_PASSWORD_LENGTH) and USER_ROLES_MIN (UserImpl:385). The
  rule the file states and keeps: every entry names its backend source, because a client-side
  cap with no server-side counterpart blocks the user with a rule that does not exist. The
  artifact name/text limits are deliberately absent until #171 supplies real ones.

The six editors
- login.ts: both fields required; page-level error for a failed credential pair, since that is
  about the pair and not about either field (and /auth/login is not a command endpoint, so
  there are no violations to map). Form is disabled during the request in code rather than via
  a template `disabled` binding, which is what Angular warns about on a reactive control.
- settings.ts: required + min/max + integer on the project limit, mirroring the p-inputNumber
  bounds; the <small> hints became app-field helper text, so they are aria-describedby-linked
  instead of floating unassociated. Deletes the ChangeDetectorRef.detectChanges() workaround —
  patchValue notifies the value accessors directly, so there is no empty-then-populate race
  for PrimeNG to lose.
- term-editor.ts / report-editor.ts: rows only; first real callers of applyCommandErrors, with
  a { canonicalTerm: 'canonicalTermId' } map for the one entity property that does not match a
  control name. Deletes the imperative `if (!this.name.trim())` guards and their page-level
  "… name is required." messages, which `required` now renders under the field. term-editor
  also gains the fromSSE dirty guard the N5 editors have, so a remote change no longer
  clobbers in-progress edits. report-editor's XSLT upload marks the control dirty explicitly,
  or Save would stay disabled after an upload.
- edit-account.ts: name required, email format, password bounded by the server maximum,
  confirmation matched. The optional-password rule ("leave blank to keep current") needs no
  conditional branch: Angular's minLength returns null for an empty value and passwordsMatch
  is satisfied when both rows are empty. Username stays disabled, so the save path reads
  getRawValue().
- user-editor.ts: the full §2.2 table, and the first real consumer of app-field-group (#172) —
  seven identity fields over two columns, which is also the partial-final-row case the group
  suppresses the trailing divider for. Password is required on create and optional on edit,
  matching the existing "only include password if set" payload rather than forcing a password
  change on every edit. Roles and per-role permissions moved INSIDE the form (a roleNames
  string[] control and a permissions FormGroup with one control per role) — with the
  checkboxes outside it, a permission-only change would not mark the form dirty and Save would
  stay disabled with unsaved work on screen. The payload now ships permissions for the
  selected roles only, so a deselected role no longer sends a stale list. Deletes the
  ChangeDetectorRef.detectChanges() workaround and the NgForm ViewChild.
- All six: hasUnsavedChanges() is form.dirty; Save is disabled on
  form.invalid || form.pristine || saving(); no [(ngModel)] and no local .form-grid remains.

Shared component fix
- annotations-section.ts: <h3>Annotations</h3> is now <h2 class="rq-section-title">. As an h3
  directly under the page <h1> it was an axe heading-order violation on every one of the seven
  editors that mount it, whenever the editor's own optional h2 sections happened to be empty —
  latent for goal-editor too, whose spec passes only because its fixture has referers.
  term-editor's own "Alternate Terms" / "Referenced By" headings and user-editor's "Roles &
  Permissions" are promoted to h2 for the same reason, matching what #158 did for goal-editor.
  (The explanatory comment deliberately contains no backticks: the template is a TS template
  literal, and a stray backtick there breaks compilation for all seven consumers.)

e2e
- #name, #text, #username stay stable via app-field's controlId — they are a contract, not an
  implementation detail: BaseListPage's default readySelector is #name, and nine page objects
  locate these ids. No e2e change was needed for them.
- #password / #repassword DID change meaning: the id now lands on the inner input rather than
  the p-password host, so UserEditorPage.ts and account.e2e.ts move from
  .locator('#password').locator('input') to .locator('#password').

Tests
- form-errors.spec.ts: 57 tests, covering the group-vs-control placement of passwordMismatch,
  the stale-after-password-edit case, atLeastOne across value shapes, applyCommandErrors
  (resolved / unresolved / null field / dotted-indexed path / precedence / survives a render /
  clears on edit), and clearServerErrors.
- Per editor: a *.spec.ts and a *.a11y.spec.ts. The a11y specs assert axe-clean at rest, with
  fields in their error state, and with a page-level failure showing — plus reading order
  matching the visual two-column order in user-editor, one label per control, and the
  group-level roles error announced as role="alert" beside the checkboxes it concerns.
- p-confirmdialog remains the only axe exclusion anywhere (a PrimeNG host defect, #139).

Verification
- cd requel-angular && npm test -- --watch=false: 85 files, 757 tests, all green.
- ng build --configuration production: bundle generation complete.
- No backend module touched, so `mvn clean verify` is not implicated.
- Playwright e2e not run here; the two locator changes above are the only ones this change
  requires, and no other page object references the affected ids.
