### PR TITLE
179: refresh the story after a goal or actor association, and stop the initial load discarding unsaved edits

### DIFF
--- a/requel-angular/e2e/form-wizard.e2e.ts
+++ b/requel-angular/e2e/form-wizard.e2e.ts
@@ -13,6 +13,7 @@ import {
 } from './fixtures/api-helper';
 import { GoalListPage, GoalEditorPage } from './pages/GoalEditorPage';
 import { StoryListPage, StoryEditorPage } from './pages/StoryEditorPage';
+import { gotoAndWaitForGet } from './helpers/navigation';
 
 /**
  * End-to-end coverage for the entity-create wizard (issue #158).
@@ -396,7 +397,16 @@ test.describe('Edit forms after the migration', () => {
 
     const page = await adminContext.newPage();
     const editor = new GoalEditorPage(page);
-    await page.goto(`/projects/${encodeURIComponent(PROJECT_NAME)}/goals/${goal.id}`);
+    // Wait for the goal GET, not just document load. Everything asserted below the wizard
+    // check is also true of an empty form, so a bare page.goto() lets this test type into the
+    // input before the fetch lands and then have the load reset it out from under us - Save
+    // stays disabled and the failure reads as a Save-gating bug rather than a race.
+    await gotoAndWaitForGet(
+      page,
+      `/projects/${encodeURIComponent(PROJECT_NAME)}/goals/${goal.id}`,
+      r => /\/goals\/\d+$/.test(r.url())
+    );
+    await editor.expectNameValue(goal.name);
 
     // No wizard chrome on the edit route.
     await expect(editor.wizard.root()).toHaveCount(0);

--- a/requel-angular/e2e/helpers/navigation.ts
+++ b/requel-angular/e2e/helpers/navigation.ts
@@ -8,3 +8,27 @@ export async function reloadAndWaitForGet(page: Page, predicate: (response: Resp
   await page.reload({ waitUntil: 'domcontentloaded' });
   await responseLoaded;
 }
+
+/**
+ * Navigate to `url` and wait for the entity GET that populates the page.
+ *
+ * `page.goto()` resolves on document load, which for this SPA is well before the editor's
+ * detail fetch returns. A test that starts typing in that gap is racing the load: the fetch
+ * lands afterwards and resets the form under it. Every assertion an editor route can satisfy
+ * while still empty - element counts, a disabled Save on a pristine form - passes in that gap
+ * too, so the race hides until the first assertion that needs real data.
+ *
+ * Use this instead of a bare `page.goto()` whenever the test interacts with a loaded editor.
+ */
+export async function gotoAndWaitForGet(
+  page: Page,
+  url: string,
+  predicate: (response: Response) => boolean
+): Promise<void> {
+  const responseLoaded = page.waitForResponse(response =>
+    response.status() === 200 && response.request().method() === 'GET' && predicate(response)
+  );
+
+  await page.goto(url, { waitUntil: 'domcontentloaded' });
+  await responseLoaded;
+}

--- a/requel-angular/src/app/features/actors/actor-editor.ts
+++ b/requel-angular/src/app/features/actors/actor-editor.ts
@@ -395,24 +395,35 @@ export class ActorEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
     this.sseSub?.unsubscribe();
   }
 
-  private async loadActor(fromSSE = false): Promise<void> {
+  /**
+   * Reads the actor and applies it in two parts: server state always, form state only when the
+   * user has nothing unsaved.
+   *
+   * The guard used to be `fromSSE && hasUnsavedChanges()`, which left the *initial* load free to
+   * reset the form. `page.goto()` on the edit route returns long before this fetch does, so
+   * anything typed in that gap was silently discarded and the form went back to pristine —
+   * Save then stayed disabled with no explanation. `ngOnInit`'s create path already resets
+   * synchronously to dodge exactly this; the edit path had no equivalent. It applies to every
+   * caller now, which also means a 409 recovery keeps the edit the user is retrying instead of
+   * throwing it away.
+   *
+   * The three collections stay unconditional. Previously the early return skipped them, so a
+   * refresh arriving while the form was dirty left the goals and referenced-by tables stale.
+   */
+  private async loadActor(): Promise<void> {
     try {
       const a = await this.actorService.getActor(this.projectName, this.actorId!);
-      // Don't overwrite unsaved user edits when called from an SSE notification.
-      if (fromSSE && this.hasUnsavedChanges()) {
-        // Still take the new version: the entity moved on, and holding the stale one
-        // guarantees a 409 on the user's next save.
-        this.version = a.version;
-        this.actor.set(a);
-        return;
-      }
+      // Always take the version. The entity moved on, and holding the stale one guarantees a
+      // 409 on the user's next save.
       this.actor.set(a);
-      this.actorName.set(a.name);
-      this.detailsForm.reset({ name: a.name, text: a.text ?? '' });
       this.version = a.version;
       this.goals.set(a.goals ?? []);
       this.referencedByUseCases.set(a.referencedByUseCases ?? []);
       this.referencedByStories.set(a.referencedByStories ?? []);
+      if (!this.hasUnsavedChanges()) {
+        this.actorName.set(a.name);
+        this.detailsForm.reset({ name: a.name, text: a.text ?? '' });
+      }
     } catch {
       this.errorMessage.set('Failed to load actor.');
     }
@@ -420,7 +431,7 @@ export class ActorEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
       void this.eventStreamService.addSubscription('Actor', this.actorId);
       this.sseSub = this.eventStreamService.events$.subscribe(envelope => {
         if (envelope.targetType === 'Actor' && envelope.targetId === this.actorId) {
-          void this.loadActor(true);
+          void this.loadActor();
         }
       });
     }

--- a/requel-angular/src/app/features/goals/goal-editor.ts
+++ b/requel-angular/src/app/features/goals/goal-editor.ts
@@ -429,21 +429,34 @@ export class GoalEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
     this.sseSub?.unsubscribe();
   }
 
-  private async loadGoal(fromSSE = false): Promise<void> {
+  /**
+   * Reads the goal and applies it in two parts: server state always, form state only when the
+   * user has nothing unsaved.
+   *
+   * The guard used to be `fromSSE && hasUnsavedChanges()`, which left the *initial* load free to
+   * reset the form. `page.goto()` on the edit route returns long before this fetch does, so
+   * anything typed in that gap was silently discarded and the form went back to pristine —
+   * Save then stayed disabled with no explanation. `ngOnInit`'s create path already resets
+   * synchronously to dodge exactly this; the edit path had no equivalent. It applies to every
+   * caller now, which also means a 409 recovery keeps the edit the user is retrying instead of
+   * throwing it away.
+   *
+   * `goal` stays unconditional because the relations tables render from it, so the refresh after
+   * adding or deleting a relation still lands even with a rename sitting in the Name field.
+   * `goalName` is the *persisted* name used to address relation commands, so it deliberately
+   * moves only with the form.
+   */
+  private async loadGoal(): Promise<void> {
     try {
       const g = await this.goalService.getGoal(this.projectName, this.goalId!);
-      // Don't overwrite unsaved user edits when called from an SSE notification.
-      if (fromSSE && this.hasUnsavedChanges()) {
-        // Still take the new version: the entity moved on, and holding the stale one
-        // guarantees a 409 on the user's next save.
-        this.version = g.version;
-        this.goal.set(g);
-        return;
-      }
+      // Always take the version. The entity moved on, and holding the stale one guarantees a
+      // 409 on the user's next save.
       this.goal.set(g);
-      this.goalName.set(g.name);
-      this.detailsForm.reset({ name: g.name, text: g.text });
       this.version = g.version;
+      if (!this.hasUnsavedChanges()) {
+        this.goalName.set(g.name);
+        this.detailsForm.reset({ name: g.name, text: g.text });
+      }
     } catch {
       this.errorMessage.set('Failed to load goal.');
     }
@@ -451,7 +464,7 @@ export class GoalEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
       void this.eventStreamService.addSubscription('Goal', this.goalId);
       this.sseSub = this.eventStreamService.events$.subscribe(envelope => {
         if (envelope.targetType === 'Goal' && envelope.targetId === this.goalId) {
-          void this.loadGoal(true);
+          void this.loadGoal();
         }
       });
     }

--- a/requel-angular/src/app/features/stories/story-editor.spec.ts
+++ b/requel-angular/src/app/features/stories/story-editor.spec.ts
@@ -375,22 +375,164 @@ describe('StoryEditorComponent', () => {
       expect(comp.errorMessage()).toBe('Name is required.');
     });
 
-    it('keeps unsaved edits on an SSE reload but still takes the new version', async () => {
-      // The previous implementation had no fromSSE guard at all here and overwrote
-      // whatever the user was typing.
+    it('keeps unsaved edits on a reload but still takes the new version', async () => {
+      // The first implementation had no guard here at all and overwrote whatever the user was
+      // typing. The second guarded only SSE-driven reloads, so the initial load still did.
       await renderExisting();
       comp.detailsForm.controls.name.setValue('Local edit');
       comp.detailsForm.controls.name.markAsDirty();
 
       storyServiceMock.getStory.mockResolvedValue({ ...MOCK_STORY, name: 'Remote edit', version: 15 });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await (comp as any).loadStory(true);
+      await (comp as any).loadStory();
 
       expect(comp.detailsForm.controls.name.value).toBe('Local edit');
 
       commandServiceMock.execute.mockResolvedValue({ success: true, entity: MOCK_STORY });
       await comp.onSave();
       expect(editStoryCall(0)).toEqual(expect.objectContaining({ version: 15 }));
+    });
+
+    // The initial load is the case that actually bit: form-wizard.e2e.ts typed into the edit
+    // form before the detail GET resolved, the reset landed on top, and Save stayed disabled
+    // with the typed value gone.
+    it('does not clobber a value typed while the initial load is still in flight', async () => {
+      let resolveGet: (story: unknown) => void = () => {};
+      storyServiceMock.getStory.mockImplementation(
+        () => new Promise(resolve => { resolveGet = resolve; })
+      );
+
+      paramMap$.next(convertToParamMap({ name: 'proj1', storyId: '20' }));
+      fixture.detectChanges();
+      await flush();
+
+      // The user is faster than the network.
+      comp.detailsForm.controls.name.setValue('Typed while loading');
+      comp.detailsForm.controls.name.markAsDirty();
+
+      resolveGet({ ...MOCK_STORY, name: 'User logs in', version: 4 });
+      await flush();
+
+      expect(comp.detailsForm.controls.name.value).toBe('Typed while loading');
+      expect(comp.detailsForm.dirty).toBe(true);
+      // Server state still landed, so Save has a usable version to send.
+      expect(comp.story()?.id).toBe(20);
+
+      commandServiceMock.execute.mockResolvedValue({ success: true, entity: MOCK_STORY });
+      await comp.onSave();
+      expect(editStoryCall(0)).toEqual(expect.objectContaining({
+        name: 'Typed while loading', version: 4
+      }));
+    });
+  });
+
+  // Regression #179. AddGoal/RemoveGoal/AddActor/RemoveActor all merge the container — which
+  // here is the story — so each bumps its @Version, but none of the four registers a result
+  // extractor, so result.entity is null and the new value can only be read back (#178).
+  // Before this, adding a goal and then saving the name gave a 409 the user could not avoid.
+  describe('association refresh (#179)', () => {
+    const GOAL_A = { id: 7, name: 'Avoid late fees', entityType: 'Goal' };
+    const GOAL_B = { id: 8, name: 'Buy quickly', entityType: 'Goal' };
+    const ACTOR_A = { id: 1, name: 'Customer', entityType: 'Actor' };
+
+    /** Association commands answer `entity: null` — that is the whole reason for the refetch. */
+    function associationSucceeds(): void {
+      commandServiceMock.execute.mockResolvedValue({ success: true, entity: null });
+    }
+
+    /** Renames and saves, so the version the component now holds shows up on the wire. */
+    async function saveAndReadVersion(): Promise<number | undefined> {
+      commandServiceMock.execute.mockResolvedValue({ success: true, entity: MOCK_STORY });
+      comp.detailsForm.patchValue({ name: 'Renamed after association' });
+      comp.detailsForm.markAsDirty();
+      await comp.onSave();
+      return editStoryCall(0)?.['version'] as number | undefined;
+    }
+
+    it.each([
+      ['onGoalSelected', GOAL_A, 5],
+      ['onRemoveGoal', GOAL_A, 6],
+      ['onActorSelected', ACTOR_A, 7],
+      ['onRemoveActor', ACTOR_A, 8],
+    ] as const)('%s takes the bumped version and sends it on the next save', async (method, ref, bumped) => {
+      await renderExisting();
+      associationSucceeds();
+      storyServiceMock.getStory.mockResolvedValue({ ...MOCK_STORY, version: bumped });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (comp as any)[method](ref);
+
+      // Without the refresh this would still be MOCK_STORY's 4 and the save would 409.
+      expect(await saveAndReadVersion()).toBe(bumped);
+    });
+
+    it('takes the goals list from the response instead of patching it locally', async () => {
+      await renderExisting();
+      associationSucceeds();
+      // The server sorted, renamed and assigned — none of which a local patch could know.
+      storyServiceMock.getStory.mockResolvedValue({
+        ...MOCK_STORY, version: 5, goals: [GOAL_A, GOAL_B]
+      });
+
+      await comp.onGoalSelected(GOAL_A);
+
+      expect(comp.story()?.goals).toEqual([GOAL_A, GOAL_B]);
+      expect(comp.existingGoalIds()).toEqual([7, 8]);
+    });
+
+    it('discards an out-of-order refresh so the newer read wins', async () => {
+      await renderExisting();
+      associationSucceeds();
+
+      // Two removes in flight at once — two clicks on the goals table. Their GETs are held so
+      // they can be resolved in the wrong order on purpose.
+      const resolvers: Array<(story: unknown) => void> = [];
+      storyServiceMock.getStory.mockImplementation(
+        () => new Promise(resolve => resolvers.push(resolve))
+      );
+
+      const first = comp.onRemoveGoal(GOAL_A);
+      await flush();
+      const second = comp.onRemoveGoal(GOAL_B);
+      await flush();
+      expect(resolvers.length).toBe(2);
+
+      // Newer read lands first, then the older one — the case the sequence guard exists for.
+      resolvers[1]({ ...MOCK_STORY, version: 9, goals: [] });
+      resolvers[0]({ ...MOCK_STORY, version: 7, goals: [GOAL_B] });
+      await Promise.all([first, second]);
+
+      // Unguarded, the stale snapshot would resurrect GOAL_B and roll the version back to 7.
+      expect(comp.story()?.goals).toEqual([]);
+      expect(comp.story()?.version).toBe(9);
+      expect(await saveAndReadVersion()).toBe(9);
+    });
+
+    it('keeps the held version and list when the refresh itself fails', async () => {
+      await renderExisting();
+      associationSucceeds();
+      storyServiceMock.getStory.mockRejectedValue(new Error('network'));
+
+      await comp.onGoalSelected(GOAL_A);
+
+      // A failed refresh must not block the user: nothing is surfaced, the stale version is
+      // still sent, and the 409 it earns is reported through recoverFromStaleVersion().
+      expect(comp.errorMessage()).toBeNull();
+      expect(comp.story()?.goals).toEqual([]);
+      expect(await saveAndReadVersion()).toBe(4);
+    });
+
+    it('does not refresh when the association command fails', async () => {
+      await renderExisting();
+      storyServiceMock.getStory.mockClear();
+      commandServiceMock.execute.mockResolvedValue({
+        success: false, status: 400, error: 'Goal already associated.'
+      });
+
+      await comp.onGoalSelected(GOAL_A);
+
+      expect(storyServiceMock.getStory).not.toHaveBeenCalled();
+      expect(comp.errorMessage()).toBe('Goal already associated.');
     });
   });
 

--- a/requel-angular/src/app/features/stories/story-editor.ts
+++ b/requel-angular/src/app/features/stories/story-editor.ts
@@ -372,6 +372,12 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
   projectName = '';
   storyId: number | null = null;
   private version: number | null = null;
+  /**
+   * Monotonic ticket for story reads. `refreshAfterAssociation()` takes one before its GET
+   * and applies the response only if it is still the newest, so an older read cannot land
+   * last and undo a newer one. See that method for why the guard is needed.
+   */
+  private storyReadSeq = 0;
   private paramSub?: Subscription;
   private sseSub?: Subscription;
 
@@ -441,26 +447,40 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
     this.sseSub?.unsubscribe();
   }
 
-  private async loadStory(fromSSE = false): Promise<void> {
+  /**
+   * Reads the story and applies it in two parts: server state always, form state only when the
+   * user has nothing unsaved.
+   *
+   * The guard used to be `fromSSE && hasUnsavedChanges()`, which left the *initial* load free to
+   * reset the form. `page.goto()` on the edit route returns long before this fetch does, so
+   * anything typed in that gap was silently discarded and the form went back to pristine —
+   * Save then stayed disabled with no explanation. `ngOnInit`'s create path already resets
+   * synchronously to dodge exactly this; the edit path had no equivalent. It applies to every
+   * caller now, which also means a 409 recovery keeps the edit the user is retrying instead of
+   * throwing it away.
+   *
+   * Server state stays unconditional so a refresh triggered while the form is dirty still
+   * refreshes what it was called for.
+   */
+  private async loadStory(): Promise<void> {
     try {
       const s = await this.storyService.getStory(this.projectName, this.storyId!);
-      if (fromSSE && this.hasUnsavedChanges()) {
-        // Don't overwrite unsaved user edits, but still take the new version: the
-        // entity moved on, and holding the stale one guarantees a 409 on the next
-        // save. (The previous implementation had no such guard and clobbered edits.)
-        this.version = s.version;
-        this.story.set(s);
-        return;
-      }
+      // A full load supersedes any association refresh still in flight: whichever of the two
+      // reads resolves last would otherwise win, and this one carries the form reset.
+      this.storyReadSeq++;
+      // Always take the version. The entity moved on, and holding the stale one guarantees a
+      // 409 on the next save.
       this.story.set(s);
-      this.storyName.set(s.name);
-      this.detailsForm.reset({
-        name: s.name,
-        storyType: s.storyType,
-        primaryActorName: s.primaryActorName ?? '',
-        text: s.text,
-      });
       this.version = s.version;
+      if (!this.hasUnsavedChanges()) {
+        this.storyName.set(s.name);
+        this.detailsForm.reset({
+          name: s.name,
+          storyType: s.storyType,
+          primaryActorName: s.primaryActorName ?? '',
+          text: s.text,
+        });
+      }
     } catch {
       this.errorMessage.set('Failed to load story.');
     }
@@ -468,9 +488,49 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
       void this.eventStreamService.addSubscription('Story', this.storyId);
       this.sseSub = this.eventStreamService.events$.subscribe(envelope => {
         if (envelope.targetType === 'Story' && envelope.targetId === this.storyId) {
-          void this.loadStory(true);
+          void this.loadStory();
         }
       });
+    }
+  }
+
+  /**
+   * Re-reads the story after an association command so the held `@Version` and the goals /
+   * actors tables both come from the server rather than from a locally patched array.
+   *
+   * `Add`/`RemoveGoalToGoalContainer` and `Add`/`RemoveActorToActorContainer` merge their
+   * container — which here is the story — so each one bumps its `@Version`. None of the four
+   * registers a result extractor, so `result.entity` is null and the new version can only be
+   * read back (#178). Without this, adding a goal and then saving the name 409s (#179).
+   *
+   * Applying the response is guarded by `storyReadSeq`. Two associations in quick succession —
+   * easiest by clicking two remove buttons — issue two GETs that can resolve in either order,
+   * and the older snapshot landing last would silently restore a row the user just removed.
+   * A stale *version* is self-correcting, since the next save 409s into
+   * `recoverFromStaleVersion()`, but a stale *list* is not, which is why the guard exists at
+   * all now that the tables are refreshed too.
+   *
+   * Unlike `loadStory()` this never touches `detailsForm`, so it cannot discard unsaved edits:
+   * the form belongs to the user, the signal to the server.
+   *
+   * #180 deletes this method: once the four commands return their merged container, the
+   * version and the lists both come off `result.entity` and the extra GET goes away.
+   */
+  private async refreshAfterAssociation(): Promise<void> {
+    if (this.storyId == null) {
+      return;
+    }
+    const seq = ++this.storyReadSeq;
+    try {
+      const s = await this.storyService.getStory(this.projectName, this.storyId);
+      if (seq !== this.storyReadSeq) {
+        return;
+      }
+      this.version = s.version;
+      this.story.set(s);
+    } catch {
+      // Leave the held version and lists as they are. A failed refresh is not worth blocking
+      // the user on, and a resulting 409 still reports itself through the existing recovery.
     }
   }
 
@@ -666,11 +726,8 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
         containerType: 'Story'
       });
       if (result.success) {
+        await this.refreshAfterAssociation();
         this.messageService.add({ severity: 'success', summary: 'Goal added', detail: 'Goal added.' });
-        this.story.update(s => s ? {
-          ...s,
-          goals: [...(s.goals ?? []), ref].sort((a, b) => a.name.localeCompare(b.name))
-        } : s);
       } else {
         this.errorMessage.set(result.error ?? 'Failed to add goal.');
       }
@@ -688,11 +745,8 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
         containerType: 'Story'
       });
       if (result.success) {
+        await this.refreshAfterAssociation();
         this.messageService.add({ severity: 'success', summary: 'Goal removed', detail: 'Goal removed.' });
-        this.story.update(s => s ? {
-          ...s,
-          goals: (s.goals ?? []).filter(g => g.id !== goalRef.id)
-        } : s);
       } else {
         this.errorMessage.set(result.error ?? 'Failed to remove goal.');
       }
@@ -710,11 +764,8 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
         actorId: ref.id
       });
       if (result.success) {
+        await this.refreshAfterAssociation();
         this.messageService.add({ severity: 'success', summary: 'Actor added', detail: 'Actor added.' });
-        this.story.update(s => s ? {
-          ...s,
-          actors: [...(s.actors ?? []), ref].sort((a, b) => a.name.localeCompare(b.name))
-        } : s);
       } else {
         this.errorMessage.set(result.error ?? 'Failed to add actor.');
       }
@@ -731,11 +782,8 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
         actorId: actorRef.id
       });
       if (result.success) {
+        await this.refreshAfterAssociation();
         this.messageService.add({ severity: 'success', summary: 'Actor removed', detail: 'Actor removed.' });
-        this.story.update(s => s ? {
-          ...s,
-          actors: (s.actors ?? []).filter(a => a.id !== actorRef.id)
-        } : s);
       } else {
         this.errorMessage.set(result.error ?? 'Failed to remove actor.');
       }


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/179

179: refresh the story after a goal or actor association, and stop the initial load discarding unsaved edits

Adding a goal or an actor to a story and then renaming the story returned a 409 the user had no
way to avoid. The four association commands merge their container - which here is the story - so
each one bumps its `@Version`, but none of them registers a result extractor, so
`CommandResult.entity` is null (#178) and the editor kept the version it loaded with and sent that
on the next save.

story-editor was the last editor carrying this bug. `actor-editor` and `stakeholder-editor` got
`refreshVersionAfterAssociation()` during #173, and `use-case-editor` solves it inside
`refreshCollections()`; story-editor is not one of #173's five editors, so nothing covered it.

The editor load-race fix below is **not part of #179**. It was found by the e2e run for this
change and is folded in to unblock CI rather than left red; it deserves its own issue for the
record.

requel-angular - story-editor.ts (#179)

- New `refreshAfterAssociation()` re-reads the story after a successful association and takes both
  the version and the DTO, replacing the four optimistic `this.story.update(...)` patches that
  built the goals/actors arrays by hand. The tables now render what the server has, and #180
  deletes this method wholesale once the commands return their merged container.
- Took the whole DTO rather than the version only, which is what `actor-editor` and
  `stakeholder-editor` do. The local patch cannot know about a concurrent change, and the arrays
  it built were a second source of truth behind `existingGoalIds()` / `existingActorIds()`.
- That choice is what makes a sequence guard necessary; version-only did not need one. Two
  associations can be in flight at once - two clicks on the goals table is enough - and their GETs
  can resolve in either order. A stale *version* is self-correcting, since the next save 409s into
  `recoverFromStaleVersion()`, but a stale *list* is not: the older snapshot landing last silently
  restores the row the user just removed and leaves it there until they navigate away. Each read
  now takes a ticket from `storyReadSeq` and applies its response only if it is still the newest.
- `loadStory()` bumps `storyReadSeq` when it applies, so a full load supersedes an association
  refresh still outstanding instead of racing it.
- The refresh never touches `detailsForm`, so it cannot discard unsaved edits. A failed refresh is
  swallowed: the held version stays as it was, and any 409 it later earns still reports itself
  through the existing recovery path.
- Toast severities and wording are unchanged.

requel-angular - goal-editor.ts, story-editor.ts, actor-editor.ts (the load race - not #179)

- `loadGoal` / `loadStory` / `loadActor` guarded the form reset with
  `fromSSE && hasUnsavedChanges()`, so only SSE-driven reloads protected the user's typing. The
  *initial* load on an edit route was free to reset the form, and it does so after two awaits -
  `permissionService.loadForProject()` and then the detail GET. Anything typed in that window was
  silently discarded and the form went back to pristine, which on `goal-editor` leaves Save
  permanently disabled with no message. `ngOnInit`'s create path already resets synchronously with
  a comment about exactly this trap; the edit path had no equivalent.
- Each method now applies its response in two parts. Server state - the entity signal, the
  version, and in `actor-editor` the goals and referenced-by collections - is applied
  unconditionally. Form state - the `*Name` signal and `detailsForm.reset(...)` - is applied only
  when `hasUnsavedChanges()` is false. The `fromSSE` parameter is gone; the guard no longer varies
  by caller.
- Two behaviour changes fall out of that and are wanted. A 409 recovery now keeps the edit the
  user is retrying instead of resetting it to the server's values, which is the point of the
  retry. And in `actor-editor` a refresh arriving while the form is dirty now updates the goals
  and referenced-by tables, which the old early return skipped - the tables could sit stale
  behind an unsaved rename.
- Not touched: `scenario-editor.ts`, whose guard is a different shape
  (`fromSSE && (hasUnsavedChanges() || saving() || editingStep() !== null)`) with a `skeleton`
  parameter tied to it. Same bug, but it needs its own read.

requel-angular - e2e/helpers/navigation.ts, e2e/form-wizard.e2e.ts

- New `gotoAndWaitForGet()` beside the existing `reloadAndWaitForGet()`: navigate, then wait for
  the GET that populates the page. `page.goto()` resolves on document load, long before an
  editor's detail fetch returns.
- `goal edit renders app-field rows and gates Save on a real change` used a bare `page.goto()` and
  was the test that failed. Its first three assertions - no wizard chrome, two `app-field`
  elements, Save disabled - are all true of an *empty* form, so it sailed through the gap and
  typed into the input before the fetch landed. The reset then wiped the typed name, Save stayed
  disabled, and the failure read as a Save-gating bug. It now waits for the goal GET and asserts
  the loaded name before touching anything.
- The component fix alone would make this test pass, which is precisely why the test needed
  fixing too: it would have been passing because of the guard rather than because it stopped
  racing.
- `sse-refresh.e2e.ts:57`, `terms.e2e.ts:185` and `terms.e2e.ts:238` interact after a bare
  `page.goto()` to an edit route in the same way. Left alone - they are green and `terms-editor`
  is outside this change - but they are the same latent flake and `gotoAndWaitForGet()` is there
  for them.

Verification

- `./node_modules/.bin/ng test --watch=false` - the full frontend suite, 822 tests across 89 files
  green. story-editor.spec.ts is 34 (from 24); goal-editor.spec.ts (28), actor-editor.spec.ts (31)
  and both a11y suites pass unchanged against the reworked load methods.
- `npx playwright test e2e/stories.e2e.ts` - all 14 green against a running app, with no
  page-object changes.
- That run was not a formality. The goal-row and additional-actor-row assertions used to pass off
  the local patch and now depend on the refetch repainting the table, and `reloadAndWaitForGet()`
  waits on `GET .../stories/{id}` - the exact request this change adds, so it could have consumed
  the reload's waiter. The ordering holds because every `expect*InTable` / `expect*NotInTable`
  blocks until the refetch lands, which retires the extra GET before the waiter is registered.
- New unit coverage for both bugs: an `association refresh (#179)` block of nine cases, including
  one that resolves two overlapping GETs in the wrong order and fails without the sequence guard;
  and `does not clobber a value typed while the initial load is still in flight`, which holds the
  detail GET open, types, then resolves it.
- Still to run: `npx playwright test e2e/form-wizard.e2e.ts`, the suite that surfaced the load
  race. Its goal-edit test is the one changed here.
- No backend change. #178 and #180 remain the structural fix - register result extractors, then
  read `result.entity` and drop the refetch - and #179 closes the user-visible bug on release/2.0
  in the meantime.

Closes #179
