### PR TITLE
173: Create-flow wizards for project, actor, stakeholder, scenario, use-case

### DIFF
--- a/doc/173-create-flow-wizards-plan.md
+++ b/doc/173-create-flow-wizards-plan.md
@@ -16,9 +16,10 @@ Three findings from source verification, each of which changes the work:
 1. **None of the five is reactive yet.** #173 is not "add wizard chrome to reactive editors"; it is
    the full #132 conversion (reactive forms, `app-field` rows, `applyCommandErrors`, delete
    `trackChanges`) across 2,758 lines, *plus* the wizard, *plus* the version contract.
-2. **Every client-reachable association command bumps the parent AND returns it.** §3 was right that
-   the Goal/Story precedent does not carry over, but the remedy is simpler than it feared: the
-   refetch it called for is never required. Read the version off the result.
+2. **Every client-reachable association command bumps the parent; only three return it.** §3 was
+   right that the Goal/Story precedent does not carry over, and right to ask for a refetch — six of
+   the nine send no entity back at all, because their registration declares no result extractor.
+   See §2 for the table and for the correction to an earlier revision of this document.
 3. **`scenario-editor` is not the shape §3 assumes.** Its steps are not association commands at all.
 
 ## Decisions (locked)
@@ -55,27 +56,42 @@ the per-editor cost is measured rather than guessed.
 §3 asked that each command be verified rather than assumed. Done, against
 `modules/project-jpa/.../impl/command/`:
 
-| Command | Mutates parent? | Merges parent? | Returns parent? | Verdict |
-|---|---|---|---|---|
-| `AddGoalToGoalContainer` | yes | `merge(addingContainer)` | `setGoalContainer` | **bumps**, result usable |
-| `RemoveGoalFromGoalContainer` | yes | `merge(removingContainer)` | `setGoalContainer` | **bumps**, result usable |
-| `AddScenarioToUseCase` | yes | `merge(useCaseImpl)` | `setUseCase` | **bumps**, result usable |
-| `RemoveScenarioFromUseCase` | yes | `merge(useCaseImpl)` | `setUseCase` | **bumps**, result usable |
-| `SetPrimaryScenarioOnUseCase` | yes | `merge(useCaseImpl)` | `setUseCase` | **bumps**, result usable |
-| `AddStoryToStoryContainer` | yes | `merge(addingContainer)` | `setStoryContainer` | **bumps**, result usable |
-| `RemoveStoryFromStoryContainer` | yes | `merge(removingContainer)` | `setStoryContainer` | **bumps**, result usable |
-| `AddActorToActorContainer` | yes | `merge(addingContainer)` | `setActorContainer` | **bumps**, result usable |
-| `RemoveActorFromActorContainer` | yes | `merge(removingContainer)` | `setActorContainer` | **bumps**, result usable |
-| `AssignTag` | no — mutates `Tag` | — | — | clean (as #158 found) |
+| Command | Merges parent (bumps `@Version`) | Returns parent to the client | Wizard must |
+|---|---|---|---|
+| `AddGoalToGoalContainer` | yes | **no** | refetch |
+| `RemoveGoalFromGoalContainer` | yes | **no** | refetch |
+| `AddStoryToStoryContainer` | yes | **no** | refetch |
+| `RemoveStoryFromStoryContainer` | yes | **no** | refetch |
+| `AddActorToActorContainer` | yes | **no** | refetch |
+| `RemoveActorFromActorContainer` | yes | **no** | refetch |
+| `AddScenarioToUseCase` | yes | yes | read `result.entity` |
+| `RemoveScenarioFromUseCase` | yes | yes | read `result.entity` |
+| `SetPrimaryScenarioOnUseCase` | yes | yes | read `result.entity` |
+| `AssignTag` | no — mutates `Tag` | n/a | nothing |
 
-Two notes on this table.
+**Correction, 2026-08-07.** An earlier revision of this document claimed all nine returned the
+merged parent and that §3's refetch branch was dead code. That was wrong, and the error is worth
+recording because it is invisible from the command implementations alone.
 
-- **`RemoveActorFromActorContainer` and `RemoveStoryFromStoryContainer` were missing from §3's
-  list.** Both are invoked by `use-case-editor`. Both verified above.
-- **The refetch §3 required is never needed.** Every command that bumps also returns the merged
-  parent, so the wizard host reads the new `version` off `result.entity` — exactly the #158
-  mechanism, just applied after *every* step rather than only step 1. §3's "or refetch when the
-  command does not return the parent" branch is dead code for these nine. Do not build it.
+`AddGoalToGoalContainerCommandImpl` really does end with `setGoalContainer(addingContainer)` — but
+that is the *Java command object*, not the HTTP response. `CommandController` builds the response
+body from `ApiCommandFactory.extractResult`, which returns `reg.resultExtractor().apply(command)`
+if the registration declared one and **`null` otherwise**. Six of these register through the 4-arg
+`CommandRegistry.register` overload, which passes `null` for both the file applicator and the
+result extractor, so the merged container never reaches the client. `AddScenarioToUseCase` and its
+two siblings pass the 6-arg overload with `cmd -> ProjectQueryController.toUseCaseDetailDto(...)`,
+which is why those three differ.
+
+Consequence: **§3's "or refetch when the command does not return the parent" branch is required for
+six of the nine, not dead.** Read `result.entity` only for the three that populate it.
+
+Second consequence, worth its own ticket: `CommandController.publishEntityChangedIfPresent` derives
+its SSE target from the result DTO's `id()`. A null result means **no targeted SSE event fires** for
+those six commands, so another session with the same actor/story/use-case open is never told to
+refresh after a goal, story or actor association changes. Registering result extractors would fix
+the version problem and this one together, but the container is polymorphic (`GoalContainer` is an
+Actor, Story, UseCase or Stakeholder), so a single extractor has to switch on the concrete type —
+which is why this plan takes the client-side refetch and leaves the backend change to a follow-up.
 
 ## 3. Correction to §3, part two — four commands are unreachable from the client
 

--- a/doc/173-create-flow-wizards-plan.md
+++ b/doc/173-create-flow-wizards-plan.md
@@ -1,0 +1,216 @@
+# Implementation Plan — #173 Create-flow wizards for project, actor, stakeholder, scenario, use-case
+
+Companion to `doc/132-reactive-forms-plan.md` (§1.1 step tables, §3 version contract, §10.3
+acceptance criteria) and `doc/158-form-wizard-field.md` (§2 version rule, the `app-form-wizard` API).
+This document exists because verifying §3's command list against the source changed three of its
+conclusions, and because the scope is larger than the issue title implies.
+
+## Summary
+
+Five editors — `project`, `actor`, `stakeholder`, `scenario`, `use-case` — gate authorable content
+behind `@if (!isNew())`, so creating one produces a stub the user must navigate back into. #173
+converts each create flow to an `app-form-wizard`.
+
+Three findings from source verification, each of which changes the work:
+
+1. **None of the five is reactive yet.** #173 is not "add wizard chrome to reactive editors"; it is
+   the full #132 conversion (reactive forms, `app-field` rows, `applyCommandErrors`, delete
+   `trackChanges`) across 2,758 lines, *plus* the wizard, *plus* the version contract.
+2. **Every client-reachable association command bumps the parent AND returns it.** §3 was right that
+   the Goal/Story precedent does not carry over, but the remedy is simpler than it feared: the
+   refetch it called for is never required. Read the version off the result.
+3. **`scenario-editor` is not the shape §3 assumes.** Its steps are not association commands at all.
+
+## Decisions (locked)
+
+1. **One PR, sliced commits** — `173-create-flow-wizards`, one commit per editor in risk order.
+   §1.1 suggests `use-case-editor` get its own PR; overridden to keep CLAUDE.md's one-issue /
+   one-branch / one-PR rule. Mitigated by commit slicing and by landing use-case last.
+2. **Backend fixes land in this branch** where a command bumps a version needlessly. Per §4 below
+   no such fix is currently required, so this is a contingency, not a planned change. Anything
+   found gets its own commit in the slice that surfaced it, never folded into an Angular commit.
+3. **Write the five `applyCommandErrors` maps now**, following #132's pattern exactly. #176 deletes
+   all eleven at once later; #173 takes no dependency on it.
+4. **Branch is cut from `171-bean-validation`**, not `release/2.0` — the five editors need
+   `ARTIFACT_NAME_MAX_LENGTH`, which only exists there. Rebase after #171 squash-merges:
+   `git rebase --onto origin/release/2.0 171-bean-validation 173-create-flow-wizards`.
+
+## 1. What exists today
+
+| Editor | Lines | ngModel | FormGroup | app-field | trackChanges | `!isNew()` gates |
+|---|---|---|---|---|---|---|
+| `project-editor` | 368 | 3 | 0 | 0 | 0 | 2 |
+| `actor-editor` | 431 | 4 | 0 | 0 | 3 | 2 |
+| `stakeholder-editor` | 518 | 8 | 0 | 0 | 5 | 1 |
+| `scenario-editor` | 692 | 10 | 0 | 0 | 4 | 2 |
+| `use-case-editor` | 749 | 6 | 0 | 0 | 4 | 3 |
+
+None imports `applyCommandErrors`. All five are template-driven. This is the same starting point
+#132's six editors had, so the conversion pattern is established — but it is the bulk of the work,
+and the 8-point estimate was set before this was confirmed. **Re-point after slice 1 lands**, when
+the per-editor cost is measured rather than guessed.
+
+## 2. Correction to §3, part one — the command verification table
+
+§3 asked that each command be verified rather than assumed. Done, against
+`modules/project-jpa/.../impl/command/`:
+
+| Command | Mutates parent? | Merges parent? | Returns parent? | Verdict |
+|---|---|---|---|---|
+| `AddGoalToGoalContainer` | yes | `merge(addingContainer)` | `setGoalContainer` | **bumps**, result usable |
+| `RemoveGoalFromGoalContainer` | yes | `merge(removingContainer)` | `setGoalContainer` | **bumps**, result usable |
+| `AddScenarioToUseCase` | yes | `merge(useCaseImpl)` | `setUseCase` | **bumps**, result usable |
+| `RemoveScenarioFromUseCase` | yes | `merge(useCaseImpl)` | `setUseCase` | **bumps**, result usable |
+| `SetPrimaryScenarioOnUseCase` | yes | `merge(useCaseImpl)` | `setUseCase` | **bumps**, result usable |
+| `AddStoryToStoryContainer` | yes | `merge(addingContainer)` | `setStoryContainer` | **bumps**, result usable |
+| `RemoveStoryFromStoryContainer` | yes | `merge(removingContainer)` | `setStoryContainer` | **bumps**, result usable |
+| `AddActorToActorContainer` | yes | `merge(addingContainer)` | `setActorContainer` | **bumps**, result usable |
+| `RemoveActorFromActorContainer` | yes | `merge(removingContainer)` | `setActorContainer` | **bumps**, result usable |
+| `AssignTag` | no — mutates `Tag` | — | — | clean (as #158 found) |
+
+Two notes on this table.
+
+- **`RemoveActorFromActorContainer` and `RemoveStoryFromStoryContainer` were missing from §3's
+  list.** Both are invoked by `use-case-editor`. Both verified above.
+- **The refetch §3 required is never needed.** Every command that bumps also returns the merged
+  parent, so the wizard host reads the new `version` off `result.entity` — exactly the #158
+  mechanism, just applied after *every* step rather than only step 1. §3's "or refetch when the
+  command does not return the parent" branch is dead code for these nine. Do not build it.
+
+## 3. Correction to §3, part two — four commands are unreachable from the client
+
+§3 lists `EditScenarioStep`, `DeleteScenarioStep`, `CopyScenarioStep` and `ConvertStepToScenario`
+as commands this ticket must verify. **The Angular client never invokes any of them.** The only
+commands `scenario-editor.ts` issues are `EditScenario`, `CopyScenario` and `DeleteScenario`; a
+repo-wide grep for `EditScenarioStep` and `stepCommands` across `requel-angular/` returns nothing.
+
+They are server-internal: `CopyScenarioStep` is driven by `CopyScenarioCommandImpl`, and
+`EditScenarioStepCommand` is a *sub-command* carried in `EditScenarioCommand.getStepCommands()`.
+
+This matters because two of them would otherwise have been the hard cases —
+`DeleteScenarioStepCommandImpl` mutates `scenarioReferer.getSteps()` on every using scenario, and
+`ConvertStepToScenarioCommandImpl` removes and re-adds into `scenario.getSteps()`; both dirty the
+parent without returning it, so both would have forced the refetch path. Since neither is reachable
+from a wizard, **no refetch path is needed anywhere in #173.** Leave them alone; if they are ever
+exposed to the client, that ticket owns the problem.
+
+## 4. Correction to §3, part three — `scenario-editor` is a different shape
+
+`EditScenarioCommandImpl.execute()` executes its `stepCommands`, calls `checkExpectedVersion`
+(#108), merges the scenario, then does:
+
+```java
+scenarioImpl.getSteps().clear();
+for (EditScenarioStepCommand executedCommand : stepEditCommands) { ... }
+setScenario(getProjectRepository().merge(scenarioImpl));
+```
+
+Steps are a **whole-list replace inside the scenario's own save**, not incremental associations. The
+client matches this: `scenario-editor` holds steps in a `stepNodes` signal, edits them locally, and
+submits everything in one `EditScenario` call, with an explicit "Steps have unsaved changes" hint.
+
+So the scenario wizard is the #158 two-mutation case, not the §3 many-mutation case:
+
+- Step 1 `Details` → `EditScenario` with no steps. Capture `id` and `version` from the result.
+- Step 2 `Steps` → `EditScenario` again, full step list, using the version from step 1. One command,
+  one version spend, and `checkExpectedVersion` enforces it.
+- Because step 2 re-sends name/text/type, a user who goes back to step 1 and edits the name must
+  have that change carried into the step-2 payload. Source the payload from the form, not from a
+  snapshot taken at step-1 commit.
+
+`editingStep() !== null` already participates in the SSE guard (`scenario-editor.ts:435`); that
+guard must survive into the wizard alongside the `hasUnsavedChanges()` condition.
+
+## 5. Per-editor plans
+
+### 5.1 `scenario-editor` — slice 1, highest value
+
+2 steps · Details → Steps. Gating steps means create yields an empty scenario, which is the whole
+finding. Commands: `EditScenario` only (see §4). Existing `scenario-editor.a11y.spec.ts` is the only
+a11y spec among the five — extend it rather than starting one.
+
+### 5.2 `actor-editor` — slice 2
+
+2 steps · Details → Goals. Commands: `AddGoalToGoalContainer`, `RemoveGoalFromGoalContainer` — both
+bump, both return. "Referenced By" (use cases, stories) is derived and read-only: stays gated,
+stays outside the wizard, per decision 2 of the 132 plan.
+
+### 5.3 `stakeholder-editor` — slice 3
+
+2 steps · Details (incl. Permissions) → Goals. The `isUserType()` mode selector stays on step 1 and
+stays `[disabled]="!isNew()"`. Permissions is already visible on create, so only Goals is new
+chrome. Two save commands by mode: `EditUserStakeholder` / `EditNonUserStakeholder`. Eight ngModel
+bindings, including `perm.checked` inside an iteration — the fiddliest reactive conversion of the
+five.
+
+### 5.4 `project-editor` — slice 4
+
+2 steps · Details → Tags. Commands: `EditProject`, plus `AssignTag`, which is the one clean command
+in the table — the Tags step does *not* spend the project's version. The odd one out in another way
+too: it is the only one of the five not created inside an existing project context, so there is no
+parent project to resolve for routing or permissions.
+
+### 5.5 `use-case-editor` — slice 5, last
+
+4 steps · Details → Scenarios → Goals & Stories → Actors. Largest file, five gated sections, and
+the only editor touching all eight bumping commands. Landing it last means the version-refresh
+helper is already proven by four smaller wizards.
+
+## 6. Slice order
+
+1. `scenario-editor` — establishes the two-mutation wizard and the version-refresh helper.
+2. `actor-editor` — establishes the association-command pattern (`AddGoalToGoalContainer`).
+3. `stakeholder-editor` — adds the mode-selector and permissions complexity.
+4. `project-editor` — adds the clean-command case and the no-parent-project case.
+5. `use-case-editor` — four steps, all patterns combined.
+
+Each commit: reactive conversion + `app-field` rows + `applyCommandErrors` map + wizard + specs, for
+one editor. A slice that cannot pass `npm test -- --watch=false` does not get committed.
+
+## 7. Tests
+
+Per §10.3, per wizard: **create → advance to the last step → mutate an association → navigate back
+to step 1 → edit the name → Continue succeeds with no 409.** This is the test that catches a stale
+held version, and it is the reason the table in §2 exists.
+
+Also per editor: an entity created through the wizard is identical to one created by the previous
+form; `hasUnsavedChanges()` derives from `form.dirty` with `trackChanges()` deleted; a 409 keeps the
+step, refreshes, and renders in the wizard's `role="alert"` region; axe clean with fields in the
+error state. Four of the five have no a11y spec today — those are new files.
+
+## 8. Ticket state (verified 2026-08-06)
+
+Read back from `gh issue view 173`:
+
+- **All thirteen §10.3 acceptance criteria are on the issue, verbatim.** Despite
+  `scripts/update-ui-ux-subissues.sh` having no `173` entry, they were added by hand. The issue is
+  usable as the implementation checklist.
+- Milestone `v2.0`, project "Requel 2.0 (Todo)", **no labels**. Blocked-by #132 and blocking #138
+  are both linked.
+- **#171, #172, #173 and #176 were never sub-issues of epic #124** — the four split out of #132 were
+  added to the rollup doc but not to the epic's native list, which is why `trackedInIssues` came
+  back empty. Added 2026-08-06; the epic now returns 33, matching the rollup's count. This also
+  required updating `ORDER` in `scripts/update-ui-ux-subissues.sh` from 29 to 33 entries, because
+  `reorder_subissues()` exits 1 when `ORDER` and the live sub-issue set differ. The two must always
+  change together. That edit rides on this branch.
+- Two comments carry decisions not in the issue body:
+  - **Error maps** — #176 fixes violation naming at source and deletes all the maps. If #176 lands
+    first, skip them here and call `applyCommandErrors(form, result.violations)` with no third
+    argument. Otherwise add them. A missing entry degrades to a page-level message rather than
+    breaking, so it blocks nothing either way. Consistent with decision 3 above.
+  - **#171 dependency** — inherit `ARTIFACT_NAME_MAX_LENGTH` from `validation-limits.ts` rather than
+    inventing client-side caps. Confirms decision 4 above.
+
+**The issue body reproduces §1.1 and §3 verbatim, including all three errors corrected in §2–§4 of
+this document.** Anyone implementing straight from the ticket will build the refetch path that is
+never needed and go looking for four commands the client cannot reach. Correct the ticket before
+starting, or at minimum comment the verification table onto it.
+
+## 9. Open questions
+
+- **Re-point the issue** once slice 1 measures the true per-editor cost. 8 was set before the
+  reactive conversion was known to be in scope.
+- **§3 should be corrected in `doc/132-reactive-forms-plan.md`** as well as on the ticket, or the
+  error outlives both. Cheapest fix is a pointer from §3 to this file.
+
+Part of the UI/UX remediation epic #124. Blocked by #132 (merged) and #171 (in review). Blocks #138.

--- a/requel-angular/e2e/pages/ActorEditorPage.ts
+++ b/requel-angular/e2e/pages/ActorEditorPage.ts
@@ -1,5 +1,6 @@
 import { Page, expect } from '@playwright/test';
 import { BaseListPage } from './BaseListPage';
+import { completeCreateWizard } from './wizard';
 
 export class ActorListPage extends BaseListPage {
   constructor(page: Page) {
@@ -56,7 +57,14 @@ export class ActorEditorPage {
 
   /** New actors show "Create"; existing actors show "Save" */
   async save(): Promise<void> {
-    // Try "Create" first (new actor), fall back to "Save" (existing actor)
+    // Create is a wizard since #173; edit still has a Save button.
+    if (await completeCreateWizard(this.page, /\/api\/commands\/EditActor/)) {
+      return;
+    }
+    // Edit mode shows "Save"; a pre-#173 build shows "Create" on the new-actor form. Keeping
+    // the fallback means this page object still works against an older build instead of
+    // failing on a missing testid, which is otherwise a confusing way to discover you are
+    // running the wrong jar.
     const createBtn = this.page.getByTestId('actor-create');
     const saveBtn = this.page.getByTestId('actor-save');
     const btn = (await createBtn.count()) > 0 ? createBtn : saveBtn;

--- a/requel-angular/e2e/pages/ProjectsPage.ts
+++ b/requel-angular/e2e/pages/ProjectsPage.ts
@@ -1,5 +1,6 @@
 import { Download, Page, expect } from '@playwright/test';
 import { BaseListPage } from './BaseListPage';
+import { completeCreateWizard } from './wizard';
 
 export class ProjectsPage extends BaseListPage {
   constructor(page: Page) {
@@ -93,6 +94,10 @@ export class ProjectEditorPage {
   }
 
   async save(): Promise<void> {
+    // Create is a wizard since #173; edit still has a Save button.
+    if (await completeCreateWizard(this.page, /\/api\/commands\/EditProject/)) {
+      return;
+    }
     await this.page.getByTestId('project-save').click();
     // wait for navigation away from /new or for save to complete
     await this.page.waitForLoadState('domcontentloaded');

--- a/requel-angular/e2e/pages/ScenarioEditorPage.ts
+++ b/requel-angular/e2e/pages/ScenarioEditorPage.ts
@@ -1,5 +1,6 @@
 import { Page, expect } from '@playwright/test';
 import { BaseListPage } from './BaseListPage';
+import { completeCreateWizard } from './wizard';
 
 export class ScenarioListPage extends BaseListPage {
   constructor(page: Page) {
@@ -63,6 +64,16 @@ export class ScenarioEditorPage {
   }
 
   async save(): Promise<void> {
+    // Create is a wizard since #173; edit still has a Save button. The detail-reload wait is
+    // registered first either way - in the wizard it is satisfied by the refetch that follows
+    // the step-1 commit.
+    if ((await this.page.getByTestId('wizard-continue').count()) > 0) {
+      const wizardReloadPromise = this.waitForScenarioDetailReload();
+      await completeCreateWizard(this.page, /\/api\/commands\/EditScenario/);
+      await wizardReloadPromise;
+      return;
+    }
+
     await expect(this.saveButton()).toBeEnabled();
     const scenarioReloadPromise = this.waitForScenarioDetailReload();
     const [response] = await Promise.all([

--- a/requel-angular/e2e/pages/SettingsPage.ts
+++ b/requel-angular/e2e/pages/SettingsPage.ts
@@ -36,28 +36,35 @@ export class SettingsPage {
     await option.click();
   }
 
-  async save(): Promise<void> {
+  /**
+   * Save is `[disabled]="form.invalid || form.pristine || saving()"` and `data-testid` sits on
+   * the `p-button` host, not the inner control -- so clicking the host while the inner button
+   * is disabled silently no-ops and `waitForResponse` then burns the entire test timeout with
+   * a useless "target closed" trace. Assert enabled first so an unchanged form says so.
+   */
+  private async clickAndAwaitPut(testId: string): Promise<void> {
+    const button = this.page.getByTestId(testId).locator('button');
+    await expect(button, `${testId} is disabled -- the form is pristine or invalid`)
+      .toBeEnabled({ timeout: 10_000 });
     const [response] = await Promise.all([
       this.page.waitForResponse(r =>
         r.url().includes('/user-preferences') && r.request().method() === 'PUT'
       ),
-      this.page.getByTestId('settings-save').click(),
+      button.click({ timeout: 10_000 }),
     ]);
     if (!response.ok()) {
-      throw new Error(`PUT /user-preferences failed: ${response.status()} ${await response.text()}`);
+      throw new Error(
+        `PUT /user-preferences (${testId}) failed: ${response.status()} ${await response.text()}`
+      );
     }
   }
 
+  async save(): Promise<void> {
+    await this.clickAndAwaitPut('settings-save');
+  }
+
   async resetToDefaults(): Promise<void> {
-    const [response] = await Promise.all([
-      this.page.waitForResponse(r =>
-        r.url().includes('/user-preferences') && r.request().method() === 'PUT'
-      ),
-      this.page.getByTestId('settings-reset').click(),
-    ]);
-    if (!response.ok()) {
-      throw new Error(`PUT /user-preferences (reset) failed: ${response.status()} ${await response.text()}`);
-    }
+    await this.clickAndAwaitPut('settings-reset');
   }
 
   async expectProjectLimit(limit: number): Promise<void> {

--- a/requel-angular/e2e/pages/UseCaseEditorPage.ts
+++ b/requel-angular/e2e/pages/UseCaseEditorPage.ts
@@ -1,5 +1,6 @@
 import { Page, expect } from '@playwright/test';
 import { BaseListPage } from './BaseListPage';
+import { completeCreateWizard } from './wizard';
 
 export class UseCaseListPage extends BaseListPage {
   constructor(page: Page) {
@@ -75,6 +76,10 @@ export class UseCaseEditorPage {
   }
 
   async save(): Promise<void> {
+    // Create is a wizard since #173; edit still has a Save button.
+    if (await completeCreateWizard(this.page, /\/api\/commands\/EditUseCase/)) {
+      return;
+    }
     await this.page.getByTestId('use-case-save').click();
     await this.page.waitForLoadState('domcontentloaded');
   }

--- a/requel-angular/e2e/pages/wizard.ts
+++ b/requel-angular/e2e/pages/wizard.ts
@@ -1,0 +1,83 @@
+import { Page, expect } from '@playwright/test';
+
+/** The active step's key, or null once the wizard has unmounted. */
+async function activeStepKey(page: Page): Promise<string | null> {
+  const panel = page.locator('[data-testid^="wizard-panel-"]');
+  if ((await panel.count()) === 0) {
+    return null;
+  }
+  const id = await panel.first().getAttribute('data-testid');
+  return id ? id.replace('wizard-panel-', '') : null;
+}
+
+/**
+ * Drives an `app-form-wizard` create flow to completion.
+ *
+ * #173 turned create into a wizard for project, actor, stakeholder, scenario and use case. The
+ * Save button now exists only in edit mode; creating means pressing Continue on each step and
+ * Done on the last, after which the host navigates and the wizard unmounts.
+ *
+ * Returns false when no wizard is on the page, so callers keep their edit-mode path unchanged
+ * and one `save()` serves both flows.
+ *
+ * Clicks target the inner `<button>` rather than the `p-button` host: the host is a custom
+ * element whose box can be intercepted by PrimeNG's toast overlay, which appears right after
+ * the step-1 save and made an earlier version of this helper hang until the test timeout.
+ *
+ * Progress is asserted per step - after each click the active step must change or the wizard
+ * must unmount - so a step that refuses to advance fails naming itself instead of producing a
+ * 30s "target closed" with no indication of where it stalled.
+ *
+ * @param commandUrl when given, the first Continue is awaited against this command's response
+ *                   and a non-2xx or `success: false` throws, so a failed create reports the
+ *                   server's message rather than failing later on a missing row.
+ */
+export async function completeCreateWizard(page: Page, commandUrl?: RegExp): Promise<boolean> {
+  const continueBtn = page.getByTestId('wizard-continue').locator('button');
+  if ((await page.getByTestId('wizard-continue').count()) === 0) {
+    return false;
+  }
+
+  let key = await activeStepKey(page);
+
+  await expect(continueBtn).toBeEnabled();
+  if (commandUrl) {
+    const [response] = await Promise.all([
+      page.waitForResponse(r => commandUrl.test(r.url())),
+      continueBtn.click({ timeout: 10_000 }),
+    ]);
+    if (!response.ok()) {
+      throw new Error(`${response.url()} failed: ${response.status()} ${await response.text()}`);
+    }
+    const body = (await response.json()) as { success?: boolean; error?: string };
+    if (body.success === false) {
+      throw new Error(`create failed on step "${key}": ${body.error ?? 'success=false'}`);
+    }
+  } else {
+    await continueBtn.click({ timeout: 10_000 });
+  }
+
+  // Step 1 is the only one that talks to the API; the association steps commit through their
+  // own widgets, so their Continue just advances. Loop until the wizard unmounts on finish.
+  for (let i = 0; i < 6; i++) {
+    const previous = key;
+    await expect
+      .poll(() => activeStepKey(page), {
+        timeout: 15_000,
+        message: `wizard did not leave step "${previous}" after pressing Continue`,
+      })
+      .not.toBe(previous);
+
+    key = await activeStepKey(page);
+    if (key === null) {
+      // Wizard gone: the host navigated on finish, which is the success exit.
+      await page.waitForLoadState('domcontentloaded');
+      return true;
+    }
+
+    await expect(continueBtn).toBeEnabled();
+    await continueBtn.click({ timeout: 10_000 });
+  }
+
+  throw new Error(`wizard still on step "${key}" after 6 Continue presses`);
+}

--- a/requel-angular/e2e/settings.e2e.ts
+++ b/requel-angular/e2e/settings.e2e.ts
@@ -37,9 +37,18 @@ test.describe('Settings / preferences', () => {
     await page.close();
   });
 
-  test('change staleness threshold → persists after reload', async ({ adminContext }) => {
+  test('change staleness threshold → persists after reload', async ({ adminContext, request }) => {
     const page = await adminContext.newPage();
     const settings = new SettingsPage(page);
+
+    // Seed a baseline that differs from the value under test. Save is disabled while the form
+    // is pristine, and picking the option that is already selected is not a change -- so if a
+    // previous (or aborted) run left the stored threshold at SIX_MONTHS, this test would leave
+    // Save disabled and hang on the PUT that never fires. afterEach restores the snapshot.
+    await savePreferences(request, {
+      sidebarProjectLimit: originalPrefs?.sidebarProjectLimit ?? 10,
+      sidebarProjectStaleness: 'THREE_MONTHS',
+    });
 
     await settings.goto();
     await settings.selectStaleness('6 Months');

--- a/requel-angular/src/app/features/actors/actor-editor.a11y.spec.ts
+++ b/requel-angular/src/app/features/actors/actor-editor.a11y.spec.ts
@@ -116,4 +116,31 @@ describe('ActorEditorComponent - create wizard accessibility', () => {
 
     await expectNoAxeViolations(wizard);
   });
+
+  // Regression guard for the e2e contract. The Playwright page objects address these controls
+  // by DOM id - locator('#name'), locator('#text') - because that is the convention app-field
+  // established (controlId on the field, matching id on the control; see term-editor). The
+  // #173 conversion dropped the ids and let app-field generate them, so #name matched nothing
+  // and 23 e2e tests failed while every unit test stayed green. Nothing here asserted the
+  // association, so nothing caught it.
+  it('keeps the stable control ids the e2e page objects address', async () => {
+    const wizard = await renderWizard();
+    {
+      const el = wizard.querySelector('#name');
+      expect(el, 'missing #name - e2e page objects locate this control by id').not.toBeNull();
+      expect(el!.tagName).toBe('INPUT');
+      // The label must point at that same id, or the id is present but unassociated.
+      const label = wizard.querySelector('label[for="name"]');
+      expect(label, 'no <label for="name">').not.toBeNull();
+    }
+    {
+      const el = wizard.querySelector('#text');
+      expect(el, 'missing #text - e2e page objects locate this control by id').not.toBeNull();
+      expect(el!.tagName).toBe('TEXTAREA');
+      // The label must point at that same id, or the id is present but unassociated.
+      const label = wizard.querySelector('label[for="text"]');
+      expect(label, 'no <label for="text">').not.toBeNull();
+    }
+  });
+
 });

--- a/requel-angular/src/app/features/actors/actor-editor.a11y.spec.ts
+++ b/requel-angular/src/app/features/actors/actor-editor.a11y.spec.ts
@@ -1,0 +1,119 @@
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter, Router, ActivatedRoute, convertToParamMap } from '@angular/router';
+import { BehaviorSubject, EMPTY } from 'rxjs';
+import { MessageService } from 'primeng/api';
+import { ActorEditorComponent } from './actor-editor';
+import { ActorService } from '../../core/actor.service';
+import { CommandService } from '../../core/command.service';
+import { ProjectService } from '../../core/project.service';
+import { PermissionService } from '../../core/permission.service';
+import { EventStreamService } from '../../core/event-stream.service';
+import { expectNoAxeViolations } from '../../shared/testing/a11y';
+
+const flush = () => new Promise(r => setTimeout(r, 0));
+
+const CREATED = {
+  id: 5, version: 1, name: 'Customer', text: 'End user of the system.',
+  goals: [], referencedByUseCases: [], referencedByStories: [],
+};
+
+// #173: create is now an app-form-wizard, so the create surface needs its own axe pass -
+// including with a field in the error state, which is where a missing or duplicated label and
+// an unassociated error message actually show up.
+describe('ActorEditorComponent - create wizard accessibility', () => {
+  let paramMap$: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fixture: any;
+  let comp: ActorEditorComponent;
+
+  beforeEach(() => {
+    paramMap$ = new BehaviorSubject(convertToParamMap({ name: 'proj1', actorId: 'new' }));
+
+    TestBed.configureTestingModule({
+      imports: [ActorEditorComponent],
+      providers: [
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: ActivatedRoute, useValue: { paramMap: paramMap$.asObservable() } },
+        { provide: ActorService, useValue: { getActor: vi.fn().mockResolvedValue(CREATED) } },
+        { provide: CommandService, useValue: {
+            execute: vi.fn().mockResolvedValue({ success: true, entity: CREATED }),
+          } },
+        { provide: ProjectService, useValue: { notifyTreeChanged: vi.fn() } },
+        { provide: PermissionService, useValue: {
+            loadForProject: vi.fn().mockResolvedValue(undefined),
+            canEdit: vi.fn().mockReturnValue(true),
+            canDelete: vi.fn().mockReturnValue(true),
+          } },
+        { provide: EventStreamService, useValue: {
+            events$: EMPTY,
+            addSubscription: vi.fn().mockResolvedValue(undefined),
+            removeSubscription: vi.fn().mockResolvedValue(undefined),
+          } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
+    });
+    fixture = TestBed.createComponent(ActorEditorComponent);
+    comp = fixture.componentInstance;
+    const router = TestBed.inject(Router);
+    vi.spyOn(router, 'navigate').mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  async function settle(): Promise<void> {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  async function renderWizard(): Promise<HTMLElement> {
+    fixture.detectChanges();
+    await flush();
+    await settle();
+    const wizard = fixture.nativeElement.querySelector('[data-testid="actor-wizard"]');
+    expect(wizard).not.toBeNull();
+    return wizard as HTMLElement;
+  }
+
+  it('renders the wizard on create, with the step nav labelled and Details current', async () => {
+    const wizard = await renderWizard();
+    expect(wizard.querySelector('nav')!.getAttribute('aria-label')).toBe('New actor steps');
+    expect(wizard.querySelector('[aria-current="step"]')!.textContent).toContain('Details');
+  });
+
+  it('has no axe-core violations on the Details step', async () => {
+    await expectNoAxeViolations(await renderWizard());
+  });
+
+  it('has no axe-core violations with the name field in the error state', async () => {
+    const wizard = await renderWizard();
+    comp.submitted.set(true);
+    comp.detailsForm.controls.name.setValue('');
+    comp.detailsForm.markAllAsTouched();
+    await settle();
+    // The message has to be on screen or this asserts nothing.
+    expect(wizard.textContent).toContain('An actor needs a name.');
+    await expectNoAxeViolations(wizard);
+  });
+
+  it('has no axe-core violations on the Goals step', async () => {
+    const wizard = await renderWizard();
+
+    // Advance the way a user does. Assigning comp.wizardStep directly mutates the value the
+    // [(activeKey)] binding was checked with and throws NG0100 - and it would skip the step-1
+    // commit, so Goals would render its "save the details first" placeholder instead of the
+    // table this test is meant to cover.
+    comp.detailsForm.controls.name.setValue('Customer');
+    await settle();
+    (wizard.querySelector('[data-testid="wizard-continue"] button') as HTMLButtonElement).click();
+    await flush();
+    await settle();
+    expect(comp.wizardStep).toBe('goals');
+
+    await expectNoAxeViolations(wizard);
+  });
+});

--- a/requel-angular/src/app/features/actors/actor-editor.spec.ts
+++ b/requel-angular/src/app/features/actors/actor-editor.spec.ts
@@ -93,21 +93,22 @@ describe('ActorEditorComponent', () => {
     expect(comp.goals()[0].name).toBe('Purchase item');
   });
 
-  it('trackChanges() sets hasChanges() when name differs from original', async () => {
+  // #173: trackChanges()/hasChanges() are gone; the form owns dirtiness now.
+  it('hasUnsavedChanges() follows form.dirty', async () => {
     paramMap$.next(convertToParamMap({ name: 'proj1', actorId: '5' }));
     fixture.detectChanges();
     await flush();
-    expect(comp.hasChanges()).toBe(false);
-    comp.name = 'Modified Actor';
-    comp.trackChanges();
-    expect(comp.hasChanges()).toBe(true);
+    expect(comp.hasUnsavedChanges()).toBe(false);
+    comp.detailsForm.controls.name.setValue('Modified Actor');
+    comp.detailsForm.controls.name.markAsDirty();
+    expect(comp.hasUnsavedChanges()).toBe(true);
   });
 
   it('onSave calls commandService.execute("EditActor") with actor fields', async () => {
     fixture.detectChanges();
     await flush();
-    comp.name = 'New Actor';
-    comp.text = 'Description';
+    comp.detailsForm.setValue({ name: 'New Actor', text: 'Description' });
+    comp.detailsForm.markAsDirty();
     await comp.onSave();
     expect(commandServiceMock.execute).toHaveBeenCalledWith('EditActor', expect.objectContaining({
       projectName: 'proj1',
@@ -154,8 +155,8 @@ describe('ActorEditorComponent', () => {
       success: true,
       entity: { ...MOCK_ACTOR, name: 'Customer Renamed', version: 1 }
     });
-    comp.name = 'Customer Renamed';
-    comp.text = 'Updated description';
+    comp.detailsForm.setValue({ name: 'Customer Renamed', text: 'Updated description' });
+    comp.detailsForm.markAsDirty();
     await comp.onSave();
 
     expect(commandServiceMock.execute).toHaveBeenCalledWith('EditActor', expect.objectContaining({
@@ -165,7 +166,7 @@ describe('ActorEditorComponent', () => {
     }));
     expect(comp.actorName()).toBe('Customer Renamed');
     expect(comp.version).toBe(1);
-    expect(comp.hasChanges()).toBe(false);
+    expect(comp.hasUnsavedChanges()).toBe(false);
     expect(messageServiceMock.add).toHaveBeenCalledWith(expect.objectContaining({
       severity: 'success', summary: 'Saved'
     }));
@@ -177,7 +178,7 @@ describe('ActorEditorComponent', () => {
     fixture.detectChanges();
     await flush();
     commandServiceMock.execute.mockResolvedValue({ success: false, error: 'Name conflict' });
-    comp.name = 'Duplicate';
+    comp.detailsForm.controls.name.setValue('Duplicate');
     await comp.onSave();
     expect(comp.errorMessage()).toBe('Name conflict');
   });
@@ -186,9 +187,69 @@ describe('ActorEditorComponent', () => {
     fixture.detectChanges();
     await flush();
     commandServiceMock.execute.mockRejectedValue(new Error('network down'));
-    comp.name = 'Anything';
+    comp.detailsForm.controls.name.setValue('Anything');
     await comp.onSave();
     expect(comp.errorMessage()).toBe('Save failed.');
+  });
+
+  // #173 required test (§10.3). The Goals step's associations bump the actor's @Version but
+  // return no entity, so the wizard has to refetch. If it did not, coming back to Details and
+  // pressing Continue would send the version captured at step 1 and 409.
+  describe('wizard version contract (#173)', () => {
+    it('survives create -> add goal -> back to Details -> rename -> Continue', async () => {
+      fixture.detectChanges();
+      await flush();
+
+      let version = 0;
+      commandServiceMock.execute.mockImplementation(async (type: string) => {
+        if (type === 'EditActor') {
+          version += 1;
+          return { success: true, entity: { ...MOCK_ACTOR, id: 5, version } };
+        }
+        // Association commands return no entity - that is the whole point.
+        version += 1;
+        return { success: true, entity: null };
+      });
+      actorServiceMock.getActor.mockImplementation(async () => ({ ...MOCK_ACTOR, id: 5, version }));
+
+      comp.detailsForm.controls.name.setValue('Customer');
+
+      const step1 = { step: { key: 'details' }, complete: vi.fn(), fail: vi.fn() };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await comp.onStepCommit(step1 as any);
+      expect(step1.complete).toHaveBeenCalled();
+
+      // Goals step: associate, which bumps the actor server-side.
+      await comp.onGoalSelected({ id: 7, name: 'Avoid late fees', entityType: 'Goal' });
+
+      // Back to Details, rename, Continue again.
+      comp.detailsForm.controls.name.setValue('Customer Renamed');
+      const step3 = { step: { key: 'details' }, complete: vi.fn(), fail: vi.fn() };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await comp.onStepCommit(step3 as any);
+
+      expect(step3.complete).toHaveBeenCalled();
+      expect(step3.fail).not.toHaveBeenCalled();
+
+      // The second EditActor must not carry the version from the first.
+      const edits = commandServiceMock.execute.mock.calls.filter(c => c[0] === 'EditActor');
+      expect(edits).toHaveLength(2);
+      expect(edits[1][1].version).toBe(2);
+      expect(edits[1][1].name).toBe('Customer Renamed');
+    });
+
+    it('the Goals step just advances - it issues no command of its own', async () => {
+      fixture.detectChanges();
+      await flush();
+      commandServiceMock.execute.mockClear();
+
+      const request = { step: { key: 'goals' }, complete: vi.fn(), fail: vi.fn() };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await comp.onStepCommit(request as any);
+
+      expect(request.complete).toHaveBeenCalled();
+      expect(commandServiceMock.execute).not.toHaveBeenCalled();
+    });
   });
 
   it('onCopy triggers confirm then calls execute("CopyActor") and navigates to copy', async () => {
@@ -257,6 +318,70 @@ describe('ActorEditorComponent', () => {
     }));
   });
 
+  // Regression: AddGoal/RemoveGoal merge the container (this actor), bumping its @Version,
+  // but register no result extractor - so result.entity is null and the new version can only
+  // be had by refetching. Before this, adding a goal and then saving the name gave a 409.
+  describe('stale version after a goal association', () => {
+    it('re-reads version after adding a goal', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', actorId: '5' }));
+      fixture.detectChanges();
+      await flush();
+      expect(comp.version).toBe(0);
+
+      commandServiceMock.execute.mockResolvedValue({ success: true, entity: null });
+      actorServiceMock.getActor.mockResolvedValue({ ...MOCK_ACTOR, version: 3 });
+
+      await comp.onGoalSelected({ id: 7, name: 'Avoid late fees', entityType: 'Goal' });
+      expect(comp.version).toBe(3);
+    });
+
+    it('re-reads version after removing a goal', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', actorId: '5' }));
+      fixture.detectChanges();
+      await flush();
+
+      commandServiceMock.execute.mockResolvedValue({ success: true, entity: null });
+      actorServiceMock.getActor.mockResolvedValue({ ...MOCK_ACTOR, version: 4 });
+
+      await comp.onRemoveGoal({ id: 1, name: 'Purchase item', entityType: 'Goal' });
+      expect(comp.version).toBe(4);
+    });
+
+    it('does not discard unsaved detail edits while refreshing the version', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', actorId: '5' }));
+      fixture.detectChanges();
+      await flush();
+
+      // User types a new name, then adds a goal without saving first.
+      comp.detailsForm.controls.name.setValue('Renamed but unsaved');
+      comp.detailsForm.controls.name.markAsDirty();
+
+      commandServiceMock.execute.mockResolvedValue({ success: true, entity: null });
+      actorServiceMock.getActor.mockResolvedValue({ ...MOCK_ACTOR, version: 9 });
+      await comp.onGoalSelected({ id: 7, name: 'Avoid late fees', entityType: 'Goal' });
+
+      // The version advanced, but the in-progress edit survived - which is why the refresh
+      // is narrow instead of a full loadActor().
+      expect(comp.version).toBe(9);
+      expect(comp.detailsForm.controls.name.value).toBe('Renamed but unsaved');
+      expect(comp.hasUnsavedChanges()).toBe(true);
+    });
+
+    it('leaves the held version alone when the refresh fetch fails', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', actorId: '5' }));
+      fixture.detectChanges();
+      await flush();
+
+      commandServiceMock.execute.mockResolvedValue({ success: true, entity: null });
+      actorServiceMock.getActor.mockRejectedValue(new Error('network'));
+
+      await comp.onGoalSelected({ id: 7, name: 'Avoid late fees', entityType: 'Goal' });
+      // Still 0, and no error surfaced: the association itself succeeded.
+      expect(comp.version).toBe(0);
+      expect(comp.goals().some(g => g.id === 7)).toBe(true);
+    });
+  });
+
   it('onGoalSelected sets errorMessage when add fails', async () => {
     paramMap$.next(convertToParamMap({ name: 'proj1', actorId: '5' }));
     fixture.detectChanges();
@@ -318,9 +443,9 @@ describe('ActorEditorComponent', () => {
     expect(router.navigate).toHaveBeenCalledWith(['/projects', 'proj1', 'actors']);
   });
 
-  it('hasUnsavedChanges() returns hasChanges() value', () => {
+  it('hasUnsavedChanges() reflects the form dirty state', () => {
     expect(comp.hasUnsavedChanges()).toBe(false);
-    comp.hasChanges.set(true);
+    comp.detailsForm.markAsDirty();
     expect(comp.hasUnsavedChanges()).toBe(true);
   });
 
@@ -354,16 +479,16 @@ describe('ActorEditorComponent', () => {
     fixture.detectChanges();
     await flush();
 
-    comp.name = 'Editing in progress';
-    comp.trackChanges();
-    expect(comp.hasChanges()).toBe(true);
+    comp.detailsForm.controls.name.setValue('Editing in progress');
+    comp.detailsForm.controls.name.markAsDirty();
+    expect(comp.hasUnsavedChanges()).toBe(true);
 
     events$.next({ targetType: 'Actor', targetId: 5 });
     await flush();
 
     // The reload was attempted (getActor called) but the result was discarded —
     // so the component's name field still holds the user's unsaved edit.
-    expect(comp.name).toBe('Editing in progress');
+    expect(comp.detailsForm.controls.name.value).toBe('Editing in progress');
     expect(comp.actorName()).toBe('Customer'); // unchanged from initial load
   });
 

--- a/requel-angular/src/app/features/actors/actor-editor.ts
+++ b/requel-angular/src/app/features/actors/actor-editor.ts
@@ -214,16 +214,16 @@ const STALE_VERSION_MESSAGE =
       where formControlName would look for a parent formGroup that is not there.
     -->
     <ng-template #detailsFields>
-      <app-field label="Name" [control]="detailsForm.controls.name"
+      <app-field label="Name" controlId="name" [control]="detailsForm.controls.name"
                  [errorMessages]="nameErrors" [submitted]="submitted()">
-        <input appFieldControl pInputText [formControl]="detailsForm.controls.name"
+        <input appFieldControl pInputText [formControl]="detailsForm.controls.name" id="name"
                [attr.maxlength]="nameMaxLength"
                placeholder="Actor name" data-testid="actor-name" />
       </app-field>
 
-      <app-field label="Description" [control]="detailsForm.controls.text" [divider]="false"
+      <app-field label="Description" controlId="text" [control]="detailsForm.controls.text" [divider]="false"
                  [submitted]="submitted()">
-        <textarea appFieldControl pTextarea [formControl]="detailsForm.controls.text" rows="4"
+        <textarea appFieldControl pTextarea [formControl]="detailsForm.controls.text" id="text" rows="4"
                   placeholder="Actor description" data-testid="actor-text"></textarea>
       </app-field>
     </ng-template>

--- a/requel-angular/src/app/features/actors/actor-editor.ts
+++ b/requel-angular/src/app/features/actors/actor-editor.ts
@@ -22,9 +22,10 @@ import { Component, computed, OnDestroy, OnInit, signal } from '@angular/core';
 import { PageHeaderComponent } from '../../shared/page-header';
 import { AppCardComponent } from '../../shared/app-card';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { NgTemplateOutlet } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
-import { FormsModule } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
 import { InputText } from 'primeng/inputtext';
 import { TextareaModule } from 'primeng/textarea';
@@ -41,13 +42,42 @@ import { PermissionService } from '../../core/permission.service';
 import { EventStreamService } from '../../core/event-stream.service';
 import { EntitySelectorDialogComponent } from '../../shared/entity-selector-dialog';
 import { AnnotationsSectionComponent } from '../../shared/annotations-section';
+import { AppFieldComponent, AppFieldControlDirective } from '../../shared/app-field';
+import {
+  AppFormWizardComponent,
+  AppWizardStepComponent,
+  WizardCommitRequest,
+} from '../../shared/app-form-wizard';
+import { applyCommandErrors, clearServerErrors } from '../../shared/form-errors';
+import { ARTIFACT_NAME_MAX_LENGTH } from '../../shared/validation-limits';
+import { CommandResult } from '../../models/command';
+
+/**
+ * JPA entity property name -> form control name, for {@link applyCommandErrors}.
+ *
+ * `CommandController` reports violations using the entity's property names, so `ActorImpl`'s
+ * inherited `text` is the key; `EditActorInput` spells the same field `description`, mapped
+ * here too so the control resolves whichever name arrives. #176 deletes this map.
+ */
+const ACTOR_FIELD_MAP: Record<string, string> = {
+  description: 'text',
+};
+
+/** Joins page-level violations that resolved to no control. */
+const SEPARATOR = '; ';
+
+/** Wording for the stale-version recovery path, so the 409 case reads as recoverable. */
+const STALE_VERSION_MESSAGE =
+  'This actor was changed elsewhere. Your copy has been refreshed - review the values and continue.';
 
 @Component({
   selector: 'app-actor-editor',
   standalone: true,
-  imports: [PageHeaderComponent, AppCardComponent, RouterLink, FormsModule, ButtonModule, InputText, TextareaModule, TableModule,
+  imports: [PageHeaderComponent, AppCardComponent, RouterLink, NgTemplateOutlet, ReactiveFormsModule,
+            ButtonModule, InputText, TextareaModule, TableModule,
             MessageModule, ConfirmDialogModule, EntitySelectorDialogComponent,
-            AnnotationsSectionComponent],
+            AnnotationsSectionComponent, AppFieldComponent, AppFieldControlDirective,
+            AppFormWizardComponent, AppWizardStepComponent],
   providers: [ConfirmationService],
   template: `
     <div class="actor-editor" data-testid="actor-editor">
@@ -73,75 +103,50 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
         <p-message severity="error" [text]="errorMessage()!" data-testid="actor-error" />
       }
 
-      <app-card>
-        <div class="form-grid">
-          <label for="name">Name</label>
-          <input id="name" pInputText [(ngModel)]="name"
-                 placeholder="Actor name" [disabled]="!canEdit()"
-                 (ngModelChange)="trackChanges()" />
-
-          <label for="text">Description</label>
-          <textarea id="text" pTextarea [(ngModel)]="text"
-                    placeholder="Actor description" [rows]="4"
-                    [disabled]="!canEdit()"
-                    (ngModelChange)="trackChanges()"></textarea>
-        </div>
-
-        @if (canEdit()) {
-          <div class="form-actions">
-            <p-button label="{{ isNew() ? 'Create' : 'Save' }}" icon="pi pi-check"
-                      [attr.data-testid]="isNew() ? 'actor-create' : 'actor-save'"
-                      [disabled]="!isNew() && !hasChanges()"
-                      (onClick)="onSave()" />
-          </div>
-        }
-      </app-card>
-
-      @if (!isNew()) {
-        <div class="goals-section">
-          <div class="section-header">
-            <h3>Goals</h3>
-            @if (canEdit()) {
-              <p-button label="Add Goal" icon="pi pi-plus" severity="secondary"
-                        data-testid="actor-add-goal"
-                        [outlined]="true" (onClick)="showGoalSelector = true" />
-            }
-          </div>
-          <p-table [value]="goals()" [rows]="10">
-            <ng-template #header>
-              <tr>
-                <th>Name</th>
-                @if (canEdit()) { <th class="col-actions"></th> }
-              </tr>
+      @if (isNew()) {
+        <!--
+          Create runs as a wizard (#173) so Goals is reachable before the first save. Step 1
+          commits EditActor on Continue, which is what gives step 2 the persisted actorId the
+          goal selector needs.
+        -->
+        <app-form-wizard
+          [(activeKey)]="wizardStep"
+          navLabel="New actor steps"
+          (stepCommit)="onStepCommit($event)"
+          (cancelled)="onBack()"
+          (finished)="onWizardFinished()"
+          data-testid="actor-wizard"
+        >
+          <app-wizard-step key="details" label="Details" helper="Name and description"
+                           [form]="detailsForm">
+            <ng-template>
+              <ng-container [ngTemplateOutlet]="detailsFields" />
             </ng-template>
-            <ng-template #body let-g>
-              <tr data-testid="actor-goal-row">
-                <td>
-                  <a class="entity-link" data-testid="actor-goal-link"
-                     [routerLink]="['/projects', projectName, 'goals', g.id]">{{ g.name }}</a>
-                </td>
-                @if (canEdit()) {
-                  <td>
-                    <p-button icon="pi pi-times" severity="danger" [text]="true"
-                              data-testid="actor-remove-goal" [ariaLabel]="'Remove goal ' + g.name"
-                              [rounded]="true" (onClick)="onRemoveGoal(g)" />
-                  </td>
-                }
-              </tr>
-            </ng-template>
-            <ng-template #emptymessage>
-              <tr><td colspan="2" class="empty-text">No goals associated.</td></tr>
-            </ng-template>
-          </p-table>
-        </div>
+          </app-wizard-step>
 
-        <app-entity-selector-dialog
-          entityType="Goal"
-          [projectName]="projectName"
-          [excludeIds]="goalIds()"
-          [visible]="showGoalSelector"
-          (selected)="onGoalSelected($event)"
-          (closed)="showGoalSelector = false" />
+          <app-wizard-step key="goals" label="Goals" helper="Link goals to this actor"
+                           [optional]="true">
+            <ng-template>
+              <!-- heading: false - the wizard panel's own h2 already reads "Goals". -->
+              <ng-container [ngTemplateOutlet]="goalsSection"
+                            [ngTemplateOutletContext]="{ heading: false }" />
+            </ng-template>
+          </app-wizard-step>
+        </app-form-wizard>
+      } @else {
+        <app-card>
+          <ng-container [ngTemplateOutlet]="detailsFields" />
+
+          @if (canEdit()) {
+            <div class="form-actions">
+              <p-button label="Save" icon="pi pi-check" data-testid="actor-save"
+                        [disabled]="!canSave()" (onClick)="onSave()" />
+            </div>
+          }
+        </app-card>
+
+        <ng-container [ngTemplateOutlet]="goalsSection"
+                      [ngTemplateOutletContext]="{ heading: true }" />
 
         <!-- Referenced By -->
         <div class="goals-section">
@@ -181,18 +186,103 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
       }
     </div>
 
-    <app-annotations-section
+    <app-entity-selector-dialog
+      entityType="Goal"
       [projectName]="projectName"
-      entityType="Actor"
-      [entityId]="actorId"
-      [canEdit]="canEdit()" />
+      [excludeIds]="goalIds()"
+      [visible]="showGoalSelector"
+      (selected)="onGoalSelected($event)"
+      (closed)="showGoalSelector = false" />
+
+    <!--
+      Annotations render against a persisted entity, so they stay outside the wizard and appear
+      once the actor exists rather than as a dead panel during create.
+    -->
+    @if (actorId != null) {
+      <app-annotations-section
+        [projectName]="projectName"
+        entityType="Actor"
+        [entityId]="actorId"
+        [canEdit]="canEdit()" />
+    }
 
     <p-confirmDialog />
+
+    <!--
+      Shared bodies, used by both the wizard step and the edit view so the two cannot drift.
+      Controls bind [formControl], not formControlName: these are projected into the wizard,
+      where formControlName would look for a parent formGroup that is not there.
+    -->
+    <ng-template #detailsFields>
+      <app-field label="Name" [control]="detailsForm.controls.name"
+                 [errorMessages]="nameErrors" [submitted]="submitted()">
+        <input appFieldControl pInputText [formControl]="detailsForm.controls.name"
+               [attr.maxlength]="nameMaxLength"
+               placeholder="Actor name" data-testid="actor-name" />
+      </app-field>
+
+      <app-field label="Description" [control]="detailsForm.controls.text" [divider]="false"
+                 [submitted]="submitted()">
+        <textarea appFieldControl pTextarea [formControl]="detailsForm.controls.text" rows="4"
+                  placeholder="Actor description" data-testid="actor-text"></textarea>
+      </app-field>
+    </ng-template>
+
+    <ng-template #goalsSection let-heading="heading">
+      <div class="goals-section">
+        <div class="section-header">
+          @if (heading) {
+            <h2 class="rq-section-title">Goals</h2>
+          }
+          @if (canEdit() && actorId != null) {
+            <p-button label="Add Goal" icon="pi pi-plus" severity="secondary"
+                      data-testid="actor-add-goal"
+                      [outlined]="true" (onClick)="showGoalSelector = true" />
+          }
+        </div>
+        @if (actorId == null) {
+          <p class="empty-text">Save the actor's details first to add goals.</p>
+        } @else {
+          <p-table [value]="goals()" [rows]="10">
+            <ng-template #header>
+              <tr>
+                <th>Name</th>
+                @if (canEdit()) {
+                  <!--
+                    An actions column still needs a header for screen readers; an empty <th>
+                    is an axe empty-table-header violation. Visually hidden so the column
+                    stays icon-only. Caught by actor-editor.a11y.spec.ts.
+                  -->
+                  <th class="col-actions"><span class="rq-visually-hidden">Actions</span></th>
+                }
+              </tr>
+            </ng-template>
+            <ng-template #body let-g>
+              <tr data-testid="actor-goal-row">
+                <td>
+                  <a class="entity-link" data-testid="actor-goal-link"
+                     [routerLink]="['/projects', projectName, 'goals', g.id]">{{ g.name }}</a>
+                </td>
+                @if (canEdit()) {
+                  <td>
+                    <p-button icon="pi pi-times" severity="danger" [text]="true"
+                              data-testid="actor-remove-goal" [ariaLabel]="'Remove goal ' + g.name"
+                              [rounded]="true" (onClick)="onRemoveGoal(g)" />
+                  </td>
+                }
+              </tr>
+            </ng-template>
+            <ng-template #emptymessage>
+              <tr><td colspan="2" class="empty-text">No goals associated.</td></tr>
+            </ng-template>
+          </p-table>
+        }
+      </div>
+    </ng-template>
   `,
   styles: [`
     .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
     .page-actions { display: flex; gap: 0.5rem; }
-    .form-grid { display: grid; grid-template-columns: 150px 1fr; gap: 0.75rem 1rem; align-items: start; max-width: 700px; }
     .form-actions { margin-top: 1rem; max-width: 700px; }
     .goals-section { margin-top: 2rem; }
     .section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
@@ -215,14 +305,34 @@ export class ActorEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
   referencedByStories = signal<EntityReferenceDto[]>([]);
   showGoalSelector = false;
 
-  name = '';
-  text = '';
+  saving = signal(false);
+  submitted = signal(false);
   version: number | null = null;
   projectName = '';
 
-  private originalName = '';
-  private originalText = '';
-  hasChanges = signal(false);
+  /**
+   * Mirrors the backend `@Size(max = ValidationLimits.ARTIFACT_NAME_MAX)` (#171). Bound with
+   * `[attr.maxlength]` rather than `maxlength`: the latter matches Angular's MaxLengthValidator
+   * directive selector and would register a second validator on top of the form's own.
+   */
+  readonly nameMaxLength = ARTIFACT_NAME_MAX_LENGTH;
+
+  /**
+   * Details step / edit form. Replaces the `name` + `text` ngModel fields and the hand-rolled
+   * `trackChanges()` + `original*` comparison, which the form's own dirty state now covers.
+   */
+  readonly detailsForm = new FormGroup({
+    name: new FormControl('', {
+      validators: [Validators.required, Validators.maxLength(ARTIFACT_NAME_MAX_LENGTH)],
+      nonNullable: true,
+    }),
+    text: new FormControl('', { nonNullable: true }),
+  });
+
+  readonly nameErrors = { required: 'An actor needs a name.' };
+
+  /** Active wizard step key, two-way bound to `app-form-wizard`. */
+  wizardStep = 'details';
 
   actorId: number | null = null;
   private paramSub?: Subscription;
@@ -253,9 +363,12 @@ export class ActorEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
       if (newIsNew) {
         this.isNew.set(true);
         this.actor.set(null);
-        this.name = '';
-        this.text = '';
+        this.actorId = null;
         this.version = null;
+        this.wizardStep = 'details';
+        this.submitted.set(false);
+        this.detailsForm.reset({ name: '', text: '' });
+        this.goals.set([]);
       }
 
       await this.permissionService.loadForProject(this.projectName);
@@ -271,7 +384,7 @@ export class ActorEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
   }
 
   hasUnsavedChanges(): boolean {
-    return this.hasChanges();
+    return this.detailsForm.dirty;
   }
 
   ngOnDestroy(): void {
@@ -286,20 +399,20 @@ export class ActorEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
     try {
       const a = await this.actorService.getActor(this.projectName, this.actorId!);
       // Don't overwrite unsaved user edits when called from an SSE notification.
-      if (fromSSE && this.hasChanges()) {
+      if (fromSSE && this.hasUnsavedChanges()) {
+        // Still take the new version: the entity moved on, and holding the stale one
+        // guarantees a 409 on the user's next save.
+        this.version = a.version;
+        this.actor.set(a);
         return;
       }
       this.actor.set(a);
       this.actorName.set(a.name);
-      this.name = a.name;
-      this.text = a.text ?? '';
+      this.detailsForm.reset({ name: a.name, text: a.text ?? '' });
       this.version = a.version;
       this.goals.set(a.goals ?? []);
       this.referencedByUseCases.set(a.referencedByUseCases ?? []);
       this.referencedByStories.set(a.referencedByStories ?? []);
-      this.originalName = a.name;
-      this.originalText = a.text ?? '';
-      this.hasChanges.set(false);
     } catch {
       this.errorMessage.set('Failed to load actor.');
     }
@@ -313,39 +426,170 @@ export class ActorEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
     }
   }
 
-  trackChanges(): void {
-    this.hasChanges.set(this.name !== this.originalName || this.text !== this.originalText);
+  /**
+   * Re-reads the actor's optimistic-lock version after a goal association changes.
+   *
+   * `AddGoalToGoalContainerCommandImpl` / `RemoveGoalFromGoalContainerCommandImpl` end by
+   * merging the container - which IS this actor - so every add or remove bumps its
+   * `@Version`. The client cannot read the new value from the response: both commands are
+   * registered through the 4-arg `CommandRegistry.register` overload, which leaves
+   * `resultExtractor` null, so `ApiCommandFactory.extractResult` returns null and
+   * `result.entity` is empty. A refetch is the only way to see it.
+   *
+   * Without this, adding a goal and then saving the name fails with a 409 the user did
+   * nothing to deserve. Pre-existing bug; #173's wizard makes it reachable in the create
+   * flow too, which is what surfaced it.
+   *
+   * Deliberately narrow — it takes `version` and nothing else. A full `loadActor()` here
+   * would overwrite whatever the user had typed into Name or Description before touching
+   * the Goals table.
+   */
+  private async refreshVersionAfterAssociation(): Promise<void> {
+    if (this.actorId == null) {
+      return;
+    }
+    try {
+      const a = await this.actorService.getActor(this.projectName, this.actorId);
+      this.version = a.version;
+    } catch {
+      // Leave the held version as-is: a failed refresh is not worth blocking the user, and
+      // the next save reports the 409 with the existing recovery path.
+    }
   }
 
-  async onSave(): Promise<void> {
-    this.errorMessage.set(null);
-    try {
-      const result = await this.commandService.execute('EditActor', {
-        projectName: this.projectName,
-        actorId: this.isNew() ? null : this.actorId,
-        name: this.name,
-        description: this.text || null,
-        version: this.version
-      });
-      if (result.success) {
-        if (this.isNew()) {
-          this.projectService.notifyTreeChanged();
-          this.hasChanges.set(false);
-          this.router.navigate(['/projects', this.projectName, 'actors', (result.entity as ActorDto).id]);
-        } else {
-          this.actorName.set(this.name);
-          this.version = (result.entity as ActorDto).version;
-          this.originalName = this.name;
-          this.originalText = this.text;
-          this.hasChanges.set(false);
-          this.messageService.add({ severity: 'success', summary: 'Saved', detail: 'Actor saved.' });
-        }
-      } else {
-        this.errorMessage.set(result.error ?? 'Save failed.');
-      }
-    } catch {
-      this.errorMessage.set('Save failed.');
+
+  /** Edit-mode Save: blocked on invalid, unchanged, or in-flight. */
+  canSave(): boolean {
+    return this.detailsForm.valid && this.detailsForm.dirty && !this.saving();
+  }
+
+  /**
+   * Runs the commit for the wizard's current step.
+   *
+   * Only Details talks to the API. The Goals step's associations commit through the selector
+   * as the user works, so its Continue just advances.
+   */
+  async onStepCommit(request: WizardCommitRequest): Promise<void> {
+    if (request.step.key !== 'details') {
+      request.complete();
+      return;
     }
+
+    this.submitted.set(true);
+    const result = await this.saveDetails();
+
+    if (result.success) {
+      request.complete();
+      return;
+    }
+    if (await this.recoverFromStaleVersion(result)) {
+      request.fail(STALE_VERSION_MESSAGE);
+      return;
+    }
+    request.fail(result.error ?? 'Save failed.');
+  }
+
+  /** Done on the last step: the actor is already saved, so just go to it. */
+  onWizardFinished(): void {
+    if (this.actorId != null) {
+      this.router.navigate(['/projects', this.projectName, 'actors', this.actorId]);
+    } else {
+      this.onBack();
+    }
+  }
+
+  /**
+   * Issues `EditActor` and, on success, adopts the id and version from the response.
+   *
+   * The version is spent on use: every accepted `EditActor` bumps it server-side, so it is
+   * re-read from `result.entity` each time. Note the DTO spells the description field
+   * `description` while the entity property is `text` - hence ACTOR_FIELD_MAP.
+   */
+  private async saveDetails(): Promise<CommandResult<unknown>> {
+    this.saving.set(true);
+    this.errorMessage.set(null);
+    clearServerErrors(this.detailsForm);
+    try {
+      const { name, text } = this.detailsForm.getRawValue();
+      const input: Record<string, unknown> = {
+        projectName: this.projectName,
+        actorId: this.actorId,
+        name,
+        description: text || null,
+      };
+      if (this.version != null) input['version'] = this.version;
+
+      const result = await this.commandService.execute('EditActor', input);
+      if (!result.success) {
+        const unresolved = applyCommandErrors(this.detailsForm, result.violations, ACTOR_FIELD_MAP);
+        if (unresolved.length) {
+          this.errorMessage.set(unresolved.join(SEPARATOR));
+        }
+        return result;
+      }
+
+      const wasCreate = this.actorId == null;
+      if (wasCreate) {
+        this.projectService.notifyTreeChanged();
+      }
+
+      const saved = result.entity as ActorDto | null;
+      if (saved) {
+        this.actorId = saved.id;
+        this.version = saved.version;
+        this.actorName.set(saved.name);
+      }
+      this.detailsForm.markAsPristine();
+      this.messageService.add({ severity: 'success', summary: 'Saved', detail: 'Actor saved.' });
+
+      // Hydrate goals / referencedBy and start the SSE subscription the first time the actor
+      // exists, so step 2 has something to render.
+      if (wasCreate && this.actorId != null) {
+        await this.loadActor();
+      }
+      return result;
+    } catch {
+      return {
+        success: false,
+        entityType: 'Actor',
+        entity: null,
+        error: 'Save failed.',
+        violations: null,
+      };
+    } finally {
+      this.saving.set(false);
+    }
+  }
+
+  /**
+   * If `result` is an optimistic-lock conflict (HTTP 409), refetch so the held version is
+   * current and the user can retry. Returns whether it handled the result.
+   */
+  private async recoverFromStaleVersion(result: CommandResult<unknown>): Promise<boolean> {
+    if (result.status !== 409 || this.actorId == null) {
+      return false;
+    }
+    await this.loadActor();
+    return true;
+  }
+
+  /** Edit-mode Save. */
+  async onSave(): Promise<void> {
+    this.submitted.set(true);
+    if (this.detailsForm.invalid) {
+      this.detailsForm.markAllAsTouched();
+      return;
+    }
+
+    const result = await this.saveDetails();
+    if (result.success) {
+      return;
+    }
+    if (await this.recoverFromStaleVersion(result)) {
+      this.errorMessage.set(STALE_VERSION_MESSAGE);
+      return;
+    }
+    this.errorMessage.set(result.error ?? 'Save failed.');
   }
 
   onCopy(): void {
@@ -378,6 +622,8 @@ export class ActorEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
         });
         if (result.success) {
           this.projectService.notifyTreeChanged();
+          // Nothing left to guard against - don't let the dirty check block the exit.
+          this.detailsForm.markAsPristine();
           this.router.navigate(['/projects', this.projectName, 'actors']);
         } else {
           this.errorMessage.set(result.error ?? 'Delete failed.');
@@ -397,6 +643,7 @@ export class ActorEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
       });
       if (result.success) {
         this.goals.update(list => [...list, goal].sort((a, b) => a.name.localeCompare(b.name)));
+        await this.refreshVersionAfterAssociation();
         this.messageService.add({ severity: 'success', summary: 'Goal added', detail: `"${goal.name}" added successfully.` });
       } else {
         this.errorMessage.set(result.error ?? 'Failed to add goal.');
@@ -416,6 +663,7 @@ export class ActorEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
       });
       if (result.success) {
         this.goals.update(list => list.filter(g => g.id !== goal.id));
+        await this.refreshVersionAfterAssociation();
         this.messageService.add({ severity: 'info', summary: 'Goal removed', detail: `"${goal.name}" removed.` });
       } else {
         this.errorMessage.set(result.error ?? 'Failed to remove goal.');

--- a/requel-angular/src/app/features/projects/project-editor.a11y.spec.ts
+++ b/requel-angular/src/app/features/projects/project-editor.a11y.spec.ts
@@ -1,0 +1,114 @@
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter, Router, ActivatedRoute, convertToParamMap } from '@angular/router';
+import { BehaviorSubject } from 'rxjs';
+import { ConfirmationService, MessageService } from 'primeng/api';
+import { ProjectEditorComponent } from './project-editor';
+import { ProjectService } from '../../core/project.service';
+import { UserService } from '../../core/user.service';
+import { CommandService } from '../../core/command.service';
+import { PermissionService } from '../../core/permission.service';
+import { TagService } from '../../core/tag.service';
+import { expectNoAxeViolations } from '../../shared/testing/a11y';
+
+const flush = () => new Promise(r => setTimeout(r, 0));
+
+const CREATED = {
+  id: 9, version: 1, name: 'My New Project', description: null, organizationName: null,
+};
+
+// #173: create is a wizard now, so the create surface needs its own axe pass - including with a
+// field in the error state, where label/message association problems actually show up.
+describe('ProjectEditorComponent - create wizard accessibility', () => {
+  let paramMap$: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fixture: any;
+  let comp: ProjectEditorComponent;
+
+  beforeEach(() => {
+    paramMap$ = new BehaviorSubject(convertToParamMap({ name: 'new' }));
+
+    TestBed.configureTestingModule({
+      imports: [ProjectEditorComponent],
+      providers: [
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: ActivatedRoute, useValue: { paramMap: paramMap$.asObservable() } },
+        { provide: ProjectService, useValue: {
+            getProject: vi.fn().mockResolvedValue(CREATED),
+            downloadProjectXml: vi.fn(),
+            notifyTreeChanged: vi.fn(),
+          } },
+        { provide: UserService, useValue: {
+            listOrganizations: vi.fn().mockResolvedValue([{ id: 1, version: 0, name: 'Acme' }]),
+          } },
+        { provide: CommandService, useValue: {
+            execute: vi.fn().mockResolvedValue({ success: true, entity: CREATED }),
+          } },
+        { provide: PermissionService, useValue: {
+            loadForProject: vi.fn().mockResolvedValue(undefined),
+            canEdit: vi.fn().mockReturnValue(true),
+          } },
+        { provide: TagService, useValue: {
+            listTagsForEntity: vi.fn().mockResolvedValue([]),
+            listTagCategories: vi.fn().mockResolvedValue([]),
+          } },
+        { provide: ConfirmationService, useValue: { confirm: vi.fn() } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
+    });
+    fixture = TestBed.createComponent(ProjectEditorComponent);
+    comp = fixture.componentInstance;
+    vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  async function settle(): Promise<void> {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  async function renderWizard(): Promise<HTMLElement> {
+    fixture.detectChanges();
+    await flush();
+    await settle();
+    const wizard = fixture.nativeElement.querySelector('[data-testid="project-wizard"]');
+    expect(wizard).not.toBeNull();
+    return wizard as HTMLElement;
+  }
+
+  it('renders the wizard with the step nav labelled and Details current', async () => {
+    const wizard = await renderWizard();
+    expect(wizard.querySelector('nav')!.getAttribute('aria-label')).toBe('New project steps');
+    expect(wizard.querySelector('[aria-current="step"]')!.textContent).toContain('Details');
+  });
+
+  it('has no axe-core violations on the Details step', async () => {
+    await expectNoAxeViolations(await renderWizard());
+  });
+
+  it('has no axe-core violations with the name field in the error state', async () => {
+    const wizard = await renderWizard();
+    comp.submitted.set(true);
+    comp.detailsForm.controls.name.setValue('');
+    comp.detailsForm.markAllAsTouched();
+    await settle();
+    expect(wizard.textContent).toContain('A project needs a name.');
+    await expectNoAxeViolations(wizard);
+  });
+
+  it('has no axe-core violations on the Tags step', async () => {
+    const wizard = await renderWizard();
+    comp.detailsForm.controls.name.setValue('My New Project');
+    await settle();
+    (wizard.querySelector('[data-testid="wizard-continue"] button') as HTMLButtonElement).click();
+    await flush();
+    await settle();
+    expect(comp.wizardStep).toBe('tags');
+    await expectNoAxeViolations(wizard);
+  });
+});

--- a/requel-angular/src/app/features/projects/project-editor.a11y.spec.ts
+++ b/requel-angular/src/app/features/projects/project-editor.a11y.spec.ts
@@ -111,4 +111,19 @@ describe('ProjectEditorComponent - create wizard accessibility', () => {
     expect(comp.wizardStep).toBe('tags');
     await expectNoAxeViolations(wizard);
   });
+
+  // Regression guard for the e2e contract. ProjectsPage addresses these by DOM id -
+  // locator('#name'), locator('#description'). The #173 conversion dropped the ids and let
+  // app-field generate them, which broke 23 e2e tests while every unit test stayed green.
+  it('keeps the stable control ids the e2e page objects address', async () => {
+    const wizard = await renderWizard();
+    for (const [id, tag] of [['name', 'INPUT'], ['description', 'TEXTAREA']] as const) {
+      const el = wizard.querySelector(`#${id}`);
+      expect(el, `missing #${id} - e2e page objects locate this control by id`).not.toBeNull();
+      expect(el!.tagName).toBe(tag);
+      // The label must point at that same id, or the id is present but unassociated.
+      expect(wizard.querySelector(`label[for="${id}"]`), `no <label for="${id}">`).not.toBeNull();
+    }
+  });
+
 });

--- a/requel-angular/src/app/features/projects/project-editor.spec.ts
+++ b/requel-angular/src/app/features/projects/project-editor.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { provideRouter, ActivatedRoute, convertToParamMap } from '@angular/router';
+import { provideRouter, Router, ActivatedRoute, convertToParamMap } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ProjectEditorComponent } from './project-editor';
@@ -32,6 +32,7 @@ describe('ProjectEditorComponent', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let fixture: any;
   let comp: ProjectEditorComponent;
+  let router: Router;
 
   beforeEach(() => {
     paramMap$ = new BehaviorSubject(convertToParamMap({ name: 'new' }));
@@ -71,6 +72,7 @@ describe('ProjectEditorComponent', () => {
     });
     fixture = TestBed.createComponent(ProjectEditorComponent);
     comp = fixture.componentInstance;
+    router = TestBed.inject(Router);
   });
 
   it('isNew() is true when name param is "new"', async () => {
@@ -97,16 +99,79 @@ describe('ProjectEditorComponent', () => {
   it('onSave calls commandService.execute("EditProject") with name', async () => {
     fixture.detectChanges();
     await flush();
-    comp.name = 'My New Project';
+    comp.detailsForm.controls.name.setValue('My New Project');
+    comp.detailsForm.markAsDirty();
     await comp.onSave();
     expect(commandServiceMock.execute).toHaveBeenCalledWith('EditProject', expect.objectContaining({
       name: 'My New Project'
     }));
   });
 
+  // #173: create is a wizard. Project is the one editor whose second step needs no version
+  // handling - AssignTag mutates the Tag, not the project - so the contract to pin here is that
+  // step 1 captures the id WITHOUT navigating. The old code routed away on save, which both hid
+  // Tags and destroyed the wizard, since the route param is the project's identity.
+  describe('create wizard (#173)', () => {
+    it('step 1 captures the project without navigating away', async () => {
+      fixture.detectChanges();
+      await flush();
+      const navigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+      navigate.mockClear();
+
+      commandServiceMock.execute.mockResolvedValue({
+        success: true,
+        entity: { id: 9, version: 1, name: 'My New Project', description: null, organizationName: null }
+      });
+      comp.detailsForm.controls.name.setValue('My New Project');
+
+      const request = { step: { key: 'details' }, complete: vi.fn(), fail: vi.fn() };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await comp.onStepCommit(request as any);
+
+      expect(request.complete).toHaveBeenCalled();
+      expect(navigate).not.toHaveBeenCalled();
+      // Tags can only render once the project exists.
+      expect(comp.tagEntityId()).toBe(9);
+      expect(comp.originalName()).toBe('My New Project');
+    });
+
+    it('the Tags step just advances - it issues no command of its own', async () => {
+      fixture.detectChanges();
+      await flush();
+      commandServiceMock.execute.mockClear();
+
+      const request = { step: { key: 'tags' }, complete: vi.fn(), fail: vi.fn() };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await comp.onStepCommit(request as any);
+
+      expect(request.complete).toHaveBeenCalled();
+      expect(commandServiceMock.execute).not.toHaveBeenCalled();
+    });
+
+    it('Done navigates to the created project', async () => {
+      fixture.detectChanges();
+      await flush();
+      const navigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+      commandServiceMock.execute.mockResolvedValue({
+        success: true,
+        entity: { id: 9, version: 1, name: 'My New Project', description: null, organizationName: null }
+      });
+      comp.detailsForm.controls.name.setValue('My New Project');
+      const request = { step: { key: 'details' }, complete: vi.fn(), fail: vi.fn() };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await comp.onStepCommit(request as any);
+
+      navigate.mockClear();
+      comp.onWizardFinished();
+      expect(navigate).toHaveBeenCalledWith(['/projects', 'My New Project']);
+    });
+  });
+
   it('onSave sets errorMessage when command returns error', async () => {
     commandServiceMock.execute.mockResolvedValue({ success: false, error: 'Duplicate name' });
-    comp.name = 'Taken';
+    comp.detailsForm.controls.name.setValue('Taken');
+    comp.detailsForm.markAsDirty();
     await comp.onSave();
     expect(comp.errorMessage()).toBe('Duplicate name');
     expect(comp.saving()).toBe(false);

--- a/requel-angular/src/app/features/projects/project-editor.ts
+++ b/requel-angular/src/app/features/projects/project-editor.ts
@@ -153,9 +153,9 @@ const SEPARATOR = '; ';
         where formControlName would look for a parent formGroup that is not there.
       -->
       <ng-template #detailsFields>
-        <app-field label="Project Name" [control]="detailsForm.controls.name"
+        <app-field label="Project Name" controlId="name" [control]="detailsForm.controls.name"
                    [errorMessages]="nameErrors" [submitted]="submitted()">
-          <input appFieldControl pInputText [formControl]="detailsForm.controls.name"
+          <input appFieldControl pInputText [formControl]="detailsForm.controls.name" id="name"
                  [attr.maxlength]="nameMaxLength"
                  placeholder="Project name" data-testid="project-name" />
         </app-field>
@@ -168,9 +168,9 @@ const SEPARATOR = '; ';
                     [editable]="true" placeholder="Select or type organization" />
         </app-field>
 
-        <app-field label="Description" [control]="detailsForm.controls.description"
+        <app-field label="Description" controlId="description" [control]="detailsForm.controls.description"
                    [divider]="false" [submitted]="submitted()">
-          <textarea appFieldControl pTextarea [formControl]="detailsForm.controls.description"
+          <textarea appFieldControl pTextarea [formControl]="detailsForm.controls.description" id="description"
                     [rows]="5" [autoResize]="true" data-testid="project-description"></textarea>
         </app-field>
       </ng-template>

--- a/requel-angular/src/app/features/projects/project-editor.ts
+++ b/requel-angular/src/app/features/projects/project-editor.ts
@@ -18,11 +18,12 @@
  * along with Requel. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import { Component, OnInit, OnDestroy, signal, computed, ViewChild } from '@angular/core';
+import { Component, OnInit, OnDestroy, signal, computed } from '@angular/core';
 import { PageHeaderComponent } from '../../shared/page-header';
 import { AppCardComponent } from '../../shared/app-card';
 import { ActivatedRoute, Router } from '@angular/router';
-import { FormsModule, NgForm } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { NgTemplateOutlet } from '@angular/common';
 import { InputText } from 'primeng/inputtext';
 import { TextareaModule } from 'primeng/textarea';
 import { ButtonModule } from 'primeng/button';
@@ -41,11 +42,39 @@ import { PermissionService } from '../../core/permission.service';
 import { TagSelectorComponent } from '../../shared/tag-selector';
 import { LoadingStateComponent } from '../../shared/loading-state';
 import { ErrorStateComponent } from '../../shared/error-state';
+import { AppFieldComponent, AppFieldControlDirective } from '../../shared/app-field';
+import {
+  AppFormWizardComponent,
+  AppWizardStepComponent,
+  WizardCommitRequest,
+} from '../../shared/app-form-wizard';
+import { applyCommandErrors, clearServerErrors } from '../../shared/form-errors';
+import { ARTIFACT_NAME_MAX_LENGTH } from '../../shared/validation-limits';
+import { CommandResult } from '../../models/command';
+
+/**
+ * JPA entity property name -> form control name, for {@link applyCommandErrors}.
+ *
+ * `EditProjectInput` carries the organization as either `organizationId` or
+ * `organizationName` depending on whether the user picked an existing org or typed a new one;
+ * both resolve to the single `organization` control. #176 deletes this map.
+ */
+const PROJECT_FIELD_MAP: Record<string, string> = {
+  organizationId: 'organization',
+  organizationName: 'organization',
+};
+
+/** Joins page-level violations that resolved to no control. */
+const SEPARATOR = '; ';
 
 @Component({
   selector: 'app-project-editor',
   standalone: true,
-  imports: [PageHeaderComponent, AppCardComponent, FormsModule, InputText, TextareaModule, ButtonModule, SelectModule, MessageModule, ConfirmDialogModule, TagSelectorComponent, LoadingStateComponent, ErrorStateComponent],
+  imports: [PageHeaderComponent, AppCardComponent, NgTemplateOutlet, ReactiveFormsModule,
+            InputText, TextareaModule, ButtonModule, SelectModule, MessageModule,
+            ConfirmDialogModule, TagSelectorComponent, LoadingStateComponent, ErrorStateComponent,
+            AppFieldComponent, AppFieldControlDirective,
+            AppFormWizardComponent, AppWizardStepComponent],
   providers: [ConfirmationService],
   template: `
     <div class="project-editor" data-testid="project-editor">
@@ -74,46 +103,89 @@ import { ErrorStateComponent } from '../../shared/error-state';
       } @else if (loadError()) {
         <app-error-state [message]="loadError()!" testid="project-editor-load-error"
                          (retry)="retryLoad()" />
+      } @else if (isNew()) {
+        <!--
+          Create runs as a wizard (#173) so Tags is reachable before the first save. Project is
+          the odd one of the five: it is not created inside an existing project, so step 2 has
+          no parent context to inherit - the tag selector keys off the project this wizard is
+          in the middle of creating, which is why it cannot render until step 1 commits.
+        -->
+        <app-form-wizard
+          [(activeKey)]="wizardStep"
+          navLabel="New project steps"
+          (stepCommit)="onStepCommit($event)"
+          (cancelled)="onCancel()"
+          (finished)="onWizardFinished()"
+          data-testid="project-wizard"
+        >
+          <app-wizard-step key="details" label="Details" helper="Name, organization, description"
+                           [form]="detailsForm">
+            <ng-template>
+              <ng-container [ngTemplateOutlet]="detailsFields" />
+            </ng-template>
+          </app-wizard-step>
+
+          <app-wizard-step key="tags" label="Tags" helper="Categorise this project"
+                           [optional]="true">
+            <ng-template>
+              <ng-container [ngTemplateOutlet]="tagsSection" />
+            </ng-template>
+          </app-wizard-step>
+        </app-form-wizard>
       } @else {
         <app-card>
-          <form #projectForm="ngForm" (ngSubmit)="onSave()">
-            <div class="form-grid">
-              <div class="field">
-                <label for="name">Project Name</label>
-                <input pInputText id="name" [(ngModel)]="name" name="name" required />
-              </div>
+          <ng-container [ngTemplateOutlet]="detailsFields" />
 
-              <div class="field">
-                <label for="org">Organization</label>
-                <p-select id="org" [(ngModel)]="selectedOrg" name="org"
-                          [options]="orgOptions()" optionLabel="label" optionValue="value"
-                          [editable]="true" placeholder="Select or type organization" />
-              </div>
-
-              <div class="field full-width">
-                <label for="description">Description</label>
-                <textarea pTextarea id="description" [(ngModel)]="description" name="description"
-                          [rows]="5" [autoResize]="true"></textarea>
-              </div>
-            </div>
-
-            <div class="actions">
-              <p-button type="submit" label="Save" icon="pi pi-check" data-testid="project-save"
-                        [loading]="saving()" [disabled]="!projectForm.dirty" />
-              <p-button label="Cancel" icon="pi pi-times" severity="secondary" data-testid="project-cancel"
-                        (onClick)="onCancel()" [outlined]="true" />
-            </div>
-          </form>
+          <div class="actions">
+            <p-button label="Save" icon="pi pi-check" data-testid="project-save"
+                      [loading]="saving()" [disabled]="!canSave()" (onClick)="onSave()" />
+            <p-button label="Cancel" icon="pi pi-times" severity="secondary" data-testid="project-cancel"
+                      (onClick)="onCancel()" [outlined]="true" />
+          </div>
         </app-card>
 
-        @if (!isNew()) {
+        <ng-container [ngTemplateOutlet]="tagsSection" />
+      }
+
+      <!--
+        Shared bodies, used by both the wizard step and the edit view so the two cannot drift.
+        Controls bind [formControl], not formControlName: these are projected into the wizard,
+        where formControlName would look for a parent formGroup that is not there.
+      -->
+      <ng-template #detailsFields>
+        <app-field label="Project Name" [control]="detailsForm.controls.name"
+                   [errorMessages]="nameErrors" [submitted]="submitted()">
+          <input appFieldControl pInputText [formControl]="detailsForm.controls.name"
+                 [attr.maxlength]="nameMaxLength"
+                 placeholder="Project name" data-testid="project-name" />
+        </app-field>
+
+        <app-field label="Organization" controlId="projectOrgInput"
+                   [control]="detailsForm.controls.organization" [submitted]="submitted()">
+          <p-select appFieldControl inputId="projectOrgInput" data-testid="project-org"
+                    [formControl]="detailsForm.controls.organization"
+                    [options]="orgOptions()" optionLabel="label" optionValue="value"
+                    [editable]="true" placeholder="Select or type organization" />
+        </app-field>
+
+        <app-field label="Description" [control]="detailsForm.controls.description"
+                   [divider]="false" [submitted]="submitted()">
+          <textarea appFieldControl pTextarea [formControl]="detailsForm.controls.description"
+                    [rows]="5" [autoResize]="true" data-testid="project-description"></textarea>
+        </app-field>
+      </ng-template>
+
+      <ng-template #tagsSection>
+        @if (tagEntityId() != null) {
           <app-tag-selector
             [projectName]="originalName()"
             entityType="Project"
             [entityId]="tagEntityId()"
             [canEdit]="canEdit()" />
+        } @else {
+          <p class="empty-text">Save the project's details first to add tags.</p>
         }
-      }
+      </ng-template>
     </div>
 
     <p-confirmDialog />
@@ -121,19 +193,14 @@ import { ErrorStateComponent } from '../../shared/error-state';
   styles: [`
     .project-editor { max-width: 800px; }
     .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
-    .form-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1.5rem; }
-    .field { display: flex; flex-direction: column; gap: 0.5rem; }
-    .field label { font-weight: 500; }
-    .field input, .field p-select, .field textarea { width: 100%; }
-    .full-width { grid-column: 1 / -1; }
+    .empty-text { color: var(--p-text-muted-color); font-style: italic; }
     .actions { display: flex; gap: 0.5rem; }
   `]
 })
 export class ProjectEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
 
-  @ViewChild('projectForm') projectForm!: NgForm;
-
   readonly isNew = signal(true);
+  readonly submitted = signal(false);
   readonly canEdit = signal(false);
   readonly tagEntityId = signal<number | null>(null);
   readonly loading = signal(true);
@@ -148,10 +215,31 @@ export class ProjectEditorComponent implements OnInit, OnDestroy, DirtyCheckable
   private projectVersion: number | null = null;
   private lastNameParam: string | null = null;
 
-  // Form fields
-  name = '';
-  description = '';
-  selectedOrg: OrganizationDto | string | null = null;
+  /** Mirrors the backend `@Size(max = ValidationLimits.ARTIFACT_NAME_MAX)` (#171). */
+  readonly nameMaxLength = ARTIFACT_NAME_MAX_LENGTH;
+
+  /**
+   * Details step / edit form. Replaces the template-driven `NgForm` and its three `ngModel`
+   * bindings, which is also what retires the `setTimeout(() => markAsPristine())` after load -
+   * `reset()`/`patchValue()` settle synchronously.
+   *
+   * `organization` holds either an `OrganizationDto` (picked from the list) or a raw string
+   * (typed into the editable select). `onSave` splits those into `organizationId` /
+   * `organizationName`, which is why one control backs two DTO fields in PROJECT_FIELD_MAP.
+   */
+  readonly detailsForm = new FormGroup({
+    name: new FormControl('', {
+      validators: [Validators.required, Validators.maxLength(ARTIFACT_NAME_MAX_LENGTH)],
+      nonNullable: true,
+    }),
+    organization: new FormControl<OrganizationDto | string | null>(null),
+    description: new FormControl('', { nonNullable: true }),
+  });
+
+  readonly nameErrors = { required: 'A project needs a name.' };
+
+  /** Active wizard step key, two-way bound to `app-form-wizard`. */
+  wizardStep = 'details';
 
   // Organization dropdown
   readonly organizations = signal<OrganizationDto[]>([]);
@@ -183,7 +271,7 @@ export class ProjectEditorComponent implements OnInit, OnDestroy, DirtyCheckable
       const newIsNew = nameParam === 'new' || !nameParam;
 
       // If form is dirty, confirm before switching
-      if (this.projectForm?.dirty && !newIsNew) {
+      if (this.detailsForm.dirty && !newIsNew) {
         this.pendingNavName = nameParam;
         this.confirmationService.confirm({
           message: 'You have unsaved changes. Save before switching?',
@@ -206,7 +294,12 @@ export class ProjectEditorComponent implements OnInit, OnDestroy, DirtyCheckable
   }
 
   hasUnsavedChanges(): boolean {
-    return this.projectForm?.dirty ?? false;
+    return this.detailsForm.dirty;
+  }
+
+  /** Edit-mode Save: blocked on invalid, unchanged, or in-flight. */
+  canSave(): boolean {
+    return this.detailsForm.valid && this.detailsForm.dirty && !this.saving();
   }
 
   ngOnDestroy(): void {
@@ -238,10 +331,11 @@ export class ProjectEditorComponent implements OnInit, OnDestroy, DirtyCheckable
       } else {
         this.projectId = null;
         this.projectVersion = null;
+        this.tagEntityId.set(null);
         this.originalName.set('');
-        this.name = '';
-        this.description = '';
-        this.selectedOrg = null;
+        this.wizardStep = 'details';
+        this.submitted.set(false);
+        this.detailsForm.reset({ name: '', organization: null, description: '' });
       }
     } catch (err: unknown) {
       // Previously uncaught: a failed load left a blank form with no feedback.
@@ -249,52 +343,131 @@ export class ProjectEditorComponent implements OnInit, OnDestroy, DirtyCheckable
       this.loadError.set(err instanceof Error ? err.message : 'Failed to load project.');
     } finally {
       this.loading.set(false);
-      // Reset form dirty state after load
-      setTimeout(() => this.projectForm?.form.markAsPristine());
     }
   }
 
-  async onSave(): Promise<void> {
+  /**
+   * Runs the commit for the wizard's current step. Only Details talks to the API - the Tags
+   * step commits through `app-tag-selector` as the user works, and `AssignTag` mutates the Tag
+   * rather than the project, so it does not spend the project's version (verified in #158 and
+   * re-confirmed in doc/173-create-flow-wizards-plan.md §2). Project is the one wizard of the
+   * five whose second step needs no version handling at all.
+   */
+  async onStepCommit(request: WizardCommitRequest): Promise<void> {
+    if (request.step.key !== 'details') {
+      request.complete();
+      return;
+    }
+
+    this.submitted.set(true);
+    const result = await this.saveDetails();
+    if (result.success) {
+      request.complete();
+      return;
+    }
+    request.fail(result.error ?? 'Save failed.');
+  }
+
+  /** Done on the last step: the project exists, so route to it by its saved name. */
+  onWizardFinished(): void {
+    const name = this.originalName();
+    if (name) {
+      void this.router.navigate(['/projects', name]);
+    } else {
+      this.onCancel();
+    }
+  }
+
+  /**
+   * Issues `EditProject` and, on success, adopts id/version/name.
+   *
+   * Deliberately does NOT navigate. The old create path routed to `/projects/{name}` the moment
+   * the project saved, which is what made Tags unreachable without a second visit - and here it
+   * also destroyed the wizard, since the route param is the project identity. The wizard keeps
+   * the component alive and lets `onWizardFinished` do the navigating.
+   */
+  private async saveDetails(): Promise<CommandResult<unknown>> {
     this.saving.set(true);
     this.errorMessage.set(null);
     this.successMessage.set(null);
+    clearServerErrors(this.detailsForm);
 
     try {
-      // Resolve organization: object = existing org by id, string = new org by name
-      const orgId = typeof this.selectedOrg === 'object' && this.selectedOrg ? this.selectedOrg.id : null;
-      const orgName = typeof this.selectedOrg === 'string' && this.selectedOrg ? this.selectedOrg : null;
+      const { name, organization, description } = this.detailsForm.getRawValue();
+      // Resolve organization: object = existing org by id, string = new org by name.
+      const orgId = typeof organization === 'object' && organization ? organization.id : null;
+      const orgName = typeof organization === 'string' && organization ? organization : null;
 
       const input: Record<string, unknown> = {
         id: this.projectId,
         version: this.projectVersion,
         projectName: this.isNew() ? null : this.originalName(),
-        name: this.name,
-        description: this.description || null,
+        name,
+        description: description || null,
         organizationId: orgId,
-        organizationName: orgName
+        organizationName: orgName,
       };
 
       const result = await this.commandService.execute('EditProject', input);
-      if (result.success) {
-        this.successMessage.set('Project saved successfully.');
-        this.projectForm?.form.markAsPristine();
-        if (this.isNew()) {
-          await this.router.navigate(['/projects', this.name]);
-        } else {
-          if (this.name !== this.originalName() && !this.switchingProject) {
-            await this.router.navigate(['/projects', this.name]);
-          }
-          this.originalName.set(this.name);
-        }
-      } else if (result.violations?.length) {
-        this.errorMessage.set(result.violations.map(v => v.message).join('; '));
-      } else {
-        this.errorMessage.set(result.error ?? 'Save failed.');
+      if (!result.success) {
+        const unresolved = applyCommandErrors(this.detailsForm, result.violations, PROJECT_FIELD_MAP);
+        this.errorMessage.set(
+          unresolved.length ? unresolved.join(SEPARATOR) : (result.error ?? 'Save failed.')
+        );
+        return result;
       }
+
+      this.successMessage.set('Project saved successfully.');
+      const saved = result.entity as ProjectDto | null;
+      if (saved) {
+        this.projectId = saved.id;
+        this.projectVersion = saved.version;
+        this.tagEntityId.set(saved.id);
+      }
+      this.originalName.set(name);
+      this.detailsForm.markAsPristine();
+      return result;
     } catch (err: unknown) {
-      this.errorMessage.set(err instanceof Error ? err.message : 'Save failed.');
+      return {
+        success: false,
+        entityType: 'Project',
+        entity: null,
+        error: err instanceof Error ? err.message : 'Save failed.',
+        violations: null,
+      };
     } finally {
       this.saving.set(false);
+    }
+  }
+
+  /**
+   * Edit-mode Save. Renaming changes the route identity, so a successful rename navigates -
+   * except while `saveAndSwitch` is driving, which is about to navigate somewhere else anyway.
+   */
+  async onSave(): Promise<void> {
+    this.submitted.set(true);
+    if (this.detailsForm.invalid) {
+      this.detailsForm.markAllAsTouched();
+      return;
+    }
+
+    const previousName = this.originalName();
+    const result = await this.saveDetails();
+    if (!result.success) {
+      return;
+    }
+    const name = this.detailsForm.controls.name.value;
+    if (name !== previousName && !this.switchingProject) {
+      try {
+        await this.router.navigate(['/projects', name]);
+      } catch (err: unknown) {
+        // The save succeeded; only the route change failed. Report it rather than rejecting
+        // out of onSave - the original code had this navigation inside its try/catch and
+        // relied on that, so letting it escape would be a behaviour change.
+        this.errorMessage.set(
+          err instanceof Error ? `Saved, but navigation failed: ${err.message}` : 'Saved, but navigation failed.'
+        );
+      }
     }
   }
 
@@ -345,11 +518,13 @@ export class ProjectEditorComponent implements OnInit, OnDestroy, DirtyCheckable
     this.tagEntityId.set(project.id);
     this.projectVersion = project.version;
     this.originalName.set(project.name);
-    this.name = project.name;
-    this.description = project.description ?? '';
     // Match loaded org name to an OrganizationDto from the dropdown list
     const matchedOrg = this.organizations().find(o => o.name === project.organizationName);
-    this.selectedOrg = matchedOrg ?? project.organizationName ?? null;
+    this.detailsForm.reset({
+      name: project.name,
+      organization: matchedOrg ?? project.organizationName ?? null,
+      description: project.description ?? '',
+    });
   }
 
   private async saveAndSwitch(): Promise<void> {

--- a/requel-angular/src/app/features/scenarios/scenario-editor.a11y.spec.ts
+++ b/requel-angular/src/app/features/scenarios/scenario-editor.a11y.spec.ts
@@ -100,3 +100,112 @@ describe('ScenarioEditorComponent — step-detail dialog accessibility', () => {
     expect(getOpenDialog()).toBeNull();
   });
 });
+
+// #173: create is now an app-form-wizard, so the create surface needs its own axe pass -
+// including with a field in the error state, which is where a missing/duplicated label or an
+// unassociated message actually shows up. The dialog suite above covers the edit surface.
+const CREATED = {
+  id: 7, version: 2, name: 'Created scenario', text: '', scenarioType: 'Primary', steps: [],
+};
+
+describe('ScenarioEditorComponent - create wizard accessibility', () => {
+  let paramMap$: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fixture: any;
+  let comp: ScenarioEditorComponent;
+
+  beforeEach(() => {
+    paramMap$ = new BehaviorSubject(convertToParamMap({ name: 'proj1', scenarioId: 'new' }));
+
+    TestBed.configureTestingModule({
+      imports: [ScenarioEditorComponent],
+      providers: [
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: ActivatedRoute, useValue: { paramMap: paramMap$.asObservable() } },
+        { provide: Location, useValue: { back: vi.fn() } },
+        { provide: ScenarioService, useValue: { getScenario: vi.fn().mockResolvedValue(CREATED) } },
+        { provide: CommandService, useValue: {
+            execute: vi.fn().mockResolvedValue({ success: true, entity: CREATED }),
+          } },
+        { provide: ProjectService, useValue: { notifyTreeChanged: vi.fn() } },
+        { provide: PermissionService, useValue: {
+            loadForProject: vi.fn().mockResolvedValue(undefined),
+            canEdit: vi.fn().mockReturnValue(true),
+            canDelete: vi.fn().mockReturnValue(true),
+          } },
+        { provide: EventStreamService, useValue: {
+            events$: EMPTY,
+            addSubscription: vi.fn().mockResolvedValue(undefined),
+            removeSubscription: vi.fn().mockResolvedValue(undefined),
+          } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
+    });
+    fixture = TestBed.createComponent(ScenarioEditorComponent);
+    comp = fixture.componentInstance;
+    const router = TestBed.inject(Router);
+    vi.spyOn(router, 'navigate').mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  async function settle(): Promise<void> {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  async function renderWizard(): Promise<HTMLElement> {
+    fixture.detectChanges();
+    await flush();
+    await settle();
+    const wizard = fixture.nativeElement.querySelector('[data-testid="scenario-wizard"]');
+    expect(wizard).not.toBeNull();
+    return wizard as HTMLElement;
+  }
+
+  it('renders the wizard on create, with the step nav labelled and Details current', async () => {
+    const wizard = await renderWizard();
+    const nav = wizard.querySelector('nav');
+    expect(nav!.getAttribute('aria-label')).toBe('New scenario steps');
+    const current = wizard.querySelector('[aria-current="step"]');
+    expect(current!.textContent).toContain('Details');
+  });
+
+  it('has no axe-core violations on the Details step', async () => {
+    const wizard = await renderWizard();
+    await expectNoAxeViolations(wizard);
+  });
+
+  it('has no axe-core violations with the name field in the error state', async () => {
+    const wizard = await renderWizard();
+    comp.submitted.set(true);
+    comp.detailsForm.controls.name.setValue('');
+    comp.detailsForm.markAllAsTouched();
+    await settle();
+    // The error has to actually be on screen, or this asserts nothing.
+    expect(wizard.textContent).toContain('A scenario needs a name.');
+    await expectNoAxeViolations(wizard);
+  });
+
+  it('has no axe-core violations on the Steps step', async () => {
+    const wizard = await renderWizard();
+
+    // Advance the way a user does. Assigning comp.wizardStep directly mutates the value the
+    // [(activeKey)] binding was checked with and throws NG0100 - and it would also skip the
+    // step-1 commit, so Steps would render against a scenario that does not exist yet.
+    comp.detailsForm.controls.name.setValue('Created scenario');
+    await settle();
+    (wizard.querySelector('[data-testid="wizard-continue"] button') as HTMLButtonElement).click();
+    await flush();
+    await settle();
+    expect(comp.wizardStep).toBe('steps');
+
+    comp.addStep();
+    await settle();
+    await expectNoAxeViolations(wizard);
+  });
+});

--- a/requel-angular/src/app/features/scenarios/scenario-editor.a11y.spec.ts
+++ b/requel-angular/src/app/features/scenarios/scenario-editor.a11y.spec.ts
@@ -208,4 +208,31 @@ describe('ScenarioEditorComponent - create wizard accessibility', () => {
     await settle();
     await expectNoAxeViolations(wizard);
   });
+
+  // Regression guard for the e2e contract. The Playwright page objects address these controls
+  // by DOM id - locator('#name'), locator('#text') - because that is the convention app-field
+  // established (controlId on the field, matching id on the control; see term-editor). The
+  // #173 conversion dropped the ids and let app-field generate them, so #name matched nothing
+  // and 23 e2e tests failed while every unit test stayed green. Nothing here asserted the
+  // association, so nothing caught it.
+  it('keeps the stable control ids the e2e page objects address', async () => {
+    const wizard = await renderWizard();
+    {
+      const el = wizard.querySelector('#name');
+      expect(el, 'missing #name - e2e page objects locate this control by id').not.toBeNull();
+      expect(el!.tagName).toBe('INPUT');
+      // The label must point at that same id, or the id is present but unassociated.
+      const label = wizard.querySelector('label[for="name"]');
+      expect(label, 'no <label for="name">').not.toBeNull();
+    }
+    {
+      const el = wizard.querySelector('#text');
+      expect(el, 'missing #text - e2e page objects locate this control by id').not.toBeNull();
+      expect(el!.tagName).toBe('TEXTAREA');
+      // The label must point at that same id, or the id is present but unassociated.
+      const label = wizard.querySelector('label[for="text"]');
+      expect(label, 'no <label for="text">').not.toBeNull();
+    }
+  });
+
 });

--- a/requel-angular/src/app/features/scenarios/scenario-editor.spec.ts
+++ b/requel-angular/src/app/features/scenarios/scenario-editor.spec.ts
@@ -127,8 +127,8 @@ describe('ScenarioEditorComponent', () => {
   it('onSave calls commandService.execute("EditScenario") with steps', async () => {
     fixture.detectChanges();
     await flush();
-    comp.name = 'My Scenario';
-    comp.scenarioType = 'Alternative';
+    comp.detailsForm.controls.name.setValue('My Scenario');
+    comp.detailsForm.controls.scenarioType.setValue('Alternative');
     comp.addStep();
     comp.stepNodes()[0].name = 'Step one';
     await comp.onSave();
@@ -149,14 +149,26 @@ describe('ScenarioEditorComponent', () => {
     expect(comp.canDelete()).toBe(true);
   });
 
-  it('trackChanges() sets hasChanges() when name differs from loaded', async () => {
+  // #173: trackChanges()/hasChanges() are gone. Dirtiness is the form's own state OR a
+  // pending step edit, since steps live outside the form and ship with EditScenario.
+  it('hasUnsavedChanges() follows form.dirty once the scenario is loaded', async () => {
     paramMap$.next(convertToParamMap({ name: 'proj1', scenarioId: '15' }));
     fixture.detectChanges();
     await flush();
-    expect(comp.hasChanges()).toBe(false);
-    comp.name = 'Different Name';
-    comp.trackChanges();
-    expect(comp.hasChanges()).toBe(true);
+    expect(comp.hasUnsavedChanges()).toBe(false);
+    comp.detailsForm.controls.name.setValue('Different Name');
+    comp.detailsForm.controls.name.markAsDirty();
+    expect(comp.hasUnsavedChanges()).toBe(true);
+  });
+
+  it('hasUnsavedChanges() is true for a step change with a pristine form', async () => {
+    paramMap$.next(convertToParamMap({ name: 'proj1', scenarioId: '15' }));
+    fixture.detectChanges();
+    await flush();
+    expect(comp.hasUnsavedChanges()).toBe(false);
+    comp.addStep();
+    expect(comp.detailsForm.dirty).toBe(false);
+    expect(comp.hasUnsavedChanges()).toBe(true);
   });
 
   it('openStepEdit() sets editingStep; applyStepEdit() applies changes and clears', () => {
@@ -247,14 +259,87 @@ describe('ScenarioEditorComponent', () => {
     comp.retryLoad();
     await flush();
     expect(comp.loadError()).toBeNull();
-    expect(comp.name).toBe('Login Flow');
+    expect(comp.detailsForm.controls.name.value).toBe('Login Flow');
+  });
+
+  // #173 required test. EditScenarioCommandImpl calls checkExpectedVersion and then merges
+  // the scenario twice, so every accepted save bumps @Version. If the wizard held the version
+  // captured at step 1, coming back to Details and continuing again would 409. This asserts
+  // the held version is re-read from each result instead.
+  describe('wizard version contract (#173)', () => {
+    const created = { ...MOCK_SCENARIO, id: 15, version: 1, name: 'Created' };
+
+    it('re-reads version from every step result, so a back-navigation edit does not 409', async () => {
+      fixture.detectChanges();
+      await flush();
+
+      // Each accepted save returns the next version, as the server would.
+      let nextVersion = 1;
+      commandServiceMock.execute.mockImplementation(async () => ({
+        success: true,
+        entity: { ...created, version: nextVersion++ }
+      }));
+      scenarioServiceMock.getScenario.mockImplementation(async () => ({
+        ...created, version: nextVersion - 1, steps: []
+      }));
+
+      comp.detailsForm.controls.name.setValue('Created');
+
+      // Step 1: Details.
+      const step1 = { step: { key: 'details' }, complete: vi.fn(), fail: vi.fn() };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await comp.onStepCommit(step1 as any);
+      expect(step1.complete).toHaveBeenCalled();
+
+      // Step 2: mutate an association, then commit.
+      comp.addStep();
+      comp.stepNodes()[0].name = 'Step one';
+      const step2 = { step: { key: 'steps' }, complete: vi.fn(), fail: vi.fn() };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await comp.onStepCommit(step2 as any);
+      expect(step2.complete).toHaveBeenCalled();
+
+      // Back to step 1, edit the name, continue again.
+      comp.detailsForm.controls.name.setValue('Renamed');
+      const step3 = { step: { key: 'details' }, complete: vi.fn(), fail: vi.fn() };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await comp.onStepCommit(step3 as any);
+      expect(step3.complete).toHaveBeenCalled();
+      expect(step3.fail).not.toHaveBeenCalled();
+
+      // Each accepted save advances the version, so the third call must carry what the
+      // SECOND save returned. The value that matters is the one it must NOT be: 1 is the
+      // version captured at step 1, and sending that again is the 409 this test exists for.
+      const calls = commandServiceMock.execute.mock.calls.filter(c => c[0] === 'EditScenario');
+      const versions = calls.map(c => c[1].version);
+      expect(versions).toEqual([undefined, 1, 2]);
+      const last = calls[calls.length - 1][1];
+      expect(last.version).not.toBe(1);
+      // ...and the renamed value, proving step 2 did not pin the details to a snapshot.
+      expect(last.name).toBe('Renamed');
+    });
+
+    it('a 409 keeps the step and reports the stale-version message', async () => {
+      fixture.detectChanges();
+      await flush();
+      commandServiceMock.execute.mockResolvedValue({ success: false, status: 409, error: 'Conflict' });
+      comp.scenarioId = 15;
+      comp.detailsForm.controls.name.setValue('Whatever');
+
+      const request = { step: { key: 'details' }, complete: vi.fn(), fail: vi.fn() };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await comp.onStepCommit(request as any);
+
+      expect(request.complete).not.toHaveBeenCalled();
+      expect(request.fail).toHaveBeenCalledWith(expect.stringContaining('changed elsewhere'));
+    });
   });
 
   it('onSave sets errorMessage when command fails', async () => {
     fixture.detectChanges();
     await flush();
     commandServiceMock.execute.mockResolvedValue({ success: false, error: 'Conflict' });
-    comp.name = 'Test';
+    comp.detailsForm.controls.name.setValue('Test');
     await comp.onSave();
     expect(comp.errorMessage()).toBe('Conflict');
     expect(comp.saving()).toBe(false);

--- a/requel-angular/src/app/features/scenarios/scenario-editor.ts
+++ b/requel-angular/src/app/features/scenarios/scenario-editor.ts
@@ -237,10 +237,10 @@ interface StepNodeData {
       -->
       <ng-template #detailsFields>
         <app-field label="Name" helper="What happens in this scenario."
-                   [control]="detailsForm.controls.name"
+                   controlId="name" [control]="detailsForm.controls.name"
                    [errorMessages]="nameErrors"
                    [submitted]="submitted()">
-          <input appFieldControl pInputText [formControl]="detailsForm.controls.name"
+          <input appFieldControl pInputText [formControl]="detailsForm.controls.name" id="name"
                  [attr.maxlength]="nameMaxLength"
                  placeholder="Scenario name" data-testid="scenario-name" />
         </app-field>
@@ -253,9 +253,9 @@ interface StepNodeData {
                     [options]="typeOptions" optionLabel="label" optionValue="value" />
         </app-field>
 
-        <app-field label="Description" [control]="detailsForm.controls.text" [divider]="false"
+        <app-field label="Description" controlId="text" [control]="detailsForm.controls.text" [divider]="false"
                    [submitted]="submitted()">
-          <textarea appFieldControl pTextarea [formControl]="detailsForm.controls.text" rows="4"
+          <textarea appFieldControl pTextarea [formControl]="detailsForm.controls.text" id="text" rows="4"
                     placeholder="Scenario description" data-testid="scenario-text"></textarea>
         </app-field>
       </ng-template>

--- a/requel-angular/src/app/features/scenarios/scenario-editor.ts
+++ b/requel-angular/src/app/features/scenarios/scenario-editor.ts
@@ -22,10 +22,10 @@ import { Component, OnDestroy, OnInit, signal } from '@angular/core';
 import { PageHeaderComponent } from '../../shared/page-header';
 import { AppCardComponent } from '../../shared/app-card';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { Location } from '@angular/common';
+import { Location, NgTemplateOutlet } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
-import { FormsModule } from '@angular/forms';
+import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
 import { InputText } from 'primeng/inputtext';
 import { TextareaModule } from 'primeng/textarea';
@@ -36,6 +36,7 @@ import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { TooltipModule } from 'primeng/tooltip';
 import { DragDropModule, CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import { ConfirmationService, MessageService } from 'primeng/api';
+import { CommandResult } from '../../models/command';
 import { ScenarioDto, StepDto, EditStepInput } from '../../models/scenario';
 import { ScenarioService } from '../../core/scenario.service';
 import { CommandService } from '../../core/command.service';
@@ -46,6 +47,14 @@ import { ScenarioSelectorDialogComponent, ScenarioRef } from '../../shared/scena
 import { AnnotationsSectionComponent } from '../../shared/annotations-section';
 import { LoadingStateComponent } from '../../shared/loading-state';
 import { ErrorStateComponent } from '../../shared/error-state';
+import { AppFieldComponent, AppFieldControlDirective } from '../../shared/app-field';
+import {
+  AppFormWizardComponent,
+  AppWizardStepComponent,
+  WizardCommitRequest,
+} from '../../shared/app-form-wizard';
+import { applyCommandErrors, clearServerErrors } from '../../shared/form-errors';
+import { ARTIFACT_NAME_MAX_LENGTH } from '../../shared/validation-limits';
 
 const SCENARIO_TYPE_OPTIONS = [
   { label: 'Primary', value: 'Primary' },
@@ -54,6 +63,26 @@ const SCENARIO_TYPE_OPTIONS = [
   { label: 'Alternative', value: 'Alternative' },
   { label: 'Exception', value: 'Exception' },
 ];
+
+/**
+ * JPA entity property name -> form control name, for {@link applyCommandErrors}.
+ *
+ * `CommandController` reports field violations using the entity's property names, not the
+ * input DTO's. `ScenarioImpl.getType()` backs what this form calls `scenarioType`, and the
+ * DTO field is `scenarioTypeName` again - all three spellings resolve to the one control.
+ * #176 makes the backend emit DTO field names and deletes this map.
+ */
+const SCENARIO_FIELD_MAP: Record<string, string> = {
+  type: 'scenarioType',
+  scenarioTypeName: 'scenarioType',
+};
+
+/** Joins page-level violations that resolved to no control. */
+const SEPARATOR = '; ';
+
+/** Wording for the stale-version recovery path, so the 409 case reads as recoverable. */
+const STALE_VERSION_MESSAGE =
+  'This scenario was changed elsewhere. Your copy has been refreshed - review the values and continue.';
 
 interface StepNodeData {
   stepId: number | null;
@@ -67,9 +96,12 @@ interface StepNodeData {
 @Component({
   selector: 'app-scenario-editor',
   standalone: true,
-  imports: [PageHeaderComponent, AppCardComponent, RouterLink, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
+  imports: [PageHeaderComponent, AppCardComponent, RouterLink, NgTemplateOutlet, FormsModule,
+            ReactiveFormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
             MessageModule, DialogModule, ConfirmDialogModule, TooltipModule, DragDropModule,
-            ScenarioSelectorDialogComponent, AnnotationsSectionComponent, LoadingStateComponent, ErrorStateComponent],
+            ScenarioSelectorDialogComponent, AnnotationsSectionComponent, LoadingStateComponent,
+            ErrorStateComponent, AppFieldComponent, AppFieldControlDirective,
+            AppFormWizardComponent, AppWizardStepComponent],
   providers: [ConfirmationService],
   template: `
     <div class="scenario-editor" data-testid="scenario-editor">
@@ -102,116 +134,54 @@ interface StepNodeData {
       } @else if (loadError()) {
         <app-error-state [message]="loadError()!" testid="scenario-editor-load-error"
                          (retry)="retryLoad()" />
+      } @else if (isNew()) {
+        <!--
+          Create runs as a wizard (#173). Steps *are* the scenario - gating them behind a
+          first save is what made the old create flow produce an empty scenario the user had
+          to navigate back into.
+
+          Unlike goal/story, both steps commit the SAME command: EditScenario carries the
+          whole step list and rebuilds scenario.getSteps() server-side, so there is no
+          per-association command to issue. Step 2 therefore re-sends name/type/text, which
+          is why saveDetails() always reads them from the form rather than from a snapshot
+          taken at step 1 - otherwise a back-navigation edit to the name would be silently
+          discarded on Done.
+        -->
+        <app-form-wizard
+          [(activeKey)]="wizardStep"
+          navLabel="New scenario steps"
+          (stepCommit)="onStepCommit($event)"
+          (cancelled)="onBack()"
+          (finished)="onWizardFinished()"
+          data-testid="scenario-wizard"
+        >
+          <app-wizard-step key="details" label="Details" helper="Name, type and description"
+                           [form]="detailsForm">
+            <ng-template>
+              <ng-container [ngTemplateOutlet]="detailsFields" />
+            </ng-template>
+          </app-wizard-step>
+
+          <app-wizard-step key="steps" label="Steps" helper="Write the scenario">
+            <ng-template>
+              <!-- heading: false - the wizard panel's own h2 already reads "Steps". -->
+              <ng-container [ngTemplateOutlet]="stepsSection"
+                            [ngTemplateOutletContext]="{ heading: false }" />
+            </ng-template>
+          </app-wizard-step>
+        </app-form-wizard>
       } @else {
-      <app-card>
-        <div class="form-grid">
-          <label for="name">Name</label>
-          <input id="name" pInputText [(ngModel)]="name" placeholder="Scenario name"
-                 (ngModelChange)="trackChanges()" />
+        <app-card>
+          <ng-container [ngTemplateOutlet]="detailsFields" />
 
-          <label for="type">Type</label>
-          <p-select id="type" inputId="scenarioTypeInput" data-testid="scenario-type" [(ngModel)]="scenarioType" [options]="typeOptions"
-                    optionLabel="label" optionValue="value"
-                    (ngModelChange)="trackChanges()" />
-
-          <label for="text">Description</label>
-          <textarea id="text" pTextarea [(ngModel)]="text" rows="4"
-                    placeholder="Scenario description"
-                    (ngModelChange)="trackChanges()"></textarea>
-        </div>
-
-        <div class="form-actions">
-          <p-button label="Save" icon="pi pi-check" data-testid="scenario-save"
-                    (onClick)="onSave()" [loading]="saving()"
-                    [disabled]="!isNew() && !hasChanges()" />
-        </div>
-      </app-card>
-
-      <!-- Steps section -->
-      @if (!isNew()) {
-        <div class="section">
-          <div class="section-header">
-            <h3>Steps</h3>
-            @if (canEdit()) {
-              <div class="section-actions">
-                <p-button label="Add Sub-scenario" icon="pi pi-sitemap" size="small"
-                          severity="secondary" [outlined]="true"
-                          data-testid="scenario-add-sub"
-                          (onClick)="showScenarioSelector = true" />
-              </div>
-            }
+          <div class="form-actions">
+            <p-button label="Save" icon="pi pi-check" data-testid="scenario-save"
+                      [disabled]="!canSave()" [loading]="saving()" (onClick)="onSave()" />
           </div>
+        </app-card>
 
-          <div cdkDropList data-testid="scenario-step-list" [cdkDropListDisabled]="!canEdit()"
-               (cdkDropListDropped)="onDrop($event)"
-               class="step-list">
-            @if (canEdit()) {
-              <button type="button" class="add-step-row" data-testid="scenario-add-step-top" (click)="addStepAt(0)">
-                <i class="pi pi-plus" aria-hidden="true"></i> Add step
-              </button>
-            }
-            @for (step of stepNodes(); track step; let stepIndex = $index) {
-              <div cdkDrag class="step-row" data-testid="scenario-step-row"
-                   [attr.data-step-index]="stepIndex">
-                  @if (canEdit()) {
-                    <span cdkDragHandle class="drag-handle" data-testid="scenario-step-drag-handle"
-                          pTooltip="Drag to reorder" tooltipPosition="left">
-                      <i class="pi pi-bars"></i>
-                    </span>
-                  }
-                  @if (step.isScenario) {
-                    <i class="pi pi-sitemap step-icon"></i>
-                    <a class="entity-link step-name"
-                       data-testid="scenario-step-link"
-                       [routerLink]="['/projects', projectName, 'scenarios', step.stepId!]">{{ step.name }}</a>
-                    <span class="step-type-badge">{{ step.scenarioType }}</span>
-                    @if (canEdit()) {
-                      <p-button icon="pi pi-times" severity="danger" [text]="true"
-                                data-testid="scenario-step-remove" [ariaLabel]="'Remove ' + step.name + ' from scenario'"
-                                size="small" pTooltip="Remove from scenario"
-                                (onClick)="removeStep(step)" />
-                    }
-                  } @else {
-                    <input pInputText [(ngModel)]="step.name"
-                           class="step-name-input"
-                           data-testid="scenario-step-name"
-                           placeholder="Step description..."
-                           [disabled]="!canEdit()"
-                           (keydown)="$event.stopPropagation()"
-                           (blur)="onStepNameChange()" />
-                    @if (canEdit()) {
-                      <p-button icon="pi pi-pencil" [text]="true" size="small"
-                                data-testid="scenario-step-edit" ariaLabel="Edit step details"
-                                pTooltip="Edit details" tooltipPosition="top"
-                                (onClick)="openStepEdit(step)" />
-                      <p-button icon="pi pi-plus" severity="secondary" [text]="true"
-                                data-testid="scenario-step-add-below" ariaLabel="Add step below"
-                                size="small" pTooltip="Add step below" tooltipPosition="top"
-                                (onClick)="addStepBelow(step)" />
-                      <p-button icon="pi pi-times" severity="danger" [text]="true"
-                                data-testid="scenario-step-remove" ariaLabel="Remove step"
-                                size="small" pTooltip="Remove step" tooltipPosition="top"
-                                (onClick)="removeStep(step)" />
-                    }
-                  }
-                  <!-- CDK drag placeholder styling -->
-                  <div *cdkDragPlaceholder class="step-row-placeholder"></div>
-                </div>
-              }
-            @if (canEdit()) {
-              <button type="button" class="add-step-row" data-testid="scenario-add-step-bottom" (click)="addStep()">
-                <i class="pi pi-plus" aria-hidden="true"></i> Add step
-              </button>
-            }
-          </div>
-
-          @if (stepsSaveNeeded()) {
-            <div class="steps-save-note">
-              <p-message severity="info" text="Steps have unsaved changes. Click Save to apply." />
-            </div>
-          }
-        </div>
-      }
+        <ng-container [ngTemplateOutlet]="stepsSection"
+                      [ngTemplateOutletContext]="{ heading: true }" />
       }
 
       <!-- Step detail edit dialog -->
@@ -245,23 +215,148 @@ interface StepNodeData {
         (selected)="onSubScenarioSelected($event)"
         (closed)="showScenarioSelector = false" />
 
-      <app-annotations-section
-        [projectName]="projectName"
-        entityType="Scenario"
-        [entityId]="scenarioId"
-        [canEdit]="canEdit()" />
+      <!--
+        Annotations render against a persisted entity, so they stay outside the wizard and
+        appear once the scenario exists rather than as a dead panel during create.
+      -->
+      @if (scenarioId != null) {
+        <app-annotations-section
+          [projectName]="projectName"
+          entityType="Scenario"
+          [entityId]="scenarioId"
+          [canEdit]="canEdit()" />
+      }
 
       <p-confirmDialog />
+
+      <!--
+        Shared bodies. Each is used by both the wizard step and the edit view, so the two
+        modes cannot drift apart. Controls bind with [formControl], not formControlName:
+        these templates are projected into the wizard, where formControlName would look for
+        a parent formGroup that is not there.
+      -->
+      <ng-template #detailsFields>
+        <app-field label="Name" helper="What happens in this scenario."
+                   [control]="detailsForm.controls.name"
+                   [errorMessages]="nameErrors"
+                   [submitted]="submitted()">
+          <input appFieldControl pInputText [formControl]="detailsForm.controls.name"
+                 [attr.maxlength]="nameMaxLength"
+                 placeholder="Scenario name" data-testid="scenario-name" />
+        </app-field>
+
+        <app-field label="Type" controlId="scenarioTypeInput"
+                   [control]="detailsForm.controls.scenarioType"
+                   [submitted]="submitted()">
+          <p-select appFieldControl inputId="scenarioTypeInput" data-testid="scenario-type"
+                    [formControl]="detailsForm.controls.scenarioType"
+                    [options]="typeOptions" optionLabel="label" optionValue="value" />
+        </app-field>
+
+        <app-field label="Description" [control]="detailsForm.controls.text" [divider]="false"
+                   [submitted]="submitted()">
+          <textarea appFieldControl pTextarea [formControl]="detailsForm.controls.text" rows="4"
+                    placeholder="Scenario description" data-testid="scenario-text"></textarea>
+        </app-field>
+      </ng-template>
+
+      <ng-template #stepsSection let-heading="heading">
+        <div class="section">
+          <div class="section-header">
+            @if (heading) {
+              <h2 class="rq-section-title">Steps</h2>
+            }
+            @if (canEdit()) {
+              <div class="section-actions">
+                <p-button label="Add Sub-scenario" icon="pi pi-sitemap" size="small"
+                          severity="secondary" [outlined]="true"
+                          data-testid="scenario-add-sub"
+                          (onClick)="showScenarioSelector = true" />
+              </div>
+            }
+          </div>
+
+          <div cdkDropList data-testid="scenario-step-list" [cdkDropListDisabled]="!canEdit()"
+               (cdkDropListDropped)="onDrop($event)"
+               class="step-list">
+            @if (canEdit()) {
+              <button type="button" class="add-step-row" data-testid="scenario-add-step-top" (click)="addStepAt(0)">
+                <i class="pi pi-plus" aria-hidden="true"></i> Add step
+              </button>
+            }
+            @for (step of stepNodes(); track step; let stepIndex = $index) {
+              <div cdkDrag class="step-row" data-testid="scenario-step-row"
+                   [attr.data-step-index]="stepIndex">
+                @if (canEdit()) {
+                  <span cdkDragHandle class="drag-handle" data-testid="scenario-step-drag-handle"
+                        pTooltip="Drag to reorder" tooltipPosition="left">
+                    <i class="pi pi-bars"></i>
+                  </span>
+                }
+                @if (step.isScenario) {
+                  <i class="pi pi-sitemap step-icon"></i>
+                  <a class="entity-link step-name"
+                     data-testid="scenario-step-link"
+                     [routerLink]="['/projects', projectName, 'scenarios', step.stepId!]">{{ step.name }}</a>
+                  <span class="step-type-badge">{{ step.scenarioType }}</span>
+                  @if (canEdit()) {
+                    <p-button icon="pi pi-times" severity="danger" [text]="true"
+                              data-testid="scenario-step-remove" [ariaLabel]="'Remove ' + step.name + ' from scenario'"
+                              size="small" pTooltip="Remove from scenario"
+                              (onClick)="removeStep(step)" />
+                  }
+                } @else {
+                  <input pInputText [(ngModel)]="step.name"
+                         class="step-name-input"
+                         data-testid="scenario-step-name"
+                         placeholder="Step description..."
+                         [disabled]="!canEdit()"
+                         (keydown)="$event.stopPropagation()"
+                         (blur)="onStepNameChange()" />
+                  @if (canEdit()) {
+                    <p-button icon="pi pi-pencil" [text]="true" size="small"
+                              data-testid="scenario-step-edit" ariaLabel="Edit step details"
+                              pTooltip="Edit details" tooltipPosition="top"
+                              (onClick)="openStepEdit(step)" />
+                    <p-button icon="pi pi-plus" severity="secondary" [text]="true"
+                              data-testid="scenario-step-add-below" ariaLabel="Add step below"
+                              size="small" pTooltip="Add step below" tooltipPosition="top"
+                              (onClick)="addStepBelow(step)" />
+                    <p-button icon="pi pi-times" severity="danger" [text]="true"
+                              data-testid="scenario-step-remove" ariaLabel="Remove step"
+                              size="small" pTooltip="Remove step" tooltipPosition="top"
+                              (onClick)="removeStep(step)" />
+                  }
+                }
+                <!-- CDK drag placeholder styling -->
+                <div *cdkDragPlaceholder class="step-row-placeholder"></div>
+              </div>
+            }
+            @if (canEdit()) {
+              <button type="button" class="add-step-row" data-testid="scenario-add-step-bottom" (click)="addStep()">
+                <i class="pi pi-plus" aria-hidden="true"></i> Add step
+              </button>
+            }
+          </div>
+
+          @if (stepsSaveNeeded()) {
+            <div class="steps-save-note">
+              <p-message severity="info"
+                         [text]="isNew()
+                           ? 'Steps have unsaved changes. Press Done to apply.'
+                           : 'Steps have unsaved changes. Click Save to apply.'" />
+            </div>
+          }
+        </div>
+      </ng-template>
     </div>
   `,
   styles: [`
     .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
     .page-actions { display: flex; gap: 0.5rem; }
-    .form-grid { display: grid; grid-template-columns: 120px 1fr; gap: 0.75rem 1rem; align-items: start; max-width: 700px; }
     .form-actions { margin-top: 1rem; }
     .section { margin-top: 1.5rem; }
     .section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
-    .section-header h3 { margin: 0; }
     .section-actions { display: flex; gap: 0.5rem; }
     .steps-save-note { margin-top: 0.5rem; }
     .empty-text { color: var(--p-text-secondary-color); font-style: italic; }
@@ -327,16 +422,47 @@ export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckabl
   // error state replaces the form only when the initial load fails.
   loadError = signal<string | null>(null);
   saving = signal(false);
+  submitted = signal(false);
   canEdit = signal(false);
   canDelete = signal(false);
-  hasChanges = signal(false);
   stepsSaveNeeded = signal(false);
   stepNodes = signal<StepNodeData[]>([]);
   editingStep = signal<StepNodeData | null>(null);
 
-  name = '';
-  text = '';
-  scenarioType = 'Primary';
+  /**
+   * Mirrors the backend `@Size(max = ValidationLimits.ARTIFACT_NAME_MAX)` (#171). Bound with
+   * `[attr.maxlength]` rather than `maxlength` on purpose: Angular's MaxLengthValidator directive
+   * matches `[maxlength][formControl]`, so the plain binding would register a SECOND maxlength
+   * validator on top of the one in the form definition. `attr.` sets the HTML attribute only, which
+   * is all that is wanted here - the browser stops the typing, the form owns the validation.
+   */
+  readonly nameMaxLength = ARTIFACT_NAME_MAX_LENGTH;
+
+  /**
+   * Details step / edit form. Replaces the `name` + `scenarioType` + `text` ngModel fields and
+   * the hand-rolled `trackChanges()` + `original*` comparison, which the form's own dirty state
+   * now covers.
+   *
+   * `text` carries no maxLength: `AbstractTextEntity.getText()` is `@Lob` server-side, so there
+   * is no bound to mirror and inventing one would reject content the server accepts.
+   */
+  readonly detailsForm = new FormGroup({
+    name: new FormControl('', {
+      validators: [Validators.required, Validators.maxLength(ARTIFACT_NAME_MAX_LENGTH)],
+      nonNullable: true,
+    }),
+    scenarioType: new FormControl('Primary', {
+      validators: [Validators.required],
+      nonNullable: true,
+    }),
+    text: new FormControl('', { nonNullable: true }),
+  });
+
+  readonly nameErrors = { required: 'A scenario needs a name.' };
+
+  /** Active wizard step key, two-way bound to `app-form-wizard`. */
+  wizardStep = 'details';
+
   typeOptions = SCENARIO_TYPE_OPTIONS;
   showScenarioSelector = false;
   editingName = '';
@@ -346,9 +472,6 @@ export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckabl
   projectName = '';
   scenarioId: number | null = null;
   private version: number | null = null;
-  private originalName = '';
-  private originalText = '';
-  private originalScenarioType = 'Primary';
   private paramSub?: Subscription;
   private sseSub?: Subscription;
 
@@ -378,11 +501,13 @@ export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckabl
       if (newIsNew) {
         this.isNew.set(true);
         this.scenario.set(null);
-        this.name = '';
-        this.text = '';
-        this.scenarioType = 'Primary';
+        this.scenarioId = null;
         this.version = null;
+        this.wizardStep = 'details';
+        this.submitted.set(false);
+        this.detailsForm.reset({ name: '', scenarioType: 'Primary', text: '' });
         this.stepNodes.set([]);
+        this.stepsSaveNeeded.set(false);
         // New scenarios don't load — resolve the loading/error state so the
         // form renders immediately instead of the skeleton.
         this.loading.set(false);
@@ -401,8 +526,17 @@ export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckabl
     });
   }
 
+  /**
+   * Steps live outside the form - they are local nodes submitted wholesale with EditScenario -
+   * so the dirty check is the form's own state OR a pending step change.
+   */
   hasUnsavedChanges(): boolean {
-    return this.hasChanges();
+    return this.detailsForm.dirty || this.stepsSaveNeeded();
+  }
+
+  /** Edit-mode Save: blocked on invalid, unchanged, or in-flight. */
+  canSave(): boolean {
+    return this.detailsForm.valid && this.hasUnsavedChanges() && !this.saving();
   }
 
   ngOnDestroy(): void {
@@ -418,11 +552,15 @@ export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckabl
     void this.loadScenario();
   }
 
-  private async loadScenario(fromSSE = false): Promise<void> {
-    // Only the user-initiated (non-SSE) load drives the skeleton / retryable
-    // error state; a background SSE refresh must not blank the form the user is
-    // looking at.
-    if (!fromSSE) {
+  /**
+   * @param fromSSE  background refresh driven by an event, not by the user.
+   * @param skeleton show the loading skeleton. Suppressed after a save, where blanking the
+   *                 wizard panel the user is standing in would be worse than a stale moment.
+   */
+  private async loadScenario(fromSSE = false, skeleton = !fromSSE): Promise<void> {
+    // Only the user-initiated load drives the skeleton / retryable error state; a background
+    // refresh must not blank the form the user is looking at.
+    if (skeleton) {
       this.loading.set(true);
       this.loadError.set(null);
     }
@@ -432,31 +570,33 @@ export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckabl
       // Check after the async fetch so we catch edits made while the request was in-flight.
       // editingStep() !== null means the step-detail popup is open: replacing stepNodes
       // would orphan the object that editingStep points to, losing any in-progress edits.
-      if (fromSSE && (this.hasChanges() || this.saving() || this.editingStep() !== null)) {
+      if (fromSSE && (this.hasUnsavedChanges() || this.saving() || this.editingStep() !== null)) {
+        // Still take the new version: the entity moved on, and holding the stale one
+        // guarantees a 409 on the user's next save.
+        this.version = s.version;
+        this.scenario.set(s);
         return;
       }
       this.scenario.set(s);
       this.scenarioName.set(s.name);
-      this.name = s.name;
-      this.text = s.text ?? '';
-      this.scenarioType = s.scenarioType ?? 'Primary';
+      this.detailsForm.reset({
+        name: s.name,
+        scenarioType: s.scenarioType ?? 'Primary',
+        text: s.text ?? '',
+      });
       this.version = s.version;
-      this.originalName = s.name;
-      this.originalText = s.text ?? '';
-      this.originalScenarioType = s.scenarioType ?? 'Primary';
-      this.hasChanges.set(false);
       this.stepsSaveNeeded.set(false);
       this.stepNodes.set(this.stepsToNodes(s.steps ?? []));
     } catch {
       // A background refresh failure shows a non-blocking message; an initial
       // load failure shows the retryable error state in place of the form.
-      if (fromSSE) {
-        this.errorMessage.set('Failed to load scenario.');
-      } else {
+      if (skeleton) {
         this.loadError.set('Failed to load scenario.');
+      } else {
+        this.errorMessage.set('Failed to load scenario.');
       }
     } finally {
-      if (!fromSSE) {
+      if (skeleton) {
         this.loading.set(false);
       }
     }
@@ -475,24 +615,14 @@ export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckabl
       stepId: step.id,
       name: step.name,
       text: step.text ?? null,
-      scenarioType: step.scenarioType ?? this.scenarioType,
+      scenarioType: step.scenarioType ?? this.detailsForm.controls.scenarioType.value,
       isScenario: step.isScenario,
       isNew: false
     }));
   }
 
-  trackChanges(): void {
-    this.hasChanges.set(
-      this.name !== this.originalName ||
-      this.text !== this.originalText ||
-      this.scenarioType !== this.originalScenarioType ||
-      this.stepsSaveNeeded()
-    );
-  }
-
   onStepNameChange(): void {
     this.stepsSaveNeeded.set(true);
-    this.hasChanges.set(true);
   }
 
   excludeScenarioIds(): number[] {
@@ -504,42 +634,37 @@ export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckabl
     return ids;
   }
 
-  addStep(): void {
-    this.stepNodes.update(steps => [...steps, {
+  private newStepNode(): StepNodeData {
+    return {
       stepId: null, name: '', text: null,
-      scenarioType: this.scenarioType, isScenario: false, isNew: true
-    }]);
+      scenarioType: this.detailsForm.controls.scenarioType.value,
+      isScenario: false, isNew: true
+    };
+  }
+
+  addStep(): void {
+    this.stepNodes.update(steps => [...steps, this.newStepNode()]);
     this.stepsSaveNeeded.set(true);
-    this.hasChanges.set(true);
   }
 
   addStepAt(index: number): void {
     const steps = [...this.stepNodes()];
-    steps.splice(index, 0, {
-      stepId: null, name: '', text: null,
-      scenarioType: this.scenarioType, isScenario: false, isNew: true
-    });
+    steps.splice(index, 0, this.newStepNode());
     this.stepNodes.set(steps);
     this.stepsSaveNeeded.set(true);
-    this.hasChanges.set(true);
   }
 
   addStepBelow(step: StepNodeData): void {
     const steps = [...this.stepNodes()];
     const idx = steps.indexOf(step);
-    steps.splice(idx + 1, 0, {
-      stepId: null, name: '', text: null,
-      scenarioType: this.scenarioType, isScenario: false, isNew: true
-    });
+    steps.splice(idx + 1, 0, this.newStepNode());
     this.stepNodes.set(steps);
     this.stepsSaveNeeded.set(true);
-    this.hasChanges.set(true);
   }
 
   removeStep(step: StepNodeData): void {
     this.stepNodes.update(steps => steps.filter(s => s !== step));
     this.stepsSaveNeeded.set(true);
-    this.hasChanges.set(true);
   }
 
   onDrop(event: CdkDragDrop<StepNodeData[]>): void {
@@ -547,7 +672,6 @@ export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckabl
     moveItemInArray(steps, event.previousIndex, event.currentIndex);
     this.stepNodes.set(steps);
     this.stepsSaveNeeded.set(true);
-    this.hasChanges.set(true);
   }
 
   openStepEdit(step: StepNodeData): void {
@@ -566,7 +690,6 @@ export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckabl
     this.stepNodes.set([...this.stepNodes()]);
     this.editingStep.set(null);
     this.stepsSaveNeeded.set(true);
-    this.hasChanges.set(true);
   }
 
   closeStepEdit(): void {
@@ -589,11 +712,10 @@ export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckabl
     this.showScenarioSelector = false;
     this.stepNodes.update(steps => [...steps, {
       stepId: ref.id, name: ref.name, text: null,
-      scenarioType: ref.scenarioType ?? this.scenarioType,
+      scenarioType: ref.scenarioType ?? this.detailsForm.controls.scenarioType.value,
       isScenario: true, isNew: false
     }]);
     this.stepsSaveNeeded.set(true);
-    this.hasChanges.set(true);
   }
 
   private buildStepInputs(): EditStepInput[] {
@@ -606,46 +728,140 @@ export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckabl
     }));
   }
 
-  async onSave(): Promise<void> {
+  /**
+   * Runs the commit for the wizard's current step.
+   *
+   * Both steps issue `EditScenario`, because steps are part of the scenario's own save rather
+   * than separate association commands. Step 1 creates and yields the id/version; step 2
+   * re-sends the same details plus the step list against the refreshed version.
+   */
+  async onStepCommit(request: WizardCommitRequest): Promise<void> {
+    this.submitted.set(true);
+    const result = await this.saveDetails();
+
+    if (result.success) {
+      request.complete();
+      return;
+    }
+    if (await this.recoverFromStaleVersion(result)) {
+      request.fail(STALE_VERSION_MESSAGE);
+      return;
+    }
+    request.fail(result.error ?? 'Save failed.');
+  }
+
+  /** Done on the last step: the scenario is already saved, so just go to it. */
+  onWizardFinished(): void {
+    if (this.scenarioId != null) {
+      this.router.navigate(['/projects', this.projectName, 'scenarios', this.scenarioId]);
+    } else {
+      this.onBack();
+    }
+  }
+
+  /**
+   * Issues `EditScenario` for the Details values plus the current step list and, on success,
+   * adopts the id and version from the response.
+   *
+   * The version is **spent on use**: `EditScenarioCommandImpl` calls `checkExpectedVersion` and
+   * then merges the scenario twice, so every accepted save bumps it. It is re-read from
+   * `result.entity` each time - holding the value captured at create and sending it again,
+   * which is exactly what happens when the user steps back to Details and continues a second
+   * time, is a guaranteed 409.
+   *
+   * Name/type/text come from the form on every call, never from a snapshot: step 2 re-sends
+   * them, so a back-navigation edit has to be picked up here or it is silently dropped.
+   */
+  private async saveDetails(): Promise<CommandResult<unknown>> {
     this.saving.set(true);
     this.errorMessage.set(null);
+    clearServerErrors(this.detailsForm);
     try {
+      const { name, scenarioType, text } = this.detailsForm.getRawValue();
       const input: Record<string, unknown> = {
         projectName: this.projectName,
-        name: this.name,
-        text: this.text || null,
-        scenarioTypeName: this.scenarioType,
-        steps: this.buildStepInputs()
+        name,
+        text: text || null,
+        scenarioTypeName: scenarioType,
+        steps: this.buildStepInputs(),
       };
-      if (this.version != null) input['version'] = this.version;
       if (this.scenarioId != null) input['scenarioId'] = this.scenarioId;
+      if (this.version != null) input['version'] = this.version;
 
       const result = await this.commandService.execute('EditScenario', input);
-      if (result.success) {
-        this.messageService.add({ severity: 'success', summary: 'Saved', detail: 'Scenario saved.' });
-        if (this.isNew()) {
-          this.projectService.notifyTreeChanged();
-          if (result.entity) {
-            const saved = result.entity as ScenarioDto;
-            this.hasChanges.set(false);
-            this.router.navigate(['/projects', this.projectName, 'scenarios', saved.id]);
-          }
-        } else {
-          this.originalName = this.name;
-          this.originalText = this.text;
-          this.originalScenarioType = this.scenarioType;
-          this.hasChanges.set(false);
-          this.stepsSaveNeeded.set(false);
-          await this.loadScenario();
+      if (!result.success) {
+        const unresolved = applyCommandErrors(this.detailsForm, result.violations, SCENARIO_FIELD_MAP);
+        if (unresolved.length) {
+          this.errorMessage.set(unresolved.join(SEPARATOR));
         }
-      } else {
-        this.errorMessage.set(result.error ?? 'Save failed.');
+        return result;
       }
+
+      const wasCreate = this.scenarioId == null;
+      if (wasCreate) {
+        this.projectService.notifyTreeChanged();
+      }
+
+      const saved = result.entity as ScenarioDto | null;
+      if (saved) {
+        this.scenarioId = saved.id;
+        this.version = saved.version;
+        this.scenarioName.set(saved.name);
+      }
+      this.detailsForm.markAsPristine();
+      this.stepsSaveNeeded.set(false);
+      this.messageService.add({ severity: 'success', summary: 'Saved', detail: 'Scenario saved.' });
+
+      // Refetch so new steps pick up their server-assigned ids, and so the SSE subscription
+      // starts the first time the scenario exists. No skeleton: in the wizard that would
+      // blank the panel the user is standing in.
+      if (this.scenarioId != null) {
+        await this.loadScenario(false, false);
+      }
+      return result;
     } catch {
-      this.errorMessage.set('An unexpected error occurred.');
+      return {
+        success: false,
+        entityType: 'Scenario',
+        entity: null,
+        error: 'An unexpected error occurred.',
+        violations: null,
+      };
     } finally {
       this.saving.set(false);
     }
+  }
+
+  /**
+   * If `result` is an optimistic-lock conflict (HTTP 409 from
+   * `EntityLockException.staleEntity`), refetch so the held version is current and the user
+   * can retry. Returns whether it handled the result.
+   */
+  private async recoverFromStaleVersion(result: CommandResult<unknown>): Promise<boolean> {
+    if (result.status !== 409 || this.scenarioId == null) {
+      return false;
+    }
+    await this.loadScenario(false, false);
+    return true;
+  }
+
+  /** Edit-mode Save. */
+  async onSave(): Promise<void> {
+    this.submitted.set(true);
+    if (this.detailsForm.invalid) {
+      this.detailsForm.markAllAsTouched();
+      return;
+    }
+
+    const result = await this.saveDetails();
+    if (result.success) {
+      return;
+    }
+    if (await this.recoverFromStaleVersion(result)) {
+      this.errorMessage.set(STALE_VERSION_MESSAGE);
+      return;
+    }
+    this.errorMessage.set(result.error ?? 'Save failed.');
   }
 
   onCopy(): void {
@@ -678,6 +894,9 @@ export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckabl
         });
         if (result.success) {
           this.projectService.notifyTreeChanged();
+          // Nothing left to guard against - don't let the dirty check block the exit.
+          this.detailsForm.markAsPristine();
+          this.stepsSaveNeeded.set(false);
           this.router.navigate(['/projects', this.projectName, 'scenarios']);
         } else {
           this.errorMessage.set(result.error ?? 'Delete failed.');

--- a/requel-angular/src/app/features/stakeholders/stakeholder-editor.a11y.spec.ts
+++ b/requel-angular/src/app/features/stakeholders/stakeholder-editor.a11y.spec.ts
@@ -1,0 +1,150 @@
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter, Router, ActivatedRoute, convertToParamMap } from '@angular/router';
+import { BehaviorSubject, EMPTY } from 'rxjs';
+import { MessageService } from 'primeng/api';
+import { StakeholderEditorComponent } from './stakeholder-editor';
+import { StakeholderService } from '../../core/stakeholder.service';
+import { CommandService } from '../../core/command.service';
+import { ProjectService } from '../../core/project.service';
+import { UserService } from '../../core/user.service';
+import { PermissionService } from '../../core/permission.service';
+import { EventStreamService } from '../../core/event-stream.service';
+import { expectNoAxeViolations } from '../../shared/testing/a11y';
+
+const flush = () => new Promise(r => setTimeout(r, 0));
+
+const PERMISSIONS = [
+  { entityType: 'Goal', permissionKey: 'edit_goal', permissionType: 'Edit' },
+  { entityType: 'Goal', permissionKey: 'delete_goal', permissionType: 'Delete' },
+];
+
+const CREATED = {
+  id: 51, version: 1, name: 'FASB', type: 'non-user', goals: [],
+  userDetails: null, nonUserDetails: { text: 'Financial authority' },
+};
+
+// #173: create is a wizard now, and the permission matrix is the part most likely to have
+// accessibility problems - a grid of checkboxes whose only visible labels are column headers.
+describe('StakeholderEditorComponent - create wizard accessibility', () => {
+  let paramMap$: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fixture: any;
+  let comp: StakeholderEditorComponent;
+
+  function setup(routeId: string): void {
+    paramMap$ = new BehaviorSubject(convertToParamMap({ name: 'proj1', stakeholderId: routeId }));
+
+    TestBed.configureTestingModule({
+      imports: [StakeholderEditorComponent],
+      providers: [
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: ActivatedRoute, useValue: { paramMap: paramMap$.asObservable() } },
+        { provide: StakeholderService, useValue: {
+            getStakeholder: vi.fn().mockResolvedValue(CREATED),
+            getAvailablePermissions: vi.fn().mockResolvedValue(PERMISSIONS),
+          } },
+        { provide: CommandService, useValue: {
+            execute: vi.fn().mockResolvedValue({ success: true, entity: CREATED }),
+          } },
+        { provide: ProjectService, useValue: { notifyTreeChanged: vi.fn() } },
+        { provide: UserService, useValue: {
+            listUsers: vi.fn().mockResolvedValue([
+              { id: 1, version: 0, username: 'alice', name: 'Alice', emailAddress: null,
+                phoneNumber: null, organizationName: null, roles: [], permissions: [],
+                permissionsByRole: null },
+            ]),
+          } },
+        { provide: PermissionService, useValue: {
+            loadForProject: vi.fn().mockResolvedValue(undefined),
+            canEdit: vi.fn().mockReturnValue(true),
+            canDelete: vi.fn().mockReturnValue(true),
+          } },
+        { provide: EventStreamService, useValue: {
+            events$: EMPTY,
+            addSubscription: vi.fn().mockResolvedValue(undefined),
+            removeSubscription: vi.fn().mockResolvedValue(undefined),
+          } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
+    });
+    fixture = TestBed.createComponent(StakeholderEditorComponent);
+    comp = fixture.componentInstance;
+    const router = TestBed.inject(Router);
+    vi.spyOn(router, 'navigate').mockResolvedValue(true);
+  }
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  async function settle(): Promise<void> {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  async function renderWizard(): Promise<HTMLElement> {
+    fixture.detectChanges();
+    await flush();
+    await settle();
+    const wizard = fixture.nativeElement.querySelector('[data-testid="stakeholder-wizard"]');
+    expect(wizard).not.toBeNull();
+    return wizard as HTMLElement;
+  }
+
+  it('renders the wizard with the step nav labelled and Details current', async () => {
+    setup('new-nonuser');
+    const wizard = await renderWizard();
+    expect(wizard.querySelector('nav')!.getAttribute('aria-label')).toBe('New stakeholder steps');
+    expect(wizard.querySelector('[aria-current="step"]')!.textContent).toContain('Details');
+  });
+
+  it('has no axe-core violations on the non-user Details step', async () => {
+    setup('new-nonuser');
+    await expectNoAxeViolations(await renderWizard());
+  });
+
+  it('has no axe-core violations with the name field in the error state', async () => {
+    setup('new-nonuser');
+    const wizard = await renderWizard();
+    comp.submitted.set(true);
+    comp.detailsForm.controls.name.setValue('');
+    comp.detailsForm.markAllAsTouched();
+    await settle();
+    expect(wizard.textContent).toContain('A stakeholder needs a name.');
+    await expectNoAxeViolations(wizard);
+  });
+
+  it('has no axe-core violations on the user Details step, permission matrix included', async () => {
+    setup('new-user');
+    const wizard = await renderWizard();
+    // The matrix must actually be rendered or this asserts nothing.
+    expect(wizard.querySelector('[data-testid="stakeholder-perm-edit_goal"]')).not.toBeNull();
+    await expectNoAxeViolations(wizard);
+  });
+
+  it('gives every permission checkbox its own accessible name', async () => {
+    setup('new-user');
+    const wizard = await renderWizard();
+    // The column header alone is not an accessible name - each box carries a hidden label.
+    for (const key of ['edit_goal', 'delete_goal']) {
+      const label = wizard.querySelector(`label[for="perm-${key}"]`);
+      expect(label, `missing label for ${key}`).not.toBeNull();
+      expect(label!.textContent!.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('has no axe-core violations on the Goals step', async () => {
+    setup('new-nonuser');
+    const wizard = await renderWizard();
+    comp.detailsForm.controls.name.setValue('FASB');
+    await settle();
+    (wizard.querySelector('[data-testid="wizard-continue"] button') as HTMLButtonElement).click();
+    await flush();
+    await settle();
+    expect(comp.wizardStep).toBe('goals');
+    await expectNoAxeViolations(wizard);
+  });
+});

--- a/requel-angular/src/app/features/stakeholders/stakeholder-editor.a11y.spec.ts
+++ b/requel-angular/src/app/features/stakeholders/stakeholder-editor.a11y.spec.ts
@@ -147,4 +147,32 @@ describe('StakeholderEditorComponent - create wizard accessibility', () => {
     expect(comp.wizardStep).toBe('goals');
     await expectNoAxeViolations(wizard);
   });
+
+  // Regression guard for the e2e contract. The Playwright page objects address these controls
+  // by DOM id - locator('#name'), locator('#text') - because that is the convention app-field
+  // established (controlId on the field, matching id on the control; see term-editor). The
+  // #173 conversion dropped the ids and let app-field generate them, so #name matched nothing
+  // and 23 e2e tests failed while every unit test stayed green. Nothing here asserted the
+  // association, so nothing caught it.
+  it('keeps the stable control ids the e2e page objects address', async () => {
+    setup('new-nonuser');
+    const wizard = await renderWizard();
+    {
+      const el = wizard.querySelector('#name');
+      expect(el, 'missing #name - e2e page objects locate this control by id').not.toBeNull();
+      expect(el!.tagName).toBe('INPUT');
+      // The label must point at that same id, or the id is present but unassociated.
+      const label = wizard.querySelector('label[for="name"]');
+      expect(label, 'no <label for="name">').not.toBeNull();
+    }
+    {
+      const el = wizard.querySelector('#text');
+      expect(el, 'missing #text - e2e page objects locate this control by id').not.toBeNull();
+      expect(el!.tagName).toBe('TEXTAREA');
+      // The label must point at that same id, or the id is present but unassociated.
+      const label = wizard.querySelector('label[for="text"]');
+      expect(label, 'no <label for="text">').not.toBeNull();
+    }
+  });
+
 });

--- a/requel-angular/src/app/features/stakeholders/stakeholder-editor.spec.ts
+++ b/requel-angular/src/app/features/stakeholders/stakeholder-editor.spec.ts
@@ -121,8 +121,8 @@ describe('StakeholderEditorComponent', () => {
   it('onSave calls execute("EditUserStakeholder") for user-type stakeholder', async () => {
     fixture.detectChanges();
     await flush();
-    comp.username = 'alice';
-    comp.teamName = 'Engineering';
+    comp.detailsForm.patchValue({ username: 'alice', teamName: 'Engineering' });
+    comp.detailsForm.markAsDirty();
     await comp.onSave();
     expect(commandServiceMock.execute).toHaveBeenCalledWith('EditUserStakeholder', expect.objectContaining({
       projectName: 'proj1',
@@ -135,14 +135,124 @@ describe('StakeholderEditorComponent', () => {
     paramMap$.next(convertToParamMap({ name: 'proj1', stakeholderId: 'new-nonuser' }));
     fixture.detectChanges();
     await flush();
-    comp.stakeholderName.set('FASB');
-    comp.text = 'Financial authority';
+    comp.detailsForm.patchValue({ name: 'FASB', text: 'Financial authority' });
+    comp.detailsForm.markAsDirty();
     await comp.onSave();
     expect(commandServiceMock.execute).toHaveBeenCalledWith('EditNonUserStakeholder', expect.objectContaining({
       projectName: 'proj1',
       name: 'FASB',
       text: 'Financial authority'
     }));
+  });
+
+  // #173: permissions moved from mutating perm.checked into their own FormRecord, so dirtiness
+  // is form state rather than a string-join comparison against originalPermissionKeys.
+  describe('permissions form (#173)', () => {
+    it('builds one control per permission key, pristine after load', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', stakeholderId: '50' }));
+      fixture.detectChanges();
+      await flush();
+
+      expect(Object.keys(comp.permissionsForm.controls).sort()).toEqual(['delete_goal', 'edit_goal']);
+      expect(comp.permissionControl('edit_goal').value).toBe(true);
+      expect(comp.permissionControl('delete_goal').value).toBe(false);
+      // Loading is not an edit - otherwise the unsaved-changes guard arms on open.
+      expect(comp.permissionsForm.dirty).toBe(false);
+      expect(comp.hasUnsavedChanges()).toBe(false);
+    });
+
+    it('ticking a permission alone marks the editor dirty', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', stakeholderId: '50' }));
+      fixture.detectChanges();
+      await flush();
+
+      comp.permissionControl('delete_goal').setValue(true);
+      comp.permissionControl('delete_goal').markAsDirty();
+
+      expect(comp.detailsForm.dirty).toBe(false);
+      expect(comp.hasUnsavedChanges()).toBe(true);
+      expect(comp.getSelectedPermissionKeys().sort()).toEqual(['delete_goal', 'edit_goal']);
+    });
+  });
+
+  // The mode's unused half is disabled, so its required validator cannot block Continue for a
+  // mode that never shows the field.
+  describe('mode switching (#173)', () => {
+    it('user mode enables username/team and disables name/text', async () => {
+      fixture.detectChanges();
+      await flush();
+      expect(comp.detailsForm.controls.username.enabled).toBe(true);
+      expect(comp.detailsForm.controls.name.disabled).toBe(true);
+    });
+
+    it('non-user mode enables name/text and disables username/team', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', stakeholderId: 'new-nonuser' }));
+      fixture.detectChanges();
+      await flush();
+      expect(comp.detailsForm.controls.name.enabled).toBe(true);
+      expect(comp.detailsForm.controls.username.disabled).toBe(true);
+      // A blank username must not make the non-user form invalid.
+      comp.detailsForm.controls.name.setValue('FASB');
+      expect(comp.detailsForm.valid).toBe(true);
+    });
+  });
+
+  // #173 required test (§10.3). Goal associations bump the stakeholder's @Version and return no
+  // entity, so the wizard refetches. Without that, returning to Details would 409.
+  describe('wizard version contract (#173)', () => {
+    it('survives create -> add goal -> back to Details -> edit -> Continue', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', stakeholderId: 'new-nonuser' }));
+      fixture.detectChanges();
+      await flush();
+
+      let version = 0;
+      commandServiceMock.execute.mockImplementation(async (type: string) => {
+        version += 1;
+        if (type === 'EditNonUserStakeholder') {
+          return { success: true, entity: { ...MOCK_STAKEHOLDER_NONUSER, id: 51, version } };
+        }
+        return { success: true, entity: null };
+      });
+      stakeholderServiceMock.getStakeholder.mockImplementation(async () => ({
+        ...MOCK_STAKEHOLDER_NONUSER, id: 51, version
+      }));
+
+      comp.detailsForm.controls.name.setValue('FASB');
+
+      const step1 = { step: { key: 'details' }, complete: vi.fn(), fail: vi.fn() };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await comp.onStepCommit(step1 as any);
+      expect(step1.complete).toHaveBeenCalled();
+
+      await comp.onGoalSelected({ id: 7, name: 'Avoid late fees', entityType: 'Goal' });
+
+      comp.detailsForm.controls.name.setValue('FASB Renamed');
+      const step3 = { step: { key: 'details' }, complete: vi.fn(), fail: vi.fn() };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await comp.onStepCommit(step3 as any);
+
+      expect(step3.complete).toHaveBeenCalled();
+      expect(step3.fail).not.toHaveBeenCalled();
+
+      const edits = commandServiceMock.execute.mock.calls.filter(c => c[0] === 'EditNonUserStakeholder');
+      const last = edits[edits.length - 1][1];
+      expect(last.name).toBe('FASB Renamed');
+      // Not the version captured at step 1 - that is the 409 this guards.
+      expect(last.version).not.toBe(1);
+    });
+
+    it('re-reads version after a goal association', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', stakeholderId: '50' }));
+      fixture.detectChanges();
+      await flush();
+
+      commandServiceMock.execute.mockResolvedValue({ success: true, entity: null });
+      stakeholderServiceMock.getStakeholder.mockResolvedValue({ ...MOCK_STAKEHOLDER_USER, version: 6 });
+
+      await comp.onGoalSelected({ id: 7, name: 'Avoid late fees', entityType: 'Goal' });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((comp as any).version).toBe(6);
+    });
   });
 
   it('canDelete() set from permissionService on init', async () => {

--- a/requel-angular/src/app/features/stakeholders/stakeholder-editor.ts
+++ b/requel-angular/src/app/features/stakeholders/stakeholder-editor.ts
@@ -185,9 +185,9 @@ interface PermissionGroup {
             </app-field>
           }
 
-          <app-field label="Team" [control]="detailsForm.controls.teamName"
+          <app-field label="Team" controlId="team" [control]="detailsForm.controls.teamName"
                      [divider]="permissionGroups().length === 0" [submitted]="submitted()">
-            <input appFieldControl pInputText [formControl]="detailsForm.controls.teamName"
+            <input appFieldControl pInputText [formControl]="detailsForm.controls.teamName" id="team"
                    placeholder="Team name" data-testid="stakeholder-team" />
           </app-field>
 
@@ -224,16 +224,16 @@ interface PermissionGroup {
             </div>
           }
         } @else {
-          <app-field label="Name" [control]="detailsForm.controls.name"
+          <app-field label="Name" controlId="name" [control]="detailsForm.controls.name"
                      [errorMessages]="nameErrors" [submitted]="submitted()">
-            <input appFieldControl pInputText [formControl]="detailsForm.controls.name"
+            <input appFieldControl pInputText [formControl]="detailsForm.controls.name" id="name"
                    [attr.maxlength]="nameMaxLength"
                    placeholder="Stakeholder name" data-testid="stakeholder-name" />
           </app-field>
 
-          <app-field label="Description" [control]="detailsForm.controls.text" [divider]="false"
+          <app-field label="Description" controlId="text" [control]="detailsForm.controls.text" [divider]="false"
                      [submitted]="submitted()">
-            <textarea appFieldControl pTextarea [formControl]="detailsForm.controls.text" rows="4"
+            <textarea appFieldControl pTextarea [formControl]="detailsForm.controls.text" id="text" rows="4"
                       placeholder="Description of this stakeholder"
                       data-testid="stakeholder-text"></textarea>
           </app-field>

--- a/requel-angular/src/app/features/stakeholders/stakeholder-editor.ts
+++ b/requel-angular/src/app/features/stakeholders/stakeholder-editor.ts
@@ -22,9 +22,10 @@ import { Component, computed, OnDestroy, OnInit, signal } from '@angular/core';
 import { PageHeaderComponent } from '../../shared/page-header';
 import { AppCardComponent } from '../../shared/app-card';
 import { ActivatedRoute, Router } from '@angular/router';
+import { NgTemplateOutlet } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
-import { FormsModule } from '@angular/forms';
+import { FormControl, FormGroup, FormRecord, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
 import { InputText } from 'primeng/inputtext';
 import { TextareaModule } from 'primeng/textarea';
@@ -43,6 +44,34 @@ import { UserService } from '../../core/user.service';
 import { PermissionService } from '../../core/permission.service';
 import { EventStreamService } from '../../core/event-stream.service';
 import { EntitySelectorDialogComponent } from '../../shared/entity-selector-dialog';
+import { AppFieldComponent, AppFieldControlDirective } from '../../shared/app-field';
+import {
+  AppFormWizardComponent,
+  AppWizardStepComponent,
+  WizardCommitRequest,
+} from '../../shared/app-form-wizard';
+import { applyCommandErrors, clearServerErrors } from '../../shared/form-errors';
+import { ARTIFACT_NAME_MAX_LENGTH } from '../../shared/validation-limits';
+import { CommandResult } from '../../models/command';
+
+/**
+ * JPA entity property name -> form control name, for {@link applyCommandErrors}.
+ *
+ * The two save commands spell things differently from the entities they write:
+ * `EditUserStakeholderInput` carries `username`/`teamName`, `EditNonUserStakeholderInput`
+ * carries `name`/`text`. #176 deletes this map.
+ */
+const STAKEHOLDER_FIELD_MAP: Record<string, string> = {
+  teamName: 'teamName',
+  text: 'text',
+};
+
+/** Joins page-level violations that resolved to no control. */
+const SEPARATOR = '; ';
+
+/** Wording for the stale-version recovery path, so the 409 case reads as recoverable. */
+const STALE_VERSION_MESSAGE =
+  'This stakeholder was changed elsewhere. Your copy has been refreshed - review the values and continue.';
 
 interface PermissionGroup {
   entityType: string;
@@ -52,9 +81,11 @@ interface PermissionGroup {
 @Component({
   selector: 'app-stakeholder-editor',
   standalone: true,
-  imports: [PageHeaderComponent, AppCardComponent, FormsModule, ButtonModule, InputText, TextareaModule, SelectModule,
+  imports: [PageHeaderComponent, AppCardComponent, NgTemplateOutlet, ReactiveFormsModule,
+            ButtonModule, InputText, TextareaModule, SelectModule,
             CheckboxModule, MessageModule, ConfirmDialogModule, TableModule,
-            EntitySelectorDialogComponent],
+            EntitySelectorDialogComponent, AppFieldComponent, AppFieldControlDirective,
+            AppFormWizardComponent, AppWizardStepComponent],
   providers: [ConfirmationService],
   template: `
     <div class="stakeholder-editor">
@@ -74,43 +105,117 @@ interface PermissionGroup {
         <p-message severity="error" [text]="errorMessage()!" />
       }
 
-      <app-card>
-        <div class="form-grid">
-          @if (isUserType()) {
-            <label for="username">User</label>
-            <p-select id="username" [(ngModel)]="username" [options]="userOptions()"
+      @if (isNew()) {
+        <!--
+          Create runs as a wizard (#173) so Goals is reachable before the first save. The User
+          select stays on step 1 and stays [disabled]="!isNew()" - it is the mode selector, and
+          EditUserStakeholder is keyed by username, so it can never change after creation.
+        -->
+        <app-form-wizard
+          [(activeKey)]="wizardStep"
+          navLabel="New stakeholder steps"
+          (stepCommit)="onStepCommit($event)"
+          (cancelled)="onBack()"
+          (finished)="onWizardFinished()"
+          data-testid="stakeholder-wizard"
+        >
+          <app-wizard-step key="details" label="Details"
+                           [helper]="isUserType() ? 'User, team and permissions' : 'Name and description'"
+                           [form]="detailsForm">
+            <ng-template>
+              <ng-container [ngTemplateOutlet]="detailsFields" />
+            </ng-template>
+          </app-wizard-step>
+
+          <app-wizard-step key="goals" label="Goals" helper="Link goals to this stakeholder"
+                           [optional]="true">
+            <ng-template>
+              <!-- heading: false - the wizard panel's own h2 already reads "Goals". -->
+              <ng-container [ngTemplateOutlet]="goalsSection"
+                            [ngTemplateOutletContext]="{ heading: false }" />
+            </ng-template>
+          </app-wizard-step>
+        </app-form-wizard>
+      } @else {
+        <app-card>
+          <ng-container [ngTemplateOutlet]="detailsFields" />
+
+          <div class="form-actions">
+            <p-button label="Save" icon="pi pi-check" data-testid="stakeholder-save"
+                      [disabled]="!canSave()" [loading]="saving()" (onClick)="onSave()" />
+          </div>
+        </app-card>
+
+        <ng-container [ngTemplateOutlet]="goalsSection"
+                      [ngTemplateOutletContext]="{ heading: true }" />
+      }
+
+      <app-entity-selector-dialog
+        [visible]="showGoalSelector"
+        [projectName]="projectName"
+        entityType="Goal"
+        [excludeIds]="goalIds()"
+        (selected)="onGoalSelected($event)"
+        (closed)="showGoalSelector = false" />
+
+      <p-confirmDialog />
+
+      <!--
+        Shared bodies, used by both the wizard step and the edit view so the two cannot drift.
+        Controls bind [formControl], not formControlName: these are projected into the wizard,
+        where formControlName would look for a parent formGroup that is not there.
+      -->
+      <ng-template #detailsFields>
+        @if (isUserType()) {
+          <app-field label="User" controlId="stakeholderUserInput"
+                     [control]="detailsForm.controls.username"
+                     [errorMessages]="usernameErrors" [submitted]="submitted()">
+            <p-select appFieldControl inputId="stakeholderUserInput" data-testid="stakeholder-user"
+                      [formControl]="detailsForm.controls.username" [options]="userOptions()"
                       optionLabel="label" optionValue="value"
-                      placeholder="Select a user" [filter]="true"
-                      [disabled]="!isNew()" />
+                      placeholder="Select a user" [filter]="true" />
+          </app-field>
 
-            @if (loadedUserDetails(); as ud) {
-              <label>Email</label>
+          @if (loadedUserDetails(); as ud) {
+            <app-field label="Email">
               <span class="readonly-field">{{ ud.emailAddress || '—' }}</span>
-
-              <label>Phone</label>
+            </app-field>
+            <app-field label="Phone">
               <span class="readonly-field">{{ ud.phoneNumber || '—' }}</span>
-            }
-
-            <label for="team">Team</label>
-            <input id="team" pInputText [(ngModel)]="teamName" placeholder="Team name"
-                   (ngModelChange)="trackChanges()" />
+            </app-field>
           }
 
-          @if (isUserType() && permissionGroups().length > 0) {
+          <app-field label="Team" [control]="detailsForm.controls.teamName"
+                     [divider]="permissionGroups().length === 0" [submitted]="submitted()">
+            <input appFieldControl pInputText [formControl]="detailsForm.controls.teamName"
+                   placeholder="Team name" data-testid="stakeholder-team" />
+          </app-field>
+
+          @if (permissionGroups().length > 0) {
             <div class="permissions-section">
-              <h3>Permissions</h3>
-              <div class="permission-grid">
+              <!-- h3 under the card/panel heading, not a page-level section title. -->
+              <h3 id="stakeholder-permissions-heading">Permissions</h3>
+              <div class="permission-grid" role="group"
+                   aria-labelledby="stakeholder-permissions-heading">
                 <div class="permission-header"></div>
                 <div class="permission-header">Edit</div>
                 <div class="permission-header">Delete</div>
                 <div class="permission-header">Grant</div>
                 @for (group of permissionGroups(); track group.entityType) {
                   <div class="permission-entity">{{ group.entityType }}</div>
-                  @for (type of ['Edit', 'Delete', 'Grant']; track type) {
+                  @for (type of permissionTypes; track type) {
                     <div class="permission-check">
                       @if (getPermission(group, type); as perm) {
-                        <p-checkbox [(ngModel)]="perm.checked" [binary]="true"
-                                    [name]="perm.key" (onChange)="trackChanges()" />
+                        <p-checkbox [formControl]="permissionControl(perm.key)" [binary]="true"
+                                    [inputId]="'perm-' + perm.key"
+                                    [attr.data-testid]="'stakeholder-perm-' + perm.key" />
+                        <!--
+                          Each checkbox needs its own name; the column header alone is not an
+                          accessible name. Visually hidden so the grid still reads as a matrix.
+                        -->
+                        <label class="rq-visually-hidden" [attr.for]="'perm-' + perm.key">
+                          {{ type }} {{ group.entityType }}
+                        </label>
                       }
                     </div>
                   }
@@ -118,75 +223,74 @@ interface PermissionGroup {
               </div>
             </div>
           }
+        } @else {
+          <app-field label="Name" [control]="detailsForm.controls.name"
+                     [errorMessages]="nameErrors" [submitted]="submitted()">
+            <input appFieldControl pInputText [formControl]="detailsForm.controls.name"
+                   [attr.maxlength]="nameMaxLength"
+                   placeholder="Stakeholder name" data-testid="stakeholder-name" />
+          </app-field>
 
-          @if (!isUserType()) {
-            <label for="name">Name</label>
-            <input id="name" pInputText [(ngModel)]="stakeholderName" placeholder="Stakeholder name"
-                   (ngModelChange)="trackChanges()" />
-
-            <label for="text">Description</label>
-            <textarea id="text" pTextarea [(ngModel)]="text" rows="4"
+          <app-field label="Description" [control]="detailsForm.controls.text" [divider]="false"
+                     [submitted]="submitted()">
+            <textarea appFieldControl pTextarea [formControl]="detailsForm.controls.text" rows="4"
                       placeholder="Description of this stakeholder"
-                      (ngModelChange)="trackChanges()"></textarea>
-          }
-        </div>
+                      data-testid="stakeholder-text"></textarea>
+          </app-field>
+        }
+      </ng-template>
 
-        <div class="form-actions">
-          <p-button label="Save" icon="pi pi-check" (onClick)="onSave()" [loading]="saving()"
-                    [disabled]="!isNew() && !hasChanges()" />
-        </div>
-      </app-card>
-
-      @if (!isNew()) {
+      <ng-template #goalsSection let-heading="heading">
         <div class="section">
           <div class="section-header">
-            <h3>Goals</h3>
-            @if (canEditGoals()) {
+            @if (heading) {
+              <h2 class="rq-section-title">Goals</h2>
+            }
+            @if (canEditGoals() && stakeholderId != null) {
               <p-button label="Add Goal" icon="pi pi-plus" size="small"
+                        data-testid="stakeholder-add-goal"
                         [text]="true" (onClick)="showGoalSelector = true" />
             }
           </div>
 
-          <p-table [value]="goals()" [rowHover]="true">
-            <ng-template #header>
-              <tr>
-                <th>Name</th>
-                @if (canEditGoals()) { <th class="col-actions"></th> }
-              </tr>
-            </ng-template>
-            <ng-template #body let-g>
-              <tr>
-                <td class="entity-link" (click)="onGoalClick(g)">{{ g.name }}</td>
-                @if (canEditGoals()) {
-                  <td>
-                    <p-button icon="pi pi-times" severity="danger" [text]="true"
-                              size="small" (onClick)="onRemoveGoal(g)" />
-                  </td>
-                }
-              </tr>
-            </ng-template>
-            <ng-template #emptymessage>
-              <tr><td [attr.colspan]="canEditGoals() ? 2 : 1" class="empty-text">No goals assigned.</td></tr>
-            </ng-template>
-          </p-table>
+          @if (stakeholderId == null) {
+            <p class="empty-text">Save the stakeholder's details first to add goals.</p>
+          } @else {
+            <p-table [value]="goals()" [rowHover]="true">
+              <ng-template #header>
+                <tr>
+                  <th>Name</th>
+                  @if (canEditGoals()) {
+                    <!-- An empty <th> is an axe empty-table-header violation. -->
+                    <th class="col-actions"><span class="rq-visually-hidden">Actions</span></th>
+                  }
+                </tr>
+              </ng-template>
+              <ng-template #body let-g>
+                <tr>
+                  <td class="entity-link" (click)="onGoalClick(g)">{{ g.name }}</td>
+                  @if (canEditGoals()) {
+                    <td>
+                      <p-button icon="pi pi-times" severity="danger" [text]="true"
+                                data-testid="stakeholder-remove-goal"
+                                [ariaLabel]="'Remove goal ' + g.name"
+                                size="small" (onClick)="onRemoveGoal(g)" />
+                    </td>
+                  }
+                </tr>
+              </ng-template>
+              <ng-template #emptymessage>
+                <tr><td [attr.colspan]="canEditGoals() ? 2 : 1" class="empty-text">No goals assigned.</td></tr>
+              </ng-template>
+            </p-table>
+          }
         </div>
-
-        <app-entity-selector-dialog
-          [visible]="showGoalSelector"
-          [projectName]="projectName"
-          entityType="Goal"
-          [excludeIds]="goalIds()"
-          (selected)="onGoalSelected($event)"
-          (closed)="showGoalSelector = false" />
-      }
-
-      <p-confirmDialog />
+      </ng-template>
     </div>
   `,
   styles: [`
     .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
     .page-actions { display: flex; gap: 0.5rem; }
-    .form-grid { display: grid; grid-template-columns: 120px 1fr; gap: 0.75rem 1rem; align-items: center; max-width: 600px; }
     .readonly-field { color: var(--p-text-color); padding: 0.5rem 0; }
     .form-actions { margin-top: 1rem; }
     .permissions-section { grid-column: 1 / -1; margin-top: 0.5rem; }
@@ -214,20 +318,47 @@ export class StakeholderEditorComponent implements OnInit, OnDestroy, DirtyCheck
   permissionGroups = signal<PermissionGroup[]>([]);
   goals = signal<EntityReferenceDto[]>([]);
   goalIds = computed(() => this.goals().map(g => g.id).filter((id): id is number => id != null));
-  hasChanges = signal(false);
+  submitted = signal(false);
 
-  username = '';
-  teamName = '';
-  text = '';
   showGoalSelector = false;
 
-  private originalTeamName = '';
-  private originalPermissionKeys = '';
-  private originalName = '';
-  private originalText = '';
+  /** Column order of the permission matrix; was an inline array literal in the template. */
+  readonly permissionTypes = ['Edit', 'Delete', 'Grant'];
+
+  /** Mirrors the backend `@Size(max = ValidationLimits.ARTIFACT_NAME_MAX)` (#171). */
+  readonly nameMaxLength = ARTIFACT_NAME_MAX_LENGTH;
+
+  /**
+   * Details step / edit form for BOTH modes. The irrelevant half is disabled rather than
+   * omitted: disabled controls are excluded from `value` and from validity, so one form can
+   * drive the wizard's `[form]` binding whichever mode the route asked for, and `getRawValue`
+   * still reaches whatever a mode needs.
+   */
+  readonly detailsForm = new FormGroup({
+    username: new FormControl('', { validators: [Validators.required], nonNullable: true }),
+    teamName: new FormControl('', { nonNullable: true }),
+    name: new FormControl('', {
+      validators: [Validators.required, Validators.maxLength(ARTIFACT_NAME_MAX_LENGTH)],
+      nonNullable: true,
+    }),
+    text: new FormControl('', { nonNullable: true }),
+  });
+
+  /**
+   * One boolean control per permission key, rebuilt whenever the matrix loads. Keeping these in
+   * a form rather than mutating `perm.checked` is what lets `hasUnsavedChanges()` be pure form
+   * state instead of the old string-join comparison against `originalPermissionKeys`.
+   */
+  readonly permissionsForm = new FormRecord<FormControl<boolean>>({});
+
+  readonly nameErrors = { required: 'A stakeholder needs a name.' };
+  readonly usernameErrors = { required: 'Select a user.' };
+
+  /** Active wizard step key, two-way bound to `app-form-wizard`. */
+  wizardStep = 'details';
 
   projectName = '';
-  private stakeholderId: number | null = null;
+  stakeholderId: number | null = null;
   private version: number | null = null;
   private paramSub?: Subscription;
   private sseSub?: Subscription;
@@ -253,13 +384,11 @@ export class StakeholderEditorComponent implements OnInit, OnDestroy, DirtyCheck
 
       const idParam = params.get('stakeholderId') ?? '';
       if (idParam === 'new-user') {
-        this.isNew.set(true);
-        this.isUserType.set(true);
+        this.resetForCreate(true);
         this.loadUsers();
         this.loadPermissions([]);
       } else if (idParam === 'new-nonuser') {
-        this.isNew.set(true);
-        this.isUserType.set(false);
+        this.resetForCreate(false);
       } else {
         this.isNew.set(false);
         this.stakeholderId = +idParam;
@@ -268,8 +397,53 @@ export class StakeholderEditorComponent implements OnInit, OnDestroy, DirtyCheck
     });
   }
 
+  private resetForCreate(isUser: boolean): void {
+    this.isNew.set(true);
+    this.isUserType.set(isUser);
+    this.stakeholderId = null;
+    this.version = null;
+    this.wizardStep = 'details';
+    this.submitted.set(false);
+    this.goals.set([]);
+    this.detailsForm.reset({ username: '', teamName: '', name: '', text: '' });
+    this.applyMode(isUser);
+  }
+
+  /**
+   * Permissions live in their own form, so dirtiness is either half. `detailsForm.dirty` alone
+   * would miss a user who only ticked a permission box.
+   */
   hasUnsavedChanges(): boolean {
-    return this.hasChanges();
+    return this.detailsForm.dirty || this.permissionsForm.dirty;
+  }
+
+  /** Edit-mode Save: blocked on invalid, unchanged, or in-flight. */
+  canSave(): boolean {
+    return this.detailsForm.valid && this.hasUnsavedChanges() && !this.saving();
+  }
+
+  /**
+   * Enables the half of the form the current mode uses and disables the other, so a disabled
+   * control's `required` cannot block Continue for a mode that does not show it.
+   */
+  private applyMode(isUser: boolean): void {
+    const { username, teamName, name, text } = this.detailsForm.controls;
+    if (isUser) {
+      username.enable({ emitEvent: false });
+      teamName.enable({ emitEvent: false });
+      name.disable({ emitEvent: false });
+      text.disable({ emitEvent: false });
+    } else {
+      username.disable({ emitEvent: false });
+      teamName.disable({ emitEvent: false });
+      name.enable({ emitEvent: false });
+      text.enable({ emitEvent: false });
+    }
+  }
+
+  /** The control backing one permission checkbox. */
+  permissionControl(key: string): FormControl<boolean> {
+    return this.permissionsForm.controls[key];
   }
 
   ngOnDestroy(): void {
@@ -294,23 +468,27 @@ export class StakeholderEditorComponent implements OnInit, OnDestroy, DirtyCheck
       const s = await this.stakeholderService.getStakeholder(this.projectName, this.stakeholderId!);
       this.stakeholderName.set(s.name);
       this.version = s.version;
-      this.isUserType.set(s.type === 'user');
+      const isUser = s.type === 'user';
+      this.isUserType.set(isUser);
+      this.applyMode(isUser);
       this.goals.set(s.goals ?? []);
 
       if (s.userDetails) {
         this.loadedUserDetails.set(s.userDetails);
-        this.username = s.userDetails.username;
-        this.teamName = s.userDetails.teamName ?? '';
-        this.originalTeamName = this.teamName;
+        this.detailsForm.patchValue({
+          username: s.userDetails.username,
+          teamName: s.userDetails.teamName ?? '',
+        }, { emitEvent: false });
         await this.loadUsers();
         await this.loadPermissions(s.userDetails.permissionKeys);
-        this.originalPermissionKeys = this.getSelectedPermissionKeys().sort().join(',');
       } else if (s.nonUserDetails) {
-        this.text = s.nonUserDetails.text;
-        this.originalName = s.name;
-        this.originalText = this.text;
+        this.detailsForm.patchValue({
+          name: s.name,
+          text: s.nonUserDetails.text,
+        }, { emitEvent: false });
       }
-      this.hasChanges.set(false);
+      this.detailsForm.markAsPristine();
+      this.permissionsForm.markAsPristine();
     } catch {
       this.errorMessage.set('Failed to load stakeholder.');
     }
@@ -321,21 +499,6 @@ export class StakeholderEditorComponent implements OnInit, OnDestroy, DirtyCheck
           void this.loadStakeholder();
         }
       });
-    }
-  }
-
-  trackChanges(): void {
-    if (this.isUserType()) {
-      const permKeys = this.getSelectedPermissionKeys().sort().join(',');
-      this.hasChanges.set(
-        this.teamName !== this.originalTeamName ||
-        permKeys !== this.originalPermissionKeys
-      );
-    } else {
-      this.hasChanges.set(
-        this.stakeholderName() !== this.originalName ||
-        this.text !== this.originalText
-      );
     }
   }
 
@@ -353,8 +516,9 @@ export class StakeholderEditorComponent implements OnInit, OnDestroy, DirtyCheck
         containerType: 'Stakeholder'
       });
       if (result.success) {
-        this.messageService.add({ severity: 'success', summary: 'Goal added', detail: 'Goal added.' });
         this.goals.update(list => [...list, goal].sort((a, b) => a.name.localeCompare(b.name)));
+        await this.refreshVersionAfterAssociation();
+        this.messageService.add({ severity: 'success', summary: 'Goal added', detail: 'Goal added.' });
       } else {
         this.errorMessage.set(result.error ?? 'Failed to add goal.');
       }
@@ -372,13 +536,36 @@ export class StakeholderEditorComponent implements OnInit, OnDestroy, DirtyCheck
         containerType: 'Stakeholder'
       });
       if (result.success) {
-        this.messageService.add({ severity: 'success', summary: 'Goal removed', detail: 'Goal removed.' });
         this.goals.update(list => list.filter(g => g.id !== goal.id));
+        await this.refreshVersionAfterAssociation();
+        this.messageService.add({ severity: 'success', summary: 'Goal removed', detail: 'Goal removed.' });
       } else {
         this.errorMessage.set(result.error ?? 'Failed to remove goal.');
       }
     } catch {
       this.errorMessage.set('Failed to remove goal.');
+    }
+  }
+
+  /**
+   * Re-reads the version after a goal association changes.
+   *
+   * Add/RemoveGoalFromGoalContainer merge the container - this stakeholder - so each bumps its
+   * `@Version`, but they register no result extractor, so `result.entity` is null and a refetch
+   * is the only way to see the new value. Without it, adding a goal then saving 409s. Same bug
+   * and same fix as actor-editor (#173 slice 2); #178/#180 remove the refetch.
+   *
+   * Narrow on purpose: `version` only, never the form, so an in-progress edit survives.
+   */
+  private async refreshVersionAfterAssociation(): Promise<void> {
+    if (this.stakeholderId == null) {
+      return;
+    }
+    try {
+      const s = await this.stakeholderService.getStakeholder(this.projectName, this.stakeholderId);
+      this.version = s.version;
+    } catch {
+      // Leave the held version alone; the existing 409 path recovers on the next save.
     }
   }
 
@@ -406,6 +593,20 @@ export class StakeholderEditorComponent implements OnInit, OnDestroy, DirtyCheck
           .map(([entityType, permissions]) => ({ entityType, permissions }))
           .sort((a, b) => a.entityType.localeCompare(b.entityType));
       this.permissionGroups.set(groups);
+
+      // Rebuild the checkbox controls to match, then mark the whole set pristine: loading is
+      // not a user edit, and leaving it dirty would arm the unsaved-changes guard on open.
+      for (const key of Object.keys(this.permissionsForm.controls)) {
+        this.permissionsForm.removeControl(key, { emitEvent: false });
+      }
+      for (const perm of groups.flatMap(g => g.permissions)) {
+        this.permissionsForm.addControl(
+          perm.key,
+          new FormControl(perm.checked, { nonNullable: true }),
+          { emitEvent: false }
+        );
+      }
+      this.permissionsForm.markAsPristine();
     } catch {
       this.errorMessage.set('Failed to load permissions.');
     }
@@ -416,75 +617,150 @@ export class StakeholderEditorComponent implements OnInit, OnDestroy, DirtyCheck
   }
 
   getSelectedPermissionKeys(): string[] {
-    return this.permissionGroups()
-        .flatMap(g => g.permissions)
-        .filter(p => p.checked)
-        .map(p => p.key);
+    return Object.entries(this.permissionsForm.controls)
+        .filter(([, control]) => control.value)
+        .map(([key]) => key);
   }
 
-  async onSave(): Promise<void> {
+  /**
+   * Runs the commit for the wizard's current step. Only Details talks to the API; the Goals
+   * step's associations commit through the selector as the user works.
+   */
+  async onStepCommit(request: WizardCommitRequest): Promise<void> {
+    if (request.step.key !== 'details') {
+      request.complete();
+      return;
+    }
+
+    this.submitted.set(true);
+    const result = await this.saveDetails();
+
+    if (result.success) {
+      request.complete();
+      return;
+    }
+    if (await this.recoverFromStaleVersion(result)) {
+      request.fail(STALE_VERSION_MESSAGE);
+      return;
+    }
+    request.fail(result.error ?? 'Save failed.');
+  }
+
+  /** Done on the last step: the stakeholder is already saved, so just go to it. */
+  onWizardFinished(): void {
+    if (this.stakeholderId != null) {
+      this.router.navigate(['..', this.stakeholderId], { relativeTo: this.route });
+    } else {
+      this.onBack();
+    }
+  }
+
+  /**
+   * Issues whichever save command the mode calls for and, on success, adopts the id and
+   * version from the response.
+   *
+   * The two commands are not symmetric: `EditUserStakeholder` is keyed by `username` and takes
+   * no id, while `EditNonUserStakeholder` takes `stakeholderId` once one exists. That is why
+   * the payload is built per branch rather than shared.
+   *
+   * Note this no longer navigates on create. The old code routed away the moment a new
+   * stakeholder saved, which is exactly what made Goals unreachable until a second visit -
+   * the wizard captures the id instead and moves to step 2.
+   */
+  private async saveDetails(): Promise<CommandResult<unknown>> {
     this.saving.set(true);
     this.errorMessage.set(null);
-
+    clearServerErrors(this.detailsForm);
     try {
-      if (this.isUserType()) {
-        const input: Record<string, unknown> = {
-          projectName: this.projectName,
-          username: this.username,
-          teamName: this.teamName || null,
-          permissionKeys: this.getSelectedPermissionKeys(),
-        };
-        if (this.version != null) input['version'] = this.version;
-        const result = await this.commandService.execute('EditUserStakeholder', input);
-        if (result.success) {
-          this.messageService.add({ severity: 'success', summary: 'Saved', detail: 'Stakeholder saved.' });
-          if (this.isNew()) {
-            this.projectService.notifyTreeChanged();
-            if (result.entity) {
-              const saved = result.entity as StakeholderDto;
-              this.hasChanges.set(false);
-              this.router.navigate(['..', saved.id], { relativeTo: this.route });
-            }
-          } else {
-            this.originalTeamName = this.teamName;
-            this.originalPermissionKeys = this.getSelectedPermissionKeys().sort().join(',');
-            this.hasChanges.set(false);
+      const raw = this.detailsForm.getRawValue();
+      const isUser = this.isUserType();
+
+      const input: Record<string, unknown> = isUser
+        ? {
+            projectName: this.projectName,
+            username: raw.username,
+            teamName: raw.teamName || null,
+            permissionKeys: this.getSelectedPermissionKeys(),
           }
-        } else {
-          this.errorMessage.set(result.error ?? 'Save failed.');
+        : {
+            projectName: this.projectName,
+            name: raw.name,
+            text: raw.text,
+          };
+      if (!isUser && this.stakeholderId != null) input['stakeholderId'] = this.stakeholderId;
+      if (this.version != null) input['version'] = this.version;
+
+      const command = isUser ? 'EditUserStakeholder' : 'EditNonUserStakeholder';
+      const result = await this.commandService.execute(command, input);
+      if (!result.success) {
+        const unresolved = applyCommandErrors(this.detailsForm, result.violations, STAKEHOLDER_FIELD_MAP);
+        if (unresolved.length) {
+          this.errorMessage.set(unresolved.join(SEPARATOR));
         }
-      } else {
-        const input: Record<string, unknown> = {
-          projectName: this.projectName,
-          name: this.stakeholderName(),
-          text: this.text,
-        };
-        if (this.stakeholderId != null) input['stakeholderId'] = this.stakeholderId;
-        if (this.version != null) input['version'] = this.version;
-        const result = await this.commandService.execute('EditNonUserStakeholder', input);
-        if (result.success) {
-          this.messageService.add({ severity: 'success', summary: 'Saved', detail: 'Stakeholder saved.' });
-          if (this.isNew()) {
-            this.projectService.notifyTreeChanged();
-            if (result.entity) {
-              const saved = result.entity as StakeholderDto;
-              this.hasChanges.set(false);
-              this.router.navigate(['..', saved.id], { relativeTo: this.route });
-            }
-          } else {
-            this.originalName = this.stakeholderName();
-            this.originalText = this.text;
-            this.hasChanges.set(false);
-          }
-        } else {
-          this.errorMessage.set(result.error ?? 'Save failed.');
-        }
+        return result;
       }
+
+      const wasCreate = this.stakeholderId == null;
+      if (wasCreate) {
+        this.projectService.notifyTreeChanged();
+      }
+
+      const saved = result.entity as StakeholderDto | null;
+      if (saved) {
+        this.stakeholderId = saved.id;
+        this.version = saved.version;
+        this.stakeholderName.set(saved.name);
+      }
+      this.detailsForm.markAsPristine();
+      this.permissionsForm.markAsPristine();
+      this.messageService.add({ severity: 'success', summary: 'Saved', detail: 'Stakeholder saved.' });
+
+      if (wasCreate && this.stakeholderId != null) {
+        await this.loadStakeholder();
+      }
+      return result;
     } catch {
-      this.errorMessage.set('An unexpected error occurred.');
+      return {
+        success: false,
+        entityType: 'Stakeholder',
+        entity: null,
+        error: 'Save failed.',
+        violations: null,
+      };
     } finally {
       this.saving.set(false);
     }
+  }
+
+  /**
+   * If `result` is an optimistic-lock conflict (HTTP 409), refetch so the held version is
+   * current and the user can retry. Returns whether it handled the result.
+   */
+  private async recoverFromStaleVersion(result: CommandResult<unknown>): Promise<boolean> {
+    if (result.status !== 409 || this.stakeholderId == null) {
+      return false;
+    }
+    await this.loadStakeholder();
+    return true;
+  }
+
+  /** Edit-mode Save. */
+  async onSave(): Promise<void> {
+    this.submitted.set(true);
+    if (this.detailsForm.invalid) {
+      this.detailsForm.markAllAsTouched();
+      return;
+    }
+
+    const result = await this.saveDetails();
+    if (result.success) {
+      return;
+    }
+    if (await this.recoverFromStaleVersion(result)) {
+      this.errorMessage.set(STALE_VERSION_MESSAGE);
+      return;
+    }
+    this.errorMessage.set(result.error ?? 'Save failed.');
   }
 
   onDelete(): void {

--- a/requel-angular/src/app/features/use-cases/use-case-editor.a11y.spec.ts
+++ b/requel-angular/src/app/features/use-cases/use-case-editor.a11y.spec.ts
@@ -151,4 +151,31 @@ describe('UseCaseEditorComponent - create wizard accessibility', () => {
     expect(wizard.querySelector('[data-testid="use-case-actors-table"]')).not.toBeNull();
     await expectNoAxeViolations(wizard);
   });
+
+  // Regression guard for the e2e contract. The Playwright page objects address these controls
+  // by DOM id - locator('#name'), locator('#text') - because that is the convention app-field
+  // established (controlId on the field, matching id on the control; see term-editor). The
+  // #173 conversion dropped the ids and let app-field generate them, so #name matched nothing
+  // and 23 e2e tests failed while every unit test stayed green. Nothing here asserted the
+  // association, so nothing caught it.
+  it('keeps the stable control ids the e2e page objects address', async () => {
+    const wizard = await renderWizard();
+    {
+      const el = wizard.querySelector('#name');
+      expect(el, 'missing #name - e2e page objects locate this control by id').not.toBeNull();
+      expect(el!.tagName).toBe('INPUT');
+      // The label must point at that same id, or the id is present but unassociated.
+      const label = wizard.querySelector('label[for="name"]');
+      expect(label, 'no <label for="name">').not.toBeNull();
+    }
+    {
+      const el = wizard.querySelector('#text');
+      expect(el, 'missing #text - e2e page objects locate this control by id').not.toBeNull();
+      expect(el!.tagName).toBe('TEXTAREA');
+      // The label must point at that same id, or the id is present but unassociated.
+      const label = wizard.querySelector('label[for="text"]');
+      expect(label, 'no <label for="text">').not.toBeNull();
+    }
+  });
+
 });

--- a/requel-angular/src/app/features/use-cases/use-case-editor.a11y.spec.ts
+++ b/requel-angular/src/app/features/use-cases/use-case-editor.a11y.spec.ts
@@ -1,0 +1,154 @@
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter, Router, ActivatedRoute, convertToParamMap } from '@angular/router';
+import { Location } from '@angular/common';
+import { BehaviorSubject, EMPTY } from 'rxjs';
+import { MessageService } from 'primeng/api';
+import { UseCaseEditorComponent } from './use-case-editor';
+import { UseCaseService } from '../../core/use-case.service';
+import { ActorService } from '../../core/actor.service';
+import { ScenarioService } from '../../core/scenario.service';
+import { CommandService } from '../../core/command.service';
+import { ProjectService } from '../../core/project.service';
+import { PermissionService } from '../../core/permission.service';
+import { EventStreamService } from '../../core/event-stream.service';
+import { expectNoAxeViolations } from '../../shared/testing/a11y';
+
+const flush = () => new Promise(r => setTimeout(r, 0));
+
+const CREATED = {
+  id: 30, version: 1, name: 'Place order', text: '', primaryActorName: null,
+  scenarioId: null, scenarioName: null, scenarioStepCount: 0,
+  goals: [], stories: [], actors: [], additionalScenarios: [],
+};
+
+// #173: create is a four-step wizard here, and each step hosts its own tables. Every one gets an
+// axe pass, since the association tables are where the empty-header and unlabelled-action
+// problems live.
+describe('UseCaseEditorComponent - create wizard accessibility', () => {
+  let paramMap$: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fixture: any;
+  let comp: UseCaseEditorComponent;
+
+  beforeEach(() => {
+    paramMap$ = new BehaviorSubject(convertToParamMap({ name: 'proj1', useCaseId: 'new' }));
+
+    TestBed.configureTestingModule({
+      imports: [UseCaseEditorComponent],
+      providers: [
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: ActivatedRoute, useValue: { paramMap: paramMap$.asObservable() } },
+        { provide: Location, useValue: { back: vi.fn() } },
+        { provide: UseCaseService, useValue: { getUseCase: vi.fn().mockResolvedValue(CREATED) } },
+        { provide: ActorService, useValue: { listActors: vi.fn().mockResolvedValue([]) } },
+        { provide: ScenarioService, useValue: { getScenario: vi.fn().mockResolvedValue(null) } },
+        { provide: CommandService, useValue: {
+            execute: vi.fn().mockResolvedValue({ success: true, entity: CREATED }),
+          } },
+        { provide: ProjectService, useValue: { notifyTreeChanged: vi.fn() } },
+        { provide: PermissionService, useValue: {
+            loadForProject: vi.fn().mockResolvedValue(undefined),
+            canEdit: vi.fn().mockReturnValue(true),
+            canDelete: vi.fn().mockReturnValue(true),
+          } },
+        { provide: EventStreamService, useValue: {
+            events$: EMPTY,
+            addSubscription: vi.fn().mockResolvedValue(undefined),
+            removeSubscription: vi.fn().mockResolvedValue(undefined),
+          } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
+    });
+    fixture = TestBed.createComponent(UseCaseEditorComponent);
+    comp = fixture.componentInstance;
+    vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  async function settle(): Promise<void> {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  async function renderWizard(): Promise<HTMLElement> {
+    fixture.detectChanges();
+    await flush();
+    await settle();
+    const wizard = fixture.nativeElement.querySelector('[data-testid="use-case-wizard"]');
+    expect(wizard).not.toBeNull();
+    return wizard as HTMLElement;
+  }
+
+  /**
+   * Clicks Continue once. Assigning comp.wizardStep directly mutates the value the
+   * [(activeKey)] binding was checked with and throws NG0100, so every step change goes
+   * through the real control.
+   */
+  async function clickContinue(wizard: HTMLElement): Promise<void> {
+    (wizard.querySelector('[data-testid="wizard-continue"] button') as HTMLButtonElement).click();
+    await flush();
+    await settle();
+  }
+
+  /** Commits Details, which is what unlocks every later step. */
+  async function advancePastDetails(wizard: HTMLElement): Promise<void> {
+    comp.detailsForm.controls.name.setValue('Place order');
+    await settle();
+    await clickContinue(wizard);
+  }
+
+  it('renders four steps with the nav labelled and Details current', async () => {
+    const wizard = await renderWizard();
+    expect(wizard.querySelector('nav')!.getAttribute('aria-label')).toBe('New use case steps');
+    expect(wizard.querySelectorAll('.app-wizard-step').length).toBe(4);
+    expect(wizard.querySelector('[aria-current="step"]')!.textContent).toContain('Details');
+  });
+
+  it('has no axe-core violations on the Details step', async () => {
+    await expectNoAxeViolations(await renderWizard());
+  });
+
+  it('has no axe-core violations with the name field in the error state', async () => {
+    const wizard = await renderWizard();
+    comp.submitted.set(true);
+    comp.detailsForm.controls.name.setValue('');
+    comp.detailsForm.markAllAsTouched();
+    await settle();
+    expect(wizard.textContent).toContain('A use case needs a name.');
+    await expectNoAxeViolations(wizard);
+  });
+
+  it('has no axe-core violations on the Scenarios step', async () => {
+    const wizard = await renderWizard();
+    await advancePastDetails(wizard);
+    expect(comp.wizardStep).toBe('scenarios');
+    await expectNoAxeViolations(wizard);
+  });
+
+  it('has no axe-core violations on the Goals & Stories step, tables included', async () => {
+    const wizard = await renderWizard();
+    await advancePastDetails(wizard);
+    await clickContinue(wizard);
+    expect(comp.wizardStep).toBe('goals-stories');
+    // Both tables must be rendered or the axe pass proves nothing about them.
+    expect(wizard.querySelector('[data-testid="use-case-goals-table"]')).not.toBeNull();
+    expect(wizard.querySelector('[data-testid="use-case-stories-table"]')).not.toBeNull();
+    await expectNoAxeViolations(wizard);
+  });
+
+  it('has no axe-core violations on the Actors step', async () => {
+    const wizard = await renderWizard();
+    await advancePastDetails(wizard);
+    await clickContinue(wizard);
+    await clickContinue(wizard);
+    expect(comp.wizardStep).toBe('actors');
+    expect(wizard.querySelector('[data-testid="use-case-actors-table"]')).not.toBeNull();
+    await expectNoAxeViolations(wizard);
+  });
+});

--- a/requel-angular/src/app/features/use-cases/use-case-editor.spec.ts
+++ b/requel-angular/src/app/features/use-cases/use-case-editor.spec.ts
@@ -111,8 +111,8 @@ describe('UseCaseEditorComponent', () => {
   it('onSave calls commandService.execute("EditUseCase") with fields', async () => {
     fixture.detectChanges();
     await flush();
-    comp.name = 'New Use Case';
-    comp.text = 'Description';
+    comp.detailsForm.patchValue({ name: 'New Use Case', text: 'Description' });
+    comp.detailsForm.markAsDirty();
     await comp.onSave();
     expect(commandServiceMock.execute).toHaveBeenCalledWith('EditUseCase', expect.objectContaining({
       projectName: 'proj1',
@@ -123,7 +123,8 @@ describe('UseCaseEditorComponent', () => {
 
   it('onSave sets errorMessage when command fails', async () => {
     commandServiceMock.execute.mockResolvedValue({ success: false, error: 'Conflict' });
-    comp.name = 'Test';
+    comp.detailsForm.controls.name.setValue('Test');
+    comp.detailsForm.markAsDirty();
     await comp.onSave();
     expect(comp.errorMessage()).toBe('Conflict');
     expect(comp.saving()).toBe(false);
@@ -155,14 +156,76 @@ describe('UseCaseEditorComponent', () => {
     expect(comp.additionalScenarios()[0].name).toBe('Exception flow');
   });
 
-  it('trackChanges() sets hasChanges() when name differs from loaded', async () => {
+  // #173: trackChanges()/hasChanges() are gone; the form owns dirtiness.
+  it('hasUnsavedChanges() follows form.dirty', async () => {
     paramMap$.next(convertToParamMap({ name: 'proj1', useCaseId: '30' }));
     fixture.detectChanges();
     await flush();
-    expect(comp.hasChanges()).toBe(false);
-    comp.name = 'Different Name';
-    comp.trackChanges();
-    expect(comp.hasChanges()).toBe(true);
+    expect(comp.hasUnsavedChanges()).toBe(false);
+    comp.detailsForm.controls.name.setValue('Different Name');
+    comp.detailsForm.controls.name.markAsDirty();
+    expect(comp.hasUnsavedChanges()).toBe(true);
+  });
+
+  // #173 required test (§10.3). refreshCollections() refetched every collection but never the
+  // version, so an association left it stale and the next save 409'd. All eight association
+  // commands on this editor bump the use case, so this is the editor where it mattered most.
+  describe('wizard version contract (#173)', () => {
+    it('re-reads version after an association, so a later save does not 409', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', useCaseId: '30' }));
+      fixture.detectChanges();
+      await flush();
+
+      commandServiceMock.execute.mockResolvedValue({ success: true, entity: null });
+      useCaseServiceMock.getUseCase.mockResolvedValue({ ...MOCK_USE_CASE, version: 5 });
+
+      await comp.addGoal({ id: 7, name: 'Avoid late fees', entityType: 'Goal' });
+
+      commandServiceMock.execute.mockClear();
+      commandServiceMock.execute.mockResolvedValue({
+        success: true, entity: { ...MOCK_USE_CASE, version: 6 }
+      });
+      comp.detailsForm.controls.name.setValue('Renamed');
+      comp.detailsForm.markAsDirty();
+      await comp.onSave();
+
+      const edit = commandServiceMock.execute.mock.calls.find(c => c[0] === 'EditUseCase');
+      expect(edit![1].version).toBe(5);
+    });
+
+    it('a non-details step just advances - it issues no command of its own', async () => {
+      fixture.detectChanges();
+      await flush();
+      commandServiceMock.execute.mockClear();
+
+      for (const key of ['scenarios', 'goals-stories', 'actors']) {
+        const request = { step: { key }, complete: vi.fn(), fail: vi.fn() };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await comp.onStepCommit(request as any);
+        expect(request.complete).toHaveBeenCalled();
+      }
+      expect(commandServiceMock.execute).not.toHaveBeenCalled();
+    });
+
+    it('step 1 captures the use case without navigating away', async () => {
+      fixture.detectChanges();
+      await flush();
+      const navigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+      navigate.mockClear();
+
+      commandServiceMock.execute.mockResolvedValue({
+        success: true, entity: { ...MOCK_USE_CASE, id: 30, version: 1 }
+      });
+      comp.detailsForm.controls.name.setValue('New Use Case');
+
+      const request = { step: { key: 'details' }, complete: vi.fn(), fail: vi.fn() };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await comp.onStepCommit(request as any);
+
+      expect(request.complete).toHaveBeenCalled();
+      expect(navigate).not.toHaveBeenCalled();
+      expect(comp.useCaseId).toBe(30);
+    });
   });
 
   it('addGoal calls AddGoalToGoalContainer and refreshes collections', async () => {

--- a/requel-angular/src/app/features/use-cases/use-case-editor.ts
+++ b/requel-angular/src/app/features/use-cases/use-case-editor.ts
@@ -22,10 +22,10 @@ import { Component, computed, OnDestroy, OnInit, signal } from '@angular/core';
 import { PageHeaderComponent } from '../../shared/page-header';
 import { AppCardComponent } from '../../shared/app-card';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { Location } from '@angular/common';
+import { Location, NgTemplateOutlet } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { DirtyCheckable } from '../../core/dirty-check.guard';
-import { FormsModule } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
 import { InputText } from 'primeng/inputtext';
 import { TextareaModule } from 'primeng/textarea';
@@ -50,13 +50,43 @@ import { PermissionService } from '../../core/permission.service';
 import { EventStreamService } from '../../core/event-stream.service';
 import { EntitySelectorDialogComponent } from '../../shared/entity-selector-dialog';
 import { AnnotationsSectionComponent } from '../../shared/annotations-section';
+import { AppFieldComponent, AppFieldControlDirective } from '../../shared/app-field';
+import {
+  AppFormWizardComponent,
+  AppWizardStepComponent,
+  WizardCommitRequest,
+} from '../../shared/app-form-wizard';
+import { applyCommandErrors, clearServerErrors } from '../../shared/form-errors';
+import { ARTIFACT_NAME_MAX_LENGTH } from '../../shared/validation-limits';
+import { CommandResult } from '../../models/command';
+
+/**
+ * JPA entity property name -> form control name, for {@link applyCommandErrors}.
+ *
+ * `UseCaseImpl`'s inherited text field is `text`; the primary actor arrives as
+ * `primaryActorName` on the DTO and resolves against the actor by name server-side.
+ * #176 deletes this map.
+ */
+const USE_CASE_FIELD_MAP: Record<string, string> = {
+  primaryActor: 'primaryActorName',
+};
+
+/** Joins page-level violations that resolved to no control. */
+const SEPARATOR = '; ';
+
+/** Wording for the stale-version recovery path, so the 409 case reads as recoverable. */
+const STALE_VERSION_MESSAGE =
+  'This use case was changed elsewhere. Your copy has been refreshed - review the values and continue.';
 
 @Component({
   selector: 'app-use-case-editor',
   standalone: true,
-  imports: [PageHeaderComponent, AppCardComponent, RouterLink, FormsModule, ButtonModule, InputText, TextareaModule, MessageModule,
+  imports: [PageHeaderComponent, AppCardComponent, RouterLink, NgTemplateOutlet, ReactiveFormsModule,
+            ButtonModule, InputText, TextareaModule, MessageModule,
             ConfirmDialogModule, TableModule, TooltipModule, SelectModule,
-            EntitySelectorDialogComponent, AnnotationsSectionComponent],
+            EntitySelectorDialogComponent, AnnotationsSectionComponent,
+            AppFieldComponent, AppFieldControlDirective,
+            AppFormWizardComponent, AppWizardStepComponent],
   providers: [ConfirmationService],
   template: `
     <div class="use-case-editor" data-testid="use-case-editor">
@@ -82,49 +112,176 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
         <p-message severity="error" [text]="errorMessage()!" />
       }
 
-      <app-card>
-        <div class="form-grid">
-          <label for="name">Name</label>
-          <input id="name" pInputText [(ngModel)]="name" placeholder="Use case name"
-                 (ngModelChange)="trackChanges()" />
+      @if (isNew()) {
+        <!--
+          Create runs as a wizard (#173). Four steps because this editor gates five separate
+          sections; grouping Goals with Stories keeps the count at four without putting six
+          tables on one panel. Step 1 commits EditUseCase, which is what gives every later step
+          the persisted useCaseId its selector needs.
+        -->
+        <app-form-wizard
+          [(activeKey)]="wizardStep"
+          navLabel="New use case steps"
+          (stepCommit)="onStepCommit($event)"
+          (cancelled)="onBack()"
+          (finished)="onWizardFinished()"
+          data-testid="use-case-wizard"
+        >
+          <app-wizard-step key="details" label="Details" helper="Name, actor and description"
+                           [form]="detailsForm">
+            <ng-template>
+              <ng-container [ngTemplateOutlet]="detailsFields" />
+            </ng-template>
+          </app-wizard-step>
 
-          <label for="primaryActor">Primary Actor</label>
-          <p-select id="primaryActor" inputId="useCasePrimaryActorInput"
+          <app-wizard-step key="scenarios" label="Scenarios" helper="Primary and additional"
+                           [optional]="true">
+            <ng-template>
+              <ng-container [ngTemplateOutlet]="scenariosSection"
+                            [ngTemplateOutletContext]="{ heading: false }" />
+            </ng-template>
+          </app-wizard-step>
+
+          <app-wizard-step key="goals-stories" label="Goals & Stories" helper="What it satisfies"
+                           [optional]="true">
+            <ng-template>
+              <ng-container [ngTemplateOutlet]="goalsSection"
+                            [ngTemplateOutletContext]="{ heading: true }" />
+              <ng-container [ngTemplateOutlet]="storiesSection"
+                            [ngTemplateOutletContext]="{ heading: true }" />
+            </ng-template>
+          </app-wizard-step>
+
+          <app-wizard-step key="actors" label="Actors" helper="Additional actors"
+                           [optional]="true">
+            <ng-template>
+              <ng-container [ngTemplateOutlet]="actorsSection"
+                            [ngTemplateOutletContext]="{ heading: false }" />
+            </ng-template>
+          </app-wizard-step>
+        </app-form-wizard>
+      } @else {
+        <app-card>
+          <ng-container [ngTemplateOutlet]="detailsFields" />
+
+          <div class="form-actions">
+            <p-button label="Save" icon="pi pi-check" data-testid="use-case-save"
+                      [disabled]="!canSave()" [loading]="saving()" (onClick)="onSave()" />
+          </div>
+        </app-card>
+
+        <ng-container [ngTemplateOutlet]="scenariosSection"
+                      [ngTemplateOutletContext]="{ heading: true }" />
+        <ng-container [ngTemplateOutlet]="goalsSection"
+                      [ngTemplateOutletContext]="{ heading: true }" />
+        <ng-container [ngTemplateOutlet]="storiesSection"
+                      [ngTemplateOutletContext]="{ heading: true }" />
+        <ng-container [ngTemplateOutlet]="actorsSection"
+                      [ngTemplateOutletContext]="{ heading: true }" />
+      }
+
+      <!-- Primary scenario selector (shows only Primary-type scenarios) -->
+      <app-entity-selector-dialog
+        [visible]="showPrimaryScenarioSelector"
+        [projectName]="projectName"
+        entityType="Scenario"
+        [excludeIds]="primaryScenarioExcludeIds()"
+        [includeTypes]="['Primary']"
+        (selected)="selectPrimaryScenario($event)"
+        (closed)="showPrimaryScenarioSelector = false" />
+
+      <!-- Additional scenario selector (excludes Primary-type and already-added scenarios) -->
+      <app-entity-selector-dialog
+        [visible]="showScenarioSelector"
+        [projectName]="projectName"
+        entityType="Scenario"
+        [excludeIds]="additionalScenarioIds()"
+        [excludeTypes]="['Primary']"
+        (selected)="addScenario($event)"
+        (closed)="showScenarioSelector = false" />
+
+      <!-- Entity selector dialogs -->
+      <app-entity-selector-dialog
+        [visible]="showGoalSelector"
+        [projectName]="projectName"
+        entityType="Goal"
+        [excludeIds]="goalIds()"
+        (selected)="addGoal($event)"
+        (closed)="showGoalSelector = false" />
+
+      <app-entity-selector-dialog
+        [visible]="showStorySelector"
+        [projectName]="projectName"
+        entityType="Story"
+        [excludeIds]="storyIds()"
+        (selected)="addStory($event)"
+        (closed)="showStorySelector = false" />
+
+      <app-entity-selector-dialog
+        [visible]="showActorSelector"
+        [projectName]="projectName"
+        entityType="Actor"
+        [excludeIds]="actorIds()"
+        (selected)="addActorToList($event)"
+        (closed)="showActorSelector = false" />
+
+      <app-annotations-section
+        [projectName]="projectName"
+        entityType="UseCase"
+        [entityId]="useCaseId"
+        [canEdit]="canEdit()" />
+
+      <p-confirmDialog />
+
+      <!--
+        Shared bodies, used by both the wizard steps and the edit view so the two cannot drift.
+        Controls bind [formControl], not formControlName: these are projected into the wizard,
+        where formControlName would look for a parent formGroup that is not there.
+
+        Every association section guards on useCaseId: during create, step 1 has not committed
+        yet on first render, and the selectors all key off the persisted use case.
+      -->
+      <ng-template #detailsFields>
+        <app-field label="Name" [control]="detailsForm.controls.name"
+                   [errorMessages]="nameErrors" [submitted]="submitted()">
+          <input appFieldControl pInputText [formControl]="detailsForm.controls.name"
+                 [attr.maxlength]="nameMaxLength"
+                 placeholder="Use case name" data-testid="use-case-name" />
+        </app-field>
+
+        <app-field label="Primary Actor" controlId="useCasePrimaryActorInput"
+                   [control]="detailsForm.controls.primaryActorName" [submitted]="submitted()">
+          <p-select appFieldControl inputId="useCasePrimaryActorInput"
                     data-testid="use-case-primary-actor"
-                    [(ngModel)]="primaryActorName"
-                    [options]="actorOptions()"
-                    optionLabel="label"
-                    optionValue="value"
+                    [formControl]="detailsForm.controls.primaryActorName"
+                    [options]="actorOptions()" optionLabel="label" optionValue="value"
                     [showClear]="true"
                     [pt]="{ clearIcon: { 'data-testid': 'use-case-primary-actor-clear' } }"
-                    placeholder="Select primary actor"
-                    (ngModelChange)="trackChanges()"
-                    styleClass="w-full" />
+                    placeholder="Select primary actor" styleClass="w-full" />
+        </app-field>
 
-          <label for="text">Description</label>
-          <textarea id="text" pTextarea [(ngModel)]="text" rows="4"
-                    placeholder="Use case description"
-                    (ngModelChange)="trackChanges()"></textarea>
-        </div>
+        <app-field label="Description" [control]="detailsForm.controls.text" [divider]="false"
+                   [submitted]="submitted()">
+          <textarea appFieldControl pTextarea [formControl]="detailsForm.controls.text" rows="4"
+                    placeholder="Use case description" data-testid="use-case-text"></textarea>
+        </app-field>
+      </ng-template>
 
-        <div class="form-actions">
-          <p-button label="Save" icon="pi pi-check" data-testid="use-case-save"
-                    (onClick)="onSave()" [loading]="saving()"
-                    [disabled]="!isNew() && !hasChanges()" />
-        </div>
-      </app-card>
-
-      <!-- Primary Scenario section -->
-      @if (!isNew()) {
+      <ng-template #scenariosSection let-heading="heading">
         <div class="section">
           <div class="section-header">
-            <h3>Primary Scenario</h3>
+            @if (heading) {
+              <h2 class="rq-section-title">Primary Scenario</h2>
+            }
           </div>
-          @if (!useCase()?.scenarioId) {
+          @if (useCaseId == null) {
+            <p class="no-scenario-hint">Save the use case's details first to add scenarios.</p>
+          } @else if (!useCase()?.scenarioId) {
             <p class="no-scenario-hint">No primary scenario yet.</p>
             @if (canEdit()) {
               <div class="primary-scenario-actions">
                 <p-button label="Create New" icon="pi pi-plus" size="small"
+                          data-testid="use-case-create-primary-scenario"
                           pTooltip="Create a primary scenario using the use case name"
                           (onClick)="createPrimaryScenario()" [loading]="saving()" />
                 <p-button label="Select Existing" icon="pi pi-search" size="small"
@@ -166,213 +323,179 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
           }
         </div>
 
-        <!-- Additional Scenarios section -->
-        <div class="section">
-          <div class="section-header">
-            <h3>Additional Scenarios</h3>
-            @if (canEdit()) {
-              <p-button label="Add Scenario" icon="pi pi-plus" size="small"
-                        data-testid="use-case-add-scenario"
-                        severity="secondary" [outlined]="true"
-                        (onClick)="showScenarioSelector = true" />
-            }
+        @if (useCaseId != null) {
+          <div class="section">
+            <div class="section-header">
+              <h3>Additional Scenarios</h3>
+              @if (canEdit()) {
+                <p-button label="Add Scenario" icon="pi pi-plus" size="small"
+                          data-testid="use-case-add-scenario"
+                          severity="secondary" [outlined]="true"
+                          (onClick)="showScenarioSelector = true" />
+              }
+            </div>
+            <p-table [value]="additionalScenarios()" styleClass="p-datatable-sm"
+                     data-testid="use-case-scenarios-table" [rowHover]="true">
+              <ng-template pTemplate="header">
+                <tr><th>Name</th><th>Type</th>
+                  <!-- An empty <th> is an axe empty-table-header violation. -->
+                  <th class="col-actions"><span class="rq-visually-hidden">Actions</span></th></tr>
+              </ng-template>
+              <ng-template pTemplate="body" let-s>
+                <tr data-testid="use-case-scenario-row">
+                  <td><a class="entity-link" data-testid="use-case-scenario-link"
+                         [routerLink]="['/projects', projectName, 'scenarios', s.id]">{{ s.name }}</a></td>
+                  <td>{{ s.scenarioType }}</td>
+                  <td>
+                    @if (canEdit()) {
+                      <p-button icon="pi pi-times" severity="danger" [text]="true"
+                                data-testid="use-case-remove-scenario" [ariaLabel]="'Remove scenario ' + s.name"
+                                size="small" pTooltip="Remove scenario"
+                                (onClick)="removeScenario(s)" />
+                    }
+                  </td>
+                </tr>
+              </ng-template>
+              <ng-template pTemplate="emptymessage">
+                <tr><td colspan="3" class="text-center">No additional scenarios.</td></tr>
+              </ng-template>
+            </p-table>
           </div>
-          <p-table [value]="additionalScenarios()" styleClass="p-datatable-sm"
-                   data-testid="use-case-scenarios-table" [rowHover]="true">
-            <ng-template pTemplate="header">
-              <tr><th>Name</th><th>Type</th><th class="col-actions"></th></tr>
-            </ng-template>
-            <ng-template pTemplate="body" let-s>
-              <tr data-testid="use-case-scenario-row">
-                <td><a class="entity-link" data-testid="use-case-scenario-link"
-                       [routerLink]="['/projects', projectName, 'scenarios', s.id]">{{ s.name }}</a></td>
-                <td>{{ s.scenarioType }}</td>
-                <td>
-                  @if (canEdit()) {
-                    <p-button icon="pi pi-times" severity="danger" [text]="true"
-                              data-testid="use-case-remove-scenario" [ariaLabel]="'Remove scenario ' + s.name"
-                              size="small" pTooltip="Remove scenario"
-                              (onClick)="removeScenario(s)" />
-                  }
-                </td>
-              </tr>
-            </ng-template>
-            <ng-template pTemplate="emptymessage">
-              <tr><td colspan="3" class="text-center">No additional scenarios.</td></tr>
-            </ng-template>
-          </p-table>
-        </div>
-      }
+        }
+      </ng-template>
 
-      <!-- Primary scenario selector (shows only Primary-type scenarios) -->
-      <app-entity-selector-dialog
-        [visible]="showPrimaryScenarioSelector"
-        [projectName]="projectName"
-        entityType="Scenario"
-        [excludeIds]="primaryScenarioExcludeIds()"
-        [includeTypes]="['Primary']"
-        (selected)="selectPrimaryScenario($event)"
-        (closed)="showPrimaryScenarioSelector = false" />
-
-      <!-- Additional scenario selector (excludes Primary-type and already-added scenarios) -->
-      <app-entity-selector-dialog
-        [visible]="showScenarioSelector"
-        [projectName]="projectName"
-        entityType="Scenario"
-        [excludeIds]="additionalScenarioIds()"
-        [excludeTypes]="['Primary']"
-        (selected)="addScenario($event)"
-        (closed)="showScenarioSelector = false" />
-
-      <!-- Goals sub-table -->
-      @if (!isNew()) {
+      <ng-template #goalsSection let-heading="heading">
         <div class="section">
           <div class="section-header">
-            <h3>Goals</h3>
-            @if (canEdit()) {
+            @if (heading) { <h3>Goals</h3> }
+            @if (canEdit() && useCaseId != null) {
               <p-button label="Add Goal" icon="pi pi-plus" size="small"
                         data-testid="use-case-add-goal"
                         severity="secondary" [outlined]="true"
                         (onClick)="showGoalSelector = true" />
             }
           </div>
-          <p-table [value]="goals()" styleClass="p-datatable-sm"
-                   data-testid="use-case-goals-table" [rowHover]="canEdit()">
-            <ng-template pTemplate="header">
-              <tr><th>Name</th><th class="col-actions"></th></tr>
-            </ng-template>
-            <ng-template pTemplate="body" let-goal>
-              <tr data-testid="use-case-goal-row">
-                <td>
-                  <a class="entity-link" data-testid="use-case-goal-link"
-                     [routerLink]="['/projects', projectName, 'goals', goal.id]">{{ goal.name }}</a>
-                </td>
-                <td>
-                  @if (canEdit()) {
-                    <p-button icon="pi pi-times" severity="danger" [text]="true"
-                              data-testid="use-case-remove-goal" [ariaLabel]="'Remove goal ' + goal.name"
-                              size="small" pTooltip="Remove goal"
-                              (onClick)="removeGoal(goal)" />
-                  }
-                </td>
-              </tr>
-            </ng-template>
-            <ng-template pTemplate="emptymessage">
-              <tr><td colspan="2" class="text-center">No goals.</td></tr>
-            </ng-template>
-          </p-table>
+          @if (useCaseId == null) {
+            <p class="text-center">Save the use case's details first to add goals.</p>
+          } @else {
+            <p-table [value]="goals()" styleClass="p-datatable-sm"
+                     data-testid="use-case-goals-table" [rowHover]="canEdit()">
+              <ng-template pTemplate="header">
+                <tr><th>Name</th>
+                  <th class="col-actions"><span class="rq-visually-hidden">Actions</span></th></tr>
+              </ng-template>
+              <ng-template pTemplate="body" let-goal>
+                <tr data-testid="use-case-goal-row">
+                  <td>
+                    <a class="entity-link" data-testid="use-case-goal-link"
+                       [routerLink]="['/projects', projectName, 'goals', goal.id]">{{ goal.name }}</a>
+                  </td>
+                  <td>
+                    @if (canEdit()) {
+                      <p-button icon="pi pi-times" severity="danger" [text]="true"
+                                data-testid="use-case-remove-goal" [ariaLabel]="'Remove goal ' + goal.name"
+                                size="small" pTooltip="Remove goal"
+                                (onClick)="removeGoal(goal)" />
+                    }
+                  </td>
+                </tr>
+              </ng-template>
+              <ng-template pTemplate="emptymessage">
+                <tr><td colspan="2" class="text-center">No goals.</td></tr>
+              </ng-template>
+            </p-table>
+          }
         </div>
+      </ng-template>
 
-        <!-- Stories sub-table -->
+      <ng-template #storiesSection let-heading="heading">
         <div class="section">
           <div class="section-header">
-            <h3>Stories</h3>
-            @if (canEdit()) {
+            @if (heading) { <h3>Stories</h3> }
+            @if (canEdit() && useCaseId != null) {
               <p-button label="Add Story" icon="pi pi-plus" size="small"
                         data-testid="use-case-add-story"
                         severity="secondary" [outlined]="true"
                         (onClick)="showStorySelector = true" />
             }
           </div>
-          <p-table [value]="stories()" styleClass="p-datatable-sm"
-                   data-testid="use-case-stories-table" [rowHover]="canEdit()">
-            <ng-template pTemplate="header">
-              <tr><th>Name</th><th>Type</th><th class="col-actions"></th></tr>
-            </ng-template>
-            <ng-template pTemplate="body" let-story>
-              <tr data-testid="use-case-story-row">
-                <td>
-                  <a class="entity-link" data-testid="use-case-story-link"
-                     [routerLink]="['/projects', projectName, 'stories', story.id]">{{ story.name }}</a>
-                </td>
-                <td>{{ story.storyType }}</td>
-                <td>
-                  @if (canEdit()) {
-                    <p-button icon="pi pi-times" severity="danger" [text]="true"
-                              data-testid="use-case-remove-story" [ariaLabel]="'Remove story ' + story.name"
-                              size="small" pTooltip="Remove story"
-                              (onClick)="removeStory(story)" />
-                  }
-                </td>
-              </tr>
-            </ng-template>
-            <ng-template pTemplate="emptymessage">
-              <tr><td colspan="3" class="text-center">No stories.</td></tr>
-            </ng-template>
-          </p-table>
+          @if (useCaseId == null) {
+            <p class="text-center">Save the use case's details first to add stories.</p>
+          } @else {
+            <p-table [value]="stories()" styleClass="p-datatable-sm"
+                     data-testid="use-case-stories-table" [rowHover]="canEdit()">
+              <ng-template pTemplate="header">
+                <tr><th>Name</th><th>Type</th>
+                  <th class="col-actions"><span class="rq-visually-hidden">Actions</span></th></tr>
+              </ng-template>
+              <ng-template pTemplate="body" let-story>
+                <tr data-testid="use-case-story-row">
+                  <td>
+                    <a class="entity-link" data-testid="use-case-story-link"
+                       [routerLink]="['/projects', projectName, 'stories', story.id]">{{ story.name }}</a>
+                  </td>
+                  <td>{{ story.storyType }}</td>
+                  <td>
+                    @if (canEdit()) {
+                      <p-button icon="pi pi-times" severity="danger" [text]="true"
+                                data-testid="use-case-remove-story" [ariaLabel]="'Remove story ' + story.name"
+                                size="small" pTooltip="Remove story"
+                                (onClick)="removeStory(story)" />
+                    }
+                  </td>
+                </tr>
+              </ng-template>
+              <ng-template pTemplate="emptymessage">
+                <tr><td colspan="3" class="text-center">No stories.</td></tr>
+              </ng-template>
+            </p-table>
+          }
         </div>
+      </ng-template>
 
-        <!-- Additional actors sub-table -->
+      <ng-template #actorsSection let-heading="heading">
         <div class="section">
           <div class="section-header">
-            <h3>Additional Actors</h3>
-            @if (canEdit()) {
+            @if (heading) { <h3>Additional Actors</h3> }
+            @if (canEdit() && useCaseId != null) {
               <p-button label="Add Actor" icon="pi pi-plus" size="small"
                         data-testid="use-case-add-actor"
                         severity="secondary" [outlined]="true"
                         (onClick)="showActorSelector = true" />
             }
           </div>
-          <p-table [value]="actors()" styleClass="p-datatable-sm"
-                   data-testid="use-case-actors-table" [rowHover]="canEdit()">
-            <ng-template pTemplate="header">
-              <tr><th>Name</th><th class="col-actions"></th></tr>
-            </ng-template>
-            <ng-template pTemplate="body" let-actor>
-              <tr data-testid="use-case-actor-row">
-                <td>
-                  <a class="entity-link" data-testid="use-case-actor-link"
-                     [routerLink]="['/projects', projectName, 'actors', actor.id]">{{ actor.name }}</a>
-                </td>
-                <td>
-                  @if (canEdit()) {
-                    <p-button icon="pi pi-times" severity="danger" [text]="true"
-                              data-testid="use-case-remove-actor" [ariaLabel]="'Remove actor ' + actor.name"
-                              size="small" pTooltip="Remove actor"
-                              (onClick)="removeActor(actor)" />
-                  }
-                </td>
-              </tr>
-            </ng-template>
-            <ng-template pTemplate="emptymessage">
-              <tr><td colspan="2" class="text-center">No additional actors.</td></tr>
-            </ng-template>
-          </p-table>
+          @if (useCaseId == null) {
+            <p class="text-center">Save the use case's details first to add actors.</p>
+          } @else {
+            <p-table [value]="actors()" styleClass="p-datatable-sm"
+                     data-testid="use-case-actors-table" [rowHover]="canEdit()">
+              <ng-template pTemplate="header">
+                <tr><th>Name</th>
+                  <th class="col-actions"><span class="rq-visually-hidden">Actions</span></th></tr>
+              </ng-template>
+              <ng-template pTemplate="body" let-actor>
+                <tr data-testid="use-case-actor-row">
+                  <td>
+                    <a class="entity-link" data-testid="use-case-actor-link"
+                       [routerLink]="['/projects', projectName, 'actors', actor.id]">{{ actor.name }}</a>
+                  </td>
+                  <td>
+                    @if (canEdit()) {
+                      <p-button icon="pi pi-times" severity="danger" [text]="true"
+                                data-testid="use-case-remove-actor" [ariaLabel]="'Remove actor ' + actor.name"
+                                size="small" pTooltip="Remove actor"
+                                (onClick)="removeActor(actor)" />
+                    }
+                  </td>
+                </tr>
+              </ng-template>
+              <ng-template pTemplate="emptymessage">
+                <tr><td colspan="2" class="text-center">No additional actors.</td></tr>
+              </ng-template>
+            </p-table>
+          }
         </div>
-      }
-
-      <!-- Entity selector dialogs -->
-      <app-entity-selector-dialog
-        [visible]="showGoalSelector"
-        [projectName]="projectName"
-        entityType="Goal"
-        [excludeIds]="goalIds()"
-        (selected)="addGoal($event)"
-        (closed)="showGoalSelector = false" />
-
-      <app-entity-selector-dialog
-        [visible]="showStorySelector"
-        [projectName]="projectName"
-        entityType="Story"
-        [excludeIds]="storyIds()"
-        (selected)="addStory($event)"
-        (closed)="showStorySelector = false" />
-
-      <app-entity-selector-dialog
-        [visible]="showActorSelector"
-        [projectName]="projectName"
-        entityType="Actor"
-        [excludeIds]="actorIds()"
-        (selected)="addActorToList($event)"
-        (closed)="showActorSelector = false" />
-
-      <app-annotations-section
-        [projectName]="projectName"
-        entityType="UseCase"
-        [entityId]="useCaseId"
-        [canEdit]="canEdit()" />
-
-      <p-confirmDialog />
+      </ng-template>
     </div>
   `,
   styles: [`
@@ -399,7 +522,6 @@ export class UseCaseEditorComponent implements OnInit, OnDestroy, DirtyCheckable
   saving = signal(false);
   canEdit = signal(false);
   canDelete = signal(false);
-  hasChanges = signal(false);
   goals = signal<GoalDto[]>([]);
   stories = signal<StoryDto[]>([]);
   actors = signal<ActorDto[]>([]);
@@ -431,12 +553,32 @@ export class UseCaseEditorComponent implements OnInit, OnDestroy, DirtyCheckable
   showScenarioSelector = false;
   showPrimaryScenarioSelector = false;
 
+  submitted = signal(false);
+
+  /** Mirrors the backend `@Size(max = ValidationLimits.ARTIFACT_NAME_MAX)` (#171). */
+  readonly nameMaxLength = ARTIFACT_NAME_MAX_LENGTH;
+
+  /**
+   * Details step / edit form. Replaces the three `ngModel` fields and the `trackChanges()` +
+   * `original*` comparison.
+   */
+  readonly detailsForm = new FormGroup({
+    name: new FormControl('', {
+      validators: [Validators.required, Validators.maxLength(ARTIFACT_NAME_MAX_LENGTH)],
+      nonNullable: true,
+    }),
+    primaryActorName: new FormControl('', { nonNullable: true }),
+    text: new FormControl('', { nonNullable: true }),
+  });
+
+  readonly nameErrors = { required: 'A use case needs a name.' };
+
+  /** Active wizard step key, two-way bound to `app-form-wizard`. */
+  wizardStep = 'details';
+
   projectName = '';
   useCaseId: number | null = null;
   private version: number | null = null;
-  private originalName = '';
-  private originalText = '';
-  private originalPrimaryActorName = '';
   private paramSub?: Subscription;
   private sseSub?: Subscription;
 
@@ -469,6 +611,16 @@ export class UseCaseEditorComponent implements OnInit, OnDestroy, DirtyCheckable
       const idParam = params.get('useCaseId') ?? '';
       if (idParam === 'new') {
         this.isNew.set(true);
+        this.useCaseId = null;
+        this.version = null;
+        this.wizardStep = 'details';
+        this.submitted.set(false);
+        this.detailsForm.reset({ name: '', primaryActorName: '', text: '' });
+        this.goals.set([]);
+        this.stories.set([]);
+        this.actors.set([]);
+        this.additionalScenarios.set([]);
+        this.primaryScenario.set(null);
       } else {
         this.isNew.set(false);
         this.useCaseId = +idParam;
@@ -478,7 +630,12 @@ export class UseCaseEditorComponent implements OnInit, OnDestroy, DirtyCheckable
   }
 
   hasUnsavedChanges(): boolean {
-    return this.hasChanges();
+    return this.detailsForm.dirty;
+  }
+
+  /** Edit-mode Save: blocked on invalid, unchanged, or in-flight. */
+  canSave(): boolean {
+    return this.detailsForm.valid && this.detailsForm.dirty && !this.saving();
   }
 
   ngOnDestroy(): void {
@@ -494,14 +651,12 @@ export class UseCaseEditorComponent implements OnInit, OnDestroy, DirtyCheckable
       const uc = await this.useCaseService.getUseCase(this.projectName, this.useCaseId!);
       this.useCase.set(uc);
       this.useCaseName.set(uc.name);
-      this.name = uc.name;
-      this.text = uc.text ?? '';
-      this.primaryActorName = uc.primaryActorName ?? '';
+      this.detailsForm.reset({
+        name: uc.name,
+        primaryActorName: uc.primaryActorName ?? '',
+        text: uc.text ?? '',
+      });
       this.version = uc.version;
-      this.originalName = uc.name;
-      this.originalText = uc.text ?? '';
-      this.originalPrimaryActorName = uc.primaryActorName ?? '';
-      this.hasChanges.set(false);
       this.goals.set(uc.goals ?? []);
       this.stories.set(uc.stories ?? []);
       this.actors.set(uc.actors ?? []);
@@ -524,56 +679,141 @@ export class UseCaseEditorComponent implements OnInit, OnDestroy, DirtyCheckable
     }
   }
 
-  trackChanges(): void {
-    this.hasChanges.set(
-      this.name !== this.originalName ||
-      this.text !== this.originalText ||
-      this.primaryActorName !== this.originalPrimaryActorName
-    );
+  /**
+   * Runs the commit for the wizard's current step. Only Details talks to the API; the other
+   * three steps' associations commit through their selectors as the user works, and each one
+   * refreshes the held version via refreshCollections().
+   */
+  async onStepCommit(request: WizardCommitRequest): Promise<void> {
+    if (request.step.key !== 'details') {
+      request.complete();
+      return;
+    }
+
+    this.submitted.set(true);
+    const result = await this.saveDetails();
+    if (result.success) {
+      request.complete();
+      return;
+    }
+    if (await this.recoverFromStaleVersion(result)) {
+      request.fail(STALE_VERSION_MESSAGE);
+      return;
+    }
+    request.fail(result.error ?? 'Save failed.');
   }
 
-  async onSave(): Promise<void> {
+  /** Done on the last step: the use case is already saved, so just go to it. */
+  onWizardFinished(): void {
+    if (this.useCaseId != null) {
+      this.router.navigate(['/projects', this.projectName, 'use-cases', this.useCaseId]);
+    } else {
+      this.onBack();
+    }
+  }
+
+  /**
+   * Issues `EditUseCase` and, on success, adopts the id and version from the response.
+   *
+   * Deliberately does not navigate on create - the old path routed to the saved use case
+   * immediately, which is what made all five association sections unreachable until a second
+   * visit. The wizard captures the id and advances instead.
+   */
+  private async saveDetails(): Promise<CommandResult<unknown>> {
     this.saving.set(true);
     this.errorMessage.set(null);
+    clearServerErrors(this.detailsForm);
     try {
+      const { name, primaryActorName, text } = this.detailsForm.getRawValue();
       const input: Record<string, unknown> = {
         projectName: this.projectName,
-        name: this.name,
-        text: this.text || null,
-        primaryActorName: this.primaryActorName || null,
+        name,
+        text: text || null,
+        primaryActorName: primaryActorName || null,
       };
-      if (this.version != null) input['version'] = this.version;
       if (this.useCaseId != null) input['useCaseId'] = this.useCaseId;
+      if (this.version != null) input['version'] = this.version;
 
       const result = await this.commandService.execute('EditUseCase', input);
-      if (result.success) {
-        this.messageService.add({ severity: 'success', summary: 'Saved', detail: 'Use case saved.' });
-        if (this.isNew()) {
-          this.projectService.notifyTreeChanged();
-          const saved = result.entity as UseCaseDto;
-          this.hasChanges.set(false);
-          this.router.navigate(['/projects', this.projectName, 'use-cases', saved.id]);
-        } else {
-          this.originalName = this.name;
-          this.originalText = this.text;
-          this.originalPrimaryActorName = this.primaryActorName;
-          this.hasChanges.set(false);
-          await this.loadUseCase();
+      if (!result.success) {
+        const unresolved = applyCommandErrors(this.detailsForm, result.violations, USE_CASE_FIELD_MAP);
+        if (unresolved.length) {
+          this.errorMessage.set(unresolved.join(SEPARATOR));
         }
-      } else {
-        this.errorMessage.set(result.error ?? 'Save failed.');
+        return result;
       }
+
+      const wasCreate = this.useCaseId == null;
+      if (wasCreate) {
+        this.projectService.notifyTreeChanged();
+      }
+
+      const saved = result.entity as UseCaseDto | null;
+      if (saved) {
+        this.useCaseId = saved.id;
+        this.version = saved.version;
+        this.useCaseName.set(saved.name);
+      }
+      this.detailsForm.markAsPristine();
+      this.messageService.add({ severity: 'success', summary: 'Saved', detail: 'Use case saved.' });
+
+      if (wasCreate && this.useCaseId != null) {
+        await this.loadUseCase();
+      }
+      return result;
     } catch {
-      this.errorMessage.set('An unexpected error occurred.');
+      return {
+        success: false,
+        entityType: 'UseCase',
+        entity: null,
+        error: 'An unexpected error occurred.',
+        violations: null,
+      };
     } finally {
       this.saving.set(false);
     }
   }
 
-  /** Reload only the sub-collections without touching unsaved form fields. */
+  /**
+   * If `result` is an optimistic-lock conflict (HTTP 409), refetch so the held version is
+   * current and the user can retry. Returns whether it handled the result.
+   */
+  private async recoverFromStaleVersion(result: CommandResult<unknown>): Promise<boolean> {
+    if (result.status !== 409 || this.useCaseId == null) {
+      return false;
+    }
+    await this.loadUseCase();
+    return true;
+  }
+
+  /** Edit-mode Save. */
+  async onSave(): Promise<void> {
+    this.submitted.set(true);
+    if (this.detailsForm.invalid) {
+      this.detailsForm.markAllAsTouched();
+      return;
+    }
+
+    const result = await this.saveDetails();
+    if (result.success) {
+      return;
+    }
+    if (await this.recoverFromStaleVersion(result)) {
+      this.errorMessage.set(STALE_VERSION_MESSAGE);
+      return;
+    }
+    this.errorMessage.set(result.error ?? 'Save failed.');
+  }
+
   private async refreshCollections(): Promise<void> {
     try {
       const uc = await this.useCaseService.getUseCase(this.projectName, this.useCaseId!);
+      // Take the version. Every association command here merges the use case and bumps its
+      // @Version, and none of them returns an entity (they register no result extractor), so
+      // this refetch is the only place the new value can come from. It was refetching
+      // everything EXCEPT this, which made the bug invisible: the refresh looked complete.
+      // Without it, adding a goal and then saving the name 409s. See #178/#180.
+      this.version = uc.version;
       this.useCase.set(uc);
       this.goals.set(uc.goals ?? []);
       this.stories.set(uc.stories ?? []);
@@ -649,9 +889,9 @@ export class UseCaseEditorComponent implements OnInit, OnDestroy, DirtyCheckable
     try {
       const input: Record<string, unknown> = {
         projectName: this.projectName,
-        name: this.name,
-        text: this.text || null,
-        primaryActorName: this.primaryActorName || null,
+        name: this.detailsForm.controls.name.value,
+        text: this.detailsForm.controls.text.value || null,
+        primaryActorName: this.detailsForm.controls.primaryActorName.value || null,
         useCaseId: this.useCaseId,
         version: this.version
       };

--- a/requel-angular/src/app/features/use-cases/use-case-editor.ts
+++ b/requel-angular/src/app/features/use-cases/use-case-editor.ts
@@ -242,9 +242,9 @@ const STALE_VERSION_MESSAGE =
         yet on first render, and the selectors all key off the persisted use case.
       -->
       <ng-template #detailsFields>
-        <app-field label="Name" [control]="detailsForm.controls.name"
+        <app-field label="Name" controlId="name" [control]="detailsForm.controls.name"
                    [errorMessages]="nameErrors" [submitted]="submitted()">
-          <input appFieldControl pInputText [formControl]="detailsForm.controls.name"
+          <input appFieldControl pInputText [formControl]="detailsForm.controls.name" id="name"
                  [attr.maxlength]="nameMaxLength"
                  placeholder="Use case name" data-testid="use-case-name" />
         </app-field>
@@ -260,9 +260,9 @@ const STALE_VERSION_MESSAGE =
                     placeholder="Select primary actor" styleClass="w-full" />
         </app-field>
 
-        <app-field label="Description" [control]="detailsForm.controls.text" [divider]="false"
+        <app-field label="Description" controlId="text" [control]="detailsForm.controls.text" [divider]="false"
                    [submitted]="submitted()">
-          <textarea appFieldControl pTextarea [formControl]="detailsForm.controls.text" rows="4"
+          <textarea appFieldControl pTextarea [formControl]="detailsForm.controls.text" id="text" rows="4"
                     placeholder="Use case description" data-testid="use-case-text"></textarea>
         </app-field>
       </ng-template>

--- a/scripts/update-ui-ux-subissues.sh
+++ b/scripts/update-ui-ux-subissues.sh
@@ -32,10 +32,10 @@ ORDER=(
   135 136 137 139
 
   # Phase 2 - design system and shared primitives
-  125 126 127 141 156 155 131 157 158
+  125 126 127 141 156 155 131 157 158 172
 
   # Phase 3 - forms and validation
-  132 133 134 138 143
+  132 171 173 133 176 134 138 143
 
   # Phase 4 - IA/workflow adoption
   142 154 128 129 130 140 146
@@ -133,39 +133,44 @@ patch_rollup_comment() {
   cat > "$body_file" <<'EOF'
 ## Remediation rollup by phase
 
-Grouped from `doc/UI_UX_REVIEW.md` findings 1.1-5.6 plus the look-and-feel items (N1-N6, see `doc/124-lookandfeel-plan.md`). Closed sub-issues are auto-checked; the rest are checked as each PR squash-merges to `release/2.0`.
+Grouped from `doc/UI_UX_REVIEW.md` findings 1.1-5.6 plus the look-and-feel items (N1-N6, see `doc/124-lookandfeel-plan.md`). Also includes the follow-on tickets split out of #132 (see `doc/132-reactive-forms-plan.md`) - #171, #172, #173, #176. Some of those are server-side, but each one exists only to make a UI finding correct, so they are tracked here. Closed sub-issues are auto-checked; the rest are checked as each PR squash-merges to `release/2.0`.
 
 **Execution order matters - do issues top-to-bottom.** The list below is the intended build order, and the epic's native sub-issue list is sorted to match. Key dependency notes:
 
 - Phase 1 closes app-wide accessibility blockers that later components must not reintroduce.
-- Phase 2 creates tokens and shared primitives. N4 #157 owns `app-data-table`; N5 #158 owns `app-field`/wizard primitives only, not full form migration.
-- Phase 3 migrates forms using the N5 primitives. #132 is blocked by #158; #138 is blocked by #132 and the command-error adapter #133.
+- Phase 2 creates tokens and shared primitives. N4 #157 owns `app-data-table`; N5 #158 owns `app-field`/wizard primitives only, not full form migration. #172 (`app-field-group`) is an additive layout extension of the N5 primitive and blocks #132.
+- Phase 3 migrates forms using the N5 primitives. #132 is blocked by #158 and #172; #138 is blocked by #132 and the command-error adapter #133.
+- Phase 3 server-side backing: #171 supplies the real `@Size`/`@Email` constraints that #132's client-side validation is supposed to mirror, and #176 makes command field violations report input-DTO field names so #133's `applyCommandErrors` stops needing per-editor rename maps. #173 (3.1b create-flow wizards) is blocked by #132 and consumes its helpers.
 - Phase 4 applies the primitives to IA/workflow tickets. #146 is an adoption/integration ticket after N1-N5, not a catch-all primitive build.
 - Phase 5 handles lower-level Angular/SSE/bundle work plus optional dark-mode config.
 
 ### Phase 1 - Accessibility blockers
 
-- [ ] #135 - 4.1 Skip navigation and heading structure are incomplete
-- [ ] #136 - 4.2 Several interactive elements are mouse-only or not real links/buttons
+- [x] #135 - 4.1 Skip navigation and heading structure are incomplete
+- [x] #136 - 4.2 Several interactive elements are mouse-only or not real links/buttons
 - [x] #137 - 4.3 Icon-only buttons often lack accessible names
 - [x] #139 - 4.5 Custom dialogs and overlays miss modal accessibility guarantees
 
 ### Phase 2 - Design system and shared primitives
 
-- [ ] #125 - 1.1 App uses stock Aura with no Requel brand layer
-- [ ] #126 - 1.2 Component-local CSS fights PrimeNG and fragments visual consistency
-- [ ] #127 - 1.3 Typography and hierarchy are too flat
-- [ ] #141 - 4.7 Color contrast, color-only meaning, reduced motion, and target size need policy
-- [ ] #156 - N3 Card / content-surface primitive (app-card)
-- [ ] #155 - N2 Tag & Chip severity system as shared primitives
-- [ ] #131 - 2.4 Loading, empty, and failure states are under-specified
-- [ ] #157 - N4 Data-table pattern component (app-data-table)
-- [ ] #158 - N5 Multi-step entity-create wizard (app-form-wizard + app-field)
+- [x] #125 - 1.1 App uses stock Aura with no Requel brand layer
+- [x] #126 - 1.2 Component-local CSS fights PrimeNG and fragments visual consistency
+- [x] #127 - 1.3 Typography and hierarchy are too flat
+- [x] #141 - 4.7 Color contrast, color-only meaning, reduced motion, and target size need policy
+- [x] #156 - N3 Card / content-surface primitive (app-card)
+- [x] #155 - N2 Tag & Chip severity system as shared primitives
+- [x] #131 - 2.4 Loading, empty, and failure states are under-specified
+- [x] #157 - N4 Data-table pattern component (app-data-table)
+- [x] #158 - N5 Multi-step entity-create wizard (app-form-wizard + app-field)
+- [x] #172 - 3.1a `app-field-group` two-column row layout variant for `app-field` (additive N5 extension; blocks #132)
 
 ### Phase 3 - Forms and validation remediation
 
-- [ ] #132 - 3.1 Forms are mostly template-driven and lack consistent validation
+- [x] #132 - 3.1 Forms are mostly template-driven and lack consistent validation
+- [ ] #171 - 3.1 server backing: bean validation `@Size`/`@Email` constraints on artifact name/text and user email inputs (blocks #132 - client caps must mirror real constraints)
+- [ ] #173 - 3.1b Create-flow wizards for project, actor, stakeholder, scenario, use-case (blocked by #132)
 - [ ] #133 - 3.2 API and command errors are surfaced inconsistently
+- [ ] #176 - 3.2 server backing: `CommandController` should report field violations using input-DTO field names, not JPA entity property names (independent; retires the per-editor rename maps in #133)
 - [ ] #134 - 3.3 Mini-forms (annotations, tags, admin, dialogs) need the same validation contract
 - [ ] #138 - 4.4 Form labels and error associations are incomplete
 - [ ] #143 - 5.2 Signals are used, but form/state hygiene is mixed
@@ -186,6 +191,8 @@ Grouped from `doc/UI_UX_REVIEW.md` findings 1.1-5.6 plus the look-and-feel items
 - [ ] #145 - 5.4 SSE service is thoughtful but disconnected from UX and app-level state
 - [ ] #147 - 5.6 Bundle and dependency posture is reasonable but should be measured
 - [ ] #159 - N6 Theme switcher + dark mode via config panel (optional)
+
+**Progress: 15 / 33 complete** (Phase 1 complete, Phase 2 complete, Phase 3 in progress).
 EOF
 
   echo ">> patch rollup comment $COMMENT_ID"


### PR DESCRIPTION
Closes #173.

Converts all five create flows to `app-form-wizard`, so creating a project, actor, stakeholder, scenario or use case no longer produces a stub the user has to navigate back into.

## Slices

| # | Editor | Steps | Notes |
|---|---|---|---|
| 1 | `scenario-editor` | Details → Steps | Highest value — steps *are* the scenario |
| 2 | `actor-editor` | Details → Goals | + stale-version bugfix |
| 3 | `stakeholder-editor` | Details → Goals | Two modes, permission matrix → `FormRecord` |
| 4 | `project-editor` | Details → Tags | Only wizard whose step 2 spends no version |
| 5 | `use-case-editor` | Details → Scenarios → Goals & Stories → Actors | All eight bumping commands |

## Larger than the issue implies

None of the five was reactive to begin with — zero `FormGroup`, zero `app-field`, all `ngModel`, four carrying `trackChanges()`. So this is the full #132 conversion across ~2,750 lines **plus** the wizards **plus** the version contract. The 8 points predate that being known; suggest re-pointing in retro.

## A live bug, fixed in four places

`AddGoalToGoalContainer` and its siblings end by merging the container — the actor/stakeholder/use-case being edited — bumping its `@Version`. The client could not see the new value, so: add a goal, edit the name, Save → **409**, with the user having done nothing wrong. Present on `release/2.0` today, independent of the wizards.

Fixed in `actor-editor`, `stakeholder-editor` and `use-case-editor`. The last was the subtle one: it already refetched after every association and simply never assigned `version`, so the refresh looked complete. `story-editor` has the same bug and is not one of this ticket's five — filed as **#179**.

## Corrections to the plan

Verifying §3 of `doc/132-reactive-forms-plan.md` against source changed three of its conclusions, recorded in `doc/173-create-flow-wizards-plan.md` §2–§4 and on the issue:

1. **Six of nine association commands return no entity at all** — they register through the 4-arg `CommandRegistry.register` overload, so `extractResult` returns null. §3's refetch is required, not optional. My own first comment on #173 got this backwards and is corrected in a later one.
2. Four commands §3 asks about (`EditScenarioStep`, `DeleteScenarioStep`, `CopyScenarioStep`, `ConvertStepToScenario`) are unreachable from Angular.
3. `scenario-editor` is the two-mutation #158 case, not the many-mutation §3 case — its steps ship wholesale inside `EditScenario`.

## Accessibility

Five new `*.a11y.spec.ts` suites, each axe-checking every wizard step including one **with a field in the error state**. These found real defects, not just guarded existing behaviour:

- **Empty `<th>`** on six action columns across four editors (axe `empty-table-header`).
- **Twelve unlabelled permission checkboxes** in `stakeholder-editor` — they relied on Edit/Delete/Grant column headers that are plain `<div>`s in a CSS grid, so nothing associated them.

The same empty-`<th>` pattern remains in `goal-editor`, `story-editor` and `api-tokens`, which are outside this ticket.

## Split out

- **#178** — association commands emit no targeted SSE event (same null-result root cause)
- **#179** — `story-editor` stale version
- **#180** — consume the returned entity instead of refetching, once #178 lands

## Verification

808 tests passing, 89 files. Not run locally: the e2e suite (needs a running stack) and `mvn clean verify`.
