### PR TITLE
185: Guard and gate every editor against resetting a form with unsaved edits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,21 @@ Never commit unless explicitly told to commit
 
 Never push changes to the github repo
 
+**"Let's commit" / "let's push" means prepare, then hand over the commands.** Claude does not run
+`git` or `gh` commands that change state — not commit, push, branch, tag, PR, issue edit, or
+comment — even when told to. On either phrase Claude:
+
+1. Checks the working tree holds what it should and that the verification gate in step 3 of the
+   Development Workflow has passed.
+2. (Re)writes `commit.md` for the current change, in the format above.
+3. Prints the exact commands to paste, with nothing left to fill in: `git add` naming each changed
+   file, `git commit -F commit.md`, `git push -u origin <branch>`, `gh pr create ...`.
+
+Read-only git — `log`, `show`, `status`, `diff`, `rev-parse` — is fine for Claude to run, but
+always with `--no-optional-locks`. When Claude reaches the repo over the Cowork device bridge it
+cannot delete files, so any command that takes `.git/index.lock` leaves it behind and blocks the
+next git operation from the developer's own terminal.
+
 All plans, reviews, notes and documentation go in the doc folder.
 
 Never use `TL;DR` I hate that abbreviation, use `Summary`
@@ -36,9 +51,9 @@ Never use `TL;DR` I hate that abbreviation, use `Summary`
 
 Each release such as `release/2.0` has a github project, all issues for the release get added to the project. we use 'Story Point' and 'Story Point Retro' custom fields to track effort. 
 
-Every change is tied to a GitHub issue and lands via a ticket branch and a PR — never commit straight onto `release/2.0`. Steps that create or change Git/GitHub state (branch, commit, push, PR, issue edits) are performed by Claude ONLY when explicitly told; the "never commit/push unless told" rules above always apply. Claude drives GitHub with the `gh` CLI / `gh api` (issues, comments, PRs) when asked.
+Every change is tied to a GitHub issue and lands via a ticket branch and a PR — never commit straight onto `release/2.0`. Steps that create or change Git/GitHub state (branch, commit, push, PR, issue edits) are always run by the developer, never by Claude. Claude prepares them — writes `commit.md`, works out the exact `git` / `gh` invocation, checks the tree is in the state the command assumes — and hands the commands over to paste. See the "let's commit / let's push" rule above.
 
-1. **Issue** — start from a GitHub issue. If none exists, create it (`gh issue create`) when told. Record decisions/progress with `gh issue comment`.
+1. **Issue** — start from a GitHub issue. If none exists, Claude drafts the `gh issue create` command and the body; the developer runs it. Same for `gh issue comment` when recording decisions or progress.
 2. **Branch (at the start of work)** — cut a branch from `release/2.0` named
    `<issue-number>-<short-slug>` (e.g. `87-pat-delete`, matching the existing `73-api-tokens` /
    `77-spring-ai-provider-port` convention). Do all edits on that branch.
@@ -51,16 +66,17 @@ Every change is tied to a GitHub issue and lands via a ticket branch and a PR �
    Do not commit until the relevant suite passes.
 4. **Commit message** — write it to `commit.md` in the format above. Include a closing keyword
    (`Closes #<n>` / `Fixes #<n>`) so merging the PR closes the issue; reference related issues by URL.
-5. **Commit + push** — only when told; commit on the ticket branch and push it.
-6. **PR** — open with `gh pr create --base release/2.0` (when told), always passing a `--title`
-   (`<issue#>: <concise summary>`) and using the `commit.md` content as the body via
-   `--body-file`. PRs are squash-merged.
+5. **Commit + push** — Claude hands over the `git add` / `git commit -F commit.md` /
+   `git push -u origin <branch>` lines; the developer runs them on the ticket branch.
+6. **PR** — Claude hands over the `gh pr create --base release/2.0` line, always with a `--title`
+   (`<issue#>: <concise summary>`) and the `commit.md` content as the body via `--body-file`.
+   PRs are squash-merged.
 
 **Auto-close caveat:** the repo's default branch is `master`, but PRs target `release/2.0`. GitHub auto-closes an issue from `Closes #<n>` only when the PR merges into the **default** branch, so merging into `release/2.0` does **not** close the issue. Always close it explicitly after merge:
 `gh issue close <n> --comment "Merged to release/2.0 via #<pr>."`
 
-Command reference (Claude runs these only when told; `gh`/`mvn`/`ng` run in the developer's
-environment, not Claude's sandbox):
+Command reference — all of these are run by the developer, in the developer's environment, not
+Claude's sandbox. Claude fills in the placeholders and hands them over:
 
 ```bash
 # 1. Issue (if none): gh issue create --repo rreganjr/Requel --title "..." --body "..."

--- a/requel-angular/e2e/sse-refresh.e2e.ts
+++ b/requel-angular/e2e/sse-refresh.e2e.ts
@@ -2,6 +2,7 @@ import { test, expect } from './fixtures/auth';
 import {
   createProject, createGoal, updateGoal,
 } from './fixtures/api-helper';
+import { gotoAndWaitForGet } from './helpers/navigation';
 
 /**
  * Live-refresh tests for the SSE event stream wired through
@@ -54,7 +55,16 @@ test.describe('SSE live refresh', () => {
       { timeout: 15_000 }
     );
 
-    await page.goto(`/projects/${encodeURIComponent(projectName)}/goals/${goal.id}`);
+    // gotoAndWaitForGet, not goto: page.goto() resolves on document load, well before the goal
+    // detail fetch returns, and #185 now gates the form on that fetch. The assertion below
+    // happens to be safe either way - toHaveValue(originalName) retries and cannot pass against
+    // an absent element - but waiting explicitly is the point of the helper: the test should say
+    // what it depends on rather than rely on a locator to paper over it.
+    await gotoAndWaitForGet(
+      page,
+      `/projects/${encodeURIComponent(projectName)}/goals/${goal.id}`,
+      response => response.url().includes(`/goals/${goal.id}`)
+    );
     // Since #158 the goal form is app-field rows with generated ids — locate by testid.
     const nameInput = page.getByTestId('goal-name');
     await expect(nameInput).toHaveValue(originalName);

--- a/requel-angular/e2e/terms.e2e.ts
+++ b/requel-angular/e2e/terms.e2e.ts
@@ -3,7 +3,7 @@ import {
   createProject, deleteProject, createTerm, deleteTerm, getTermDetail, TermFixture
 } from './fixtures/api-helper';
 import { TermListPage, TermEditorPage } from './pages/TermEditorPage';
-import { reloadAndWaitForGet } from './helpers/navigation';
+import { reloadAndWaitForGet, gotoAndWaitForGet } from './helpers/navigation';
 
 const PROJECT_NAME = `e2e-terms-${Date.now()}`;
 let termToCleanup: TermFixture | null = null;
@@ -182,7 +182,14 @@ test.describe('Glossary term management', () => {
     // rendered (B has no alternates of its own). The sister test below
     // ("set canonical term via UI selector …") already uses direct
     // navigation for the same reason.
-    await page.goto(`/projects/${encodeURIComponent(PROJECT_NAME)}/terms/${canonical.id}`);
+    // gotoAndWaitForGet, not goto: page.goto() resolves on document load, well before the term
+    // detail fetch returns, and #185 now gates the form on that fetch. Asserting straight after
+    // a bare goto races the skeleton.
+    await gotoAndWaitForGet(
+      page,
+      `/projects/${encodeURIComponent(PROJECT_NAME)}/terms/${canonical.id}`,
+      response => response.url().includes(`/terms/${canonical.id}`)
+    );
 
     await editorPage.expectAlternateTermInTable(alternateName);
     await editorPage.clickAlternateTerm(alternateName);
@@ -235,7 +242,11 @@ test.describe('Glossary term management', () => {
 
     // Assert the relation server-side via the alternate-terms section on A's editor —
     // this is the canonical observable proof that B.canonicalTermId === A.id.
-    await page.goto(`/projects/${encodeURIComponent(PROJECT_NAME)}/terms/${a.id}`);
+    await gotoAndWaitForGet(
+      page,
+      `/projects/${encodeURIComponent(PROJECT_NAME)}/terms/${a.id}`,
+      response => response.url().includes(`/terms/${a.id}`)
+    );
     await editorPage.expectAlternateTermInTable(bName);
 
     // Clean up B explicitly — without clearing its canonical pointer first the

--- a/requel-angular/src/app/features/actors/actor-editor.spec.ts
+++ b/requel-angular/src/app/features/actors/actor-editor.spec.ts
@@ -449,12 +449,32 @@ describe('ActorEditorComponent', () => {
     expect(comp.hasUnsavedChanges()).toBe(true);
   });
 
-  it('loadActor sets errorMessage when getActor throws', async () => {
+  // #185 moved this from the inline message to the retryable error state. A failed *initial*
+  // load now replaces the form rather than annotating it - there is no form to annotate, since
+  // the gate never opened. Background loads (SSE, post-save, 409) still use errorMessage; the
+  // test below covers that half.
+  it('loadActor sets loadError when the initial getActor throws', async () => {
     actorServiceMock.getActor.mockRejectedValue(new Error('not found'));
     paramMap$.next(convertToParamMap({ name: 'proj1', actorId: '999' }));
     fixture.detectChanges();
     await flush();
+    expect(comp.loadError()).toBe('Failed to load actor.');
+    expect(comp.errorMessage()).toBeNull();
+    expect(comp.loading()).toBe(false);
+  });
+
+  it('a failing background reload uses the inline message, not the error state', async () => {
+    paramMap$.next(convertToParamMap({ name: 'proj1', actorId: '5' }));
+    fixture.detectChanges();
+    await flush();
+
+    actorServiceMock.getActor.mockRejectedValue(new Error('boom'));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (comp as any).loadActor(false);
+
     expect(comp.errorMessage()).toBe('Failed to load actor.');
+    // The form stays on screen - a background failure must not replace it.
+    expect(comp.loadError()).toBeNull();
   });
 
   it('SSE event for matching actor triggers loadActor reload', async () => {
@@ -512,4 +532,92 @@ describe('ActorEditorComponent', () => {
     fixture.destroy();
     expect(eventStreamServiceMock.removeSubscription).toHaveBeenCalledWith('Actor', 5);
   });
+  // #185. The gate is the structural half of the fix: with the form absent until the detail GET
+  // resolves, there is no input for a user - or a fast e2e test - to type into before the load
+  // lands. The dirty-guard in loadActor() is then belt-and-braces for the background callers.
+  // Finishes the #131 / #168 migration for this editor.
+  describe('render gate (#185, finishing #131)', () => {
+    function el(): HTMLElement {
+      return fixture.nativeElement as HTMLElement;
+    }
+
+    it('shows the skeleton and no form until the detail GET resolves', async () => {
+      let resolveGet: (actor: unknown) => void = () => {};
+      actorServiceMock.getActor.mockImplementation(
+        () => new Promise(resolve => { resolveGet = resolve; })
+      );
+
+      paramMap$.next(convertToParamMap({ name: 'proj1', actorId: '5' }));
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="actor-editor-loading"]')).not.toBeNull();
+      // The point of the gate: nothing to type into yet.
+      expect(el().querySelector('[data-testid="actor-name"]')).toBeNull();
+
+      resolveGet(MOCK_ACTOR);
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="actor-editor-loading"]')).toBeNull();
+      expect(el().querySelector('[data-testid="actor-name"]')).not.toBeNull();
+    });
+
+    // The create route never loads, so the gate has to be resolved synchronously in ngOnInit -
+    // otherwise the wizard sits behind the skeleton forever and create is unreachable.
+    it('renders the create wizard immediately, with no skeleton', async () => {
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+
+      expect(comp.loading()).toBe(false);
+      expect(el().querySelector('[data-testid="actor-editor-loading"]')).toBeNull();
+      expect(el().querySelector('[data-testid="actor-wizard"]')).not.toBeNull();
+    });
+
+    it('shows a retryable error state when the load fails, and recovers on retry', async () => {
+      actorServiceMock.getActor.mockRejectedValueOnce(new Error('boom'));
+
+      paramMap$.next(convertToParamMap({ name: 'proj1', actorId: '5' }));
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="actor-editor-load-error"]')).not.toBeNull();
+      expect(el().querySelector('[data-testid="actor-name"]')).toBeNull();
+
+      actorServiceMock.getActor.mockResolvedValue(MOCK_ACTOR);
+      comp.retryLoad();
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="actor-editor-load-error"]')).toBeNull();
+      expect(el().querySelector('[data-testid="actor-name"]')).not.toBeNull();
+    });
+
+    // Background callers pass skeleton=false. Blanking the form under a user who is reading it
+    // because someone else touched the entity would be its own bug.
+    it('does not blank the form for a background reload', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', actorId: '5' }));
+      fixture.detectChanges();
+      await flush();
+
+      let resolveGet: (actor: unknown) => void = () => {};
+      actorServiceMock.getActor.mockImplementation(
+        () => new Promise(resolve => { resolveGet = resolve; })
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const reload = (comp as any).loadActor(false);
+      await flush();
+      fixture.detectChanges();
+
+      expect(comp.loading()).toBe(false);
+      expect(el().querySelector('[data-testid="actor-name"]')).not.toBeNull();
+
+      resolveGet(MOCK_ACTOR);
+      await reload;
+    });
+  });
+
 });

--- a/requel-angular/src/app/features/actors/actor-editor.spec.ts
+++ b/requel-angular/src/app/features/actors/actor-editor.spec.ts
@@ -620,4 +620,38 @@ describe('ActorEditorComponent', () => {
     });
   });
 
+  // #185 acceptance criterion: one of these per editor with a detail form, including the three
+  // #184 fixed. goal-editor's existing guard coverage was the SSE path only
+  // ("keeps the SSE guard from clobbering unsaved edits"), which is a different caller - this
+  // pins the guard on the *initial* load, where the bug was originally reported.
+  //
+  // Since the render gate landed, a user cannot actually type during this window - the form is
+  // not on screen. The test still earns its place: the guard is the only defence on the SSE,
+  // 409 and post-save paths, and holding the GET open is the cheapest way to pin it. It asserts
+  // the component contract, not the rendered one.
+  it('does not clobber a value typed while the initial load is still in flight', async () => {
+    let resolveGet: (entity: unknown) => void = () => {};
+    actorServiceMock.getActor.mockImplementation(
+      () => new Promise(resolve => { resolveGet = resolve; })
+    );
+
+    paramMap$.next(convertToParamMap({ name: 'proj1', actorId: '5' }));
+    fixture.detectChanges();
+    await flush();
+
+    comp.detailsForm.controls.name.setValue('Typed while loading');
+    comp.detailsForm.controls.name.markAsDirty();
+
+    resolveGet({ ...MOCK_ACTOR, version: 9 });
+    await flush();
+
+    expect(comp.detailsForm.controls.name.value).toBe('Typed while loading');
+    expect(comp.detailsForm.dirty).toBe(true);
+    // Server state still landed, so the next save carries a version that will not 409.
+      expect(comp.actor()?.id).toBe(5);
+      expect(comp.version).toBe(9);
+      // Collections stay outside the guard, so the tables still refreshed (#184).
+      expect(comp.goals().length).toBe(1);
+  });
+
 });

--- a/requel-angular/src/app/features/actors/actor-editor.ts
+++ b/requel-angular/src/app/features/actors/actor-editor.ts
@@ -43,6 +43,8 @@ import { EventStreamService } from '../../core/event-stream.service';
 import { EntitySelectorDialogComponent } from '../../shared/entity-selector-dialog';
 import { AnnotationsSectionComponent } from '../../shared/annotations-section';
 import { AppFieldComponent, AppFieldControlDirective } from '../../shared/app-field';
+import { LoadingStateComponent } from '../../shared/loading-state';
+import { ErrorStateComponent } from '../../shared/error-state';
 import {
   AppFormWizardComponent,
   AppWizardStepComponent,
@@ -77,7 +79,8 @@ const STALE_VERSION_MESSAGE =
             ButtonModule, InputText, TextareaModule, TableModule,
             MessageModule, ConfirmDialogModule, EntitySelectorDialogComponent,
             AnnotationsSectionComponent, AppFieldComponent, AppFieldControlDirective,
-            AppFormWizardComponent, AppWizardStepComponent],
+            AppFormWizardComponent, AppWizardStepComponent,
+            LoadingStateComponent, ErrorStateComponent],
   providers: [ConfirmationService],
   template: `
     <div class="actor-editor" data-testid="actor-editor">
@@ -103,7 +106,14 @@ const STALE_VERSION_MESSAGE =
         <p-message severity="error" [text]="errorMessage()!" data-testid="actor-error" />
       }
 
-      @if (isNew()) {
+      @if (loading()) {
+        <app-card>
+          <app-loading-state label="Loading actor…" [lines]="4" testid="actor-editor-loading" />
+        </app-card>
+      } @else if (loadError()) {
+        <app-error-state [message]="loadError()!" testid="actor-editor-load-error"
+                         (retry)="retryLoad()" />
+      } @else if (isNew()) {
         <!--
           Create runs as a wizard (#173) so Goals is reachable before the first save. Step 1
           commits EditActor on Continue, which is what gives step 2 the persisted actorId the
@@ -299,6 +309,13 @@ export class ActorEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
   canEdit = signal(false);
   canDelete = signal(false);
   errorMessage = signal<string | null>(null);
+  /**
+   * #185. The edit form renders only once the detail GET resolves, so there is no window in which
+   * a user can type into a form the load is about to reset. Starts true: an edit route is loading
+   * from the first frame, and the create path clears it synchronously in ngOnInit.
+   */
+  loading = signal(true);
+  loadError = signal<string | null>(null);
   goals = signal<EntityReferenceDto[]>([]);
   goalIds = computed(() => this.goals().map(g => g.id).filter((id): id is number => id !== null));
   referencedByUseCases = signal<EntityReferenceDto[]>([]);
@@ -369,6 +386,10 @@ export class ActorEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
         this.submitted.set(false);
         this.detailsForm.reset({ name: '', text: '' });
         this.goals.set([]);
+        // Nothing to load, so resolve the gate synchronously (#185) - otherwise the create wizard
+        // would sit behind the skeleton forever. Same reason the reset above is synchronous.
+        this.loading.set(false);
+        this.loadError.set(null);
       }
 
       await this.permissionService.loadForProject(this.projectName);
@@ -410,7 +431,23 @@ export class ActorEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
    * The three collections stay unconditional. Previously the early return skipped them, so a
    * refresh arriving while the form was dirty left the goals and referenced-by tables stale.
    */
-  private async loadActor(): Promise<void> {
+  /** Re-run the initial load; wired to the error state's (retry) output. */
+  retryLoad(): void {
+    void this.loadActor();
+  }
+
+  /**
+   * @param skeleton show the loading skeleton and the retryable error state. Suppressed for every
+   *                 background caller - SSE refresh, post-save refetch and 409 recovery - where
+   *                 blanking the form the user is looking at would be worse than a stale moment,
+   *                 and where a failure belongs in the inline message rather than in place of the
+   *                 form. Mirrors `scenario-editor`.
+   */
+  private async loadActor(skeleton = true): Promise<void> {
+    if (skeleton) {
+      this.loading.set(true);
+      this.loadError.set(null);
+    }
     try {
       const a = await this.actorService.getActor(this.projectName, this.actorId!);
       // Always take the version. The entity moved on, and holding the stale one guarantees a
@@ -425,13 +462,21 @@ export class ActorEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
         this.detailsForm.reset({ name: a.name, text: a.text ?? '' });
       }
     } catch {
-      this.errorMessage.set('Failed to load actor.');
+      if (skeleton) {
+        this.loadError.set('Failed to load actor.');
+      } else {
+        this.errorMessage.set('Failed to load actor.');
+      }
+    } finally {
+      if (skeleton) {
+        this.loading.set(false);
+      }
     }
     if (this.actorId && !this.sseSub) {
       void this.eventStreamService.addSubscription('Actor', this.actorId);
       this.sseSub = this.eventStreamService.events$.subscribe(envelope => {
         if (envelope.targetType === 'Actor' && envelope.targetId === this.actorId) {
-          void this.loadActor();
+          void this.loadActor(false);
         }
       });
     }
@@ -556,7 +601,7 @@ export class ActorEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
       // Hydrate goals / referencedBy and start the SSE subscription the first time the actor
       // exists, so step 2 has something to render.
       if (wasCreate && this.actorId != null) {
-        await this.loadActor();
+        await this.loadActor(false);
       }
       return result;
     } catch {
@@ -580,7 +625,7 @@ export class ActorEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
     if (result.status !== 409 || this.actorId == null) {
       return false;
     }
-    await this.loadActor();
+    await this.loadActor(false);
     return true;
   }
 

--- a/requel-angular/src/app/features/goals/goal-editor.spec.ts
+++ b/requel-angular/src/app/features/goals/goal-editor.spec.ts
@@ -443,4 +443,92 @@ describe('GoalEditorComponent', () => {
       expect(comp.nameMaxLength).toBe(ARTIFACT_NAME_MAX_LENGTH);
     });
   });
+  // #185. The gate is the structural half of the fix: with the form absent until the detail GET
+  // resolves, there is no input for a user - or a fast e2e test - to type into before the load
+  // lands. The dirty-guard in loadGoal() is then belt-and-braces for the background callers.
+  // Finishes the #131 / #168 migration for this editor.
+  describe('render gate (#185, finishing #131)', () => {
+    function el(): HTMLElement {
+      return fixture.nativeElement as HTMLElement;
+    }
+
+    it('shows the skeleton and no form until the detail GET resolves', async () => {
+      let resolveGet: (goal: unknown) => void = () => {};
+      goalServiceMock.getGoal.mockImplementation(
+        () => new Promise(resolve => { resolveGet = resolve; })
+      );
+
+      paramMap$.next(convertToParamMap({ name: 'proj1', goalId: '7' }));
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="goal-editor-loading"]')).not.toBeNull();
+      // The point of the gate: nothing to type into yet.
+      expect(el().querySelector('[data-testid="goal-name"]')).toBeNull();
+
+      resolveGet(MOCK_GOAL);
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="goal-editor-loading"]')).toBeNull();
+      expect(el().querySelector('[data-testid="goal-name"]')).not.toBeNull();
+    });
+
+    // The create route never loads, so the gate has to be resolved synchronously in ngOnInit -
+    // otherwise the wizard sits behind the skeleton forever and create is unreachable.
+    it('renders the create wizard immediately, with no skeleton', async () => {
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+
+      expect(comp.loading()).toBe(false);
+      expect(el().querySelector('[data-testid="goal-editor-loading"]')).toBeNull();
+      expect(el().querySelector('[data-testid="goal-wizard"]')).not.toBeNull();
+    });
+
+    it('shows a retryable error state when the load fails, and recovers on retry', async () => {
+      goalServiceMock.getGoal.mockRejectedValueOnce(new Error('boom'));
+
+      paramMap$.next(convertToParamMap({ name: 'proj1', goalId: '7' }));
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="goal-editor-load-error"]')).not.toBeNull();
+      expect(el().querySelector('[data-testid="goal-name"]')).toBeNull();
+
+      goalServiceMock.getGoal.mockResolvedValue(MOCK_GOAL);
+      comp.retryLoad();
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="goal-editor-load-error"]')).toBeNull();
+      expect(el().querySelector('[data-testid="goal-name"]')).not.toBeNull();
+    });
+
+    // Background callers pass skeleton=false. Blanking the form under a user who is reading it
+    // because someone else touched the entity would be its own bug.
+    it('does not blank the form for a background reload', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', goalId: '7' }));
+      fixture.detectChanges();
+      await flush();
+
+      let resolveGet: (goal: unknown) => void = () => {};
+      goalServiceMock.getGoal.mockImplementation(
+        () => new Promise(resolve => { resolveGet = resolve; })
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const reload = (comp as any).loadGoal(false);
+      await flush();
+      fixture.detectChanges();
+
+      expect(comp.loading()).toBe(false);
+      expect(el().querySelector('[data-testid="goal-name"]')).not.toBeNull();
+
+      resolveGet(MOCK_GOAL);
+      await reload;
+    });
+  });
+
 });

--- a/requel-angular/src/app/features/goals/goal-editor.spec.ts
+++ b/requel-angular/src/app/features/goals/goal-editor.spec.ts
@@ -531,4 +531,37 @@ describe('GoalEditorComponent', () => {
     });
   });
 
+  // #185 acceptance criterion: one of these per editor with a detail form, including the three
+  // #184 fixed. goal-editor's existing guard coverage was the SSE path only
+  // ("keeps the SSE guard from clobbering unsaved edits"), which is a different caller - this
+  // pins the guard on the *initial* load, where the bug was originally reported.
+  //
+  // Since the render gate landed, a user cannot actually type during this window - the form is
+  // not on screen. The test still earns its place: the guard is the only defence on the SSE,
+  // 409 and post-save paths, and holding the GET open is the cheapest way to pin it. It asserts
+  // the component contract, not the rendered one.
+  it('does not clobber a value typed while the initial load is still in flight', async () => {
+    let resolveGet: (entity: unknown) => void = () => {};
+    goalServiceMock.getGoal.mockImplementation(
+      () => new Promise(resolve => { resolveGet = resolve; })
+    );
+
+    paramMap$.next(convertToParamMap({ name: 'proj1', goalId: '10' }));
+    fixture.detectChanges();
+    await flush();
+
+    comp.detailsForm.controls.name.setValue('Typed while loading');
+    comp.detailsForm.controls.name.markAsDirty();
+
+    resolveGet({ ...MOCK_GOAL, version: 9 });
+    await flush();
+
+    expect(comp.detailsForm.controls.name.value).toBe('Typed while loading');
+    expect(comp.detailsForm.dirty).toBe(true);
+    // Server state still landed, so the next save carries a version that will not 409.
+      expect(comp.goal()?.id).toBe(10);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((comp as any).version).toBe(9);
+  });
+
 });

--- a/requel-angular/src/app/features/goals/goal-editor.ts
+++ b/requel-angular/src/app/features/goals/goal-editor.ts
@@ -47,6 +47,8 @@ import { AnnotationsSectionComponent } from '../../shared/annotations-section';
 import { TagSelectorComponent } from '../../shared/tag-selector';
 import { AppCardComponent } from '../../shared/app-card';
 import { AppFieldComponent, AppFieldControlDirective } from '../../shared/app-field';
+import { LoadingStateComponent } from '../../shared/loading-state';
+import { ErrorStateComponent } from '../../shared/error-state';
 import {
   AppFormWizardComponent,
   AppWizardStepComponent,
@@ -65,7 +67,8 @@ const STALE_VERSION_MESSAGE =
             ButtonModule, InputText, TextareaModule, SelectModule,
             TableModule, MessageModule, DialogModule, ConfirmDialogModule, EntitySelectorDialogComponent,
             AnnotationsSectionComponent, TagSelectorComponent, AppCardComponent, AppFieldComponent,
-            AppFieldControlDirective, AppFormWizardComponent, AppWizardStepComponent],
+            AppFieldControlDirective, AppFormWizardComponent, AppWizardStepComponent,
+            LoadingStateComponent, ErrorStateComponent],
   providers: [ConfirmationService],
   template: `
     <div class="goal-editor" data-testid="goal-editor">
@@ -91,7 +94,14 @@ const STALE_VERSION_MESSAGE =
         <p-message severity="error" [text]="errorMessage()!" />
       }
 
-      @if (isNew()) {
+      @if (loading()) {
+        <app-card>
+          <app-loading-state label="Loading goal…" [lines]="4" testid="goal-editor-loading" />
+        </app-card>
+      } @else if (loadError()) {
+        <app-error-state [message]="loadError()!" testid="goal-editor-load-error"
+                         (retry)="retryLoad()" />
+      } @else if (isNew()) {
         <!--
           Create runs as a wizard so Tags and Relations are reachable before the first
           save. Step 1 commits EditGoal on Continue, which is what gives steps 2 and 3
@@ -318,6 +328,13 @@ export class GoalEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
   goalName = signal('');
   goal = signal<GoalDto | null>(null);
   errorMessage = signal<string | null>(null);
+  /**
+   * #185. The edit form renders only once the detail GET resolves, so there is no window in which
+   * a user can type into a form the load is about to reset. Starts true: an edit route is loading
+   * from the first frame, and the create path clears it synchronously in ngOnInit.
+   */
+  loading = signal(true);
+  loadError = signal<string | null>(null);
   saving = signal(false);
   canEdit = signal(false);
   canDelete = signal(false);
@@ -398,6 +415,10 @@ export class GoalEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
         this.wizardStep = 'details';
         this.submitted.set(false);
         this.detailsForm.reset({ name: '', text: '' });
+        // Nothing to load, so resolve the gate synchronously (#185) - otherwise the create wizard
+        // would sit behind the skeleton forever. Same reason the reset above is synchronous.
+        this.loading.set(false);
+        this.loadError.set(null);
       }
 
       await this.permissionService.loadForProject(this.projectName);
@@ -446,7 +467,23 @@ export class GoalEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
    * `goalName` is the *persisted* name used to address relation commands, so it deliberately
    * moves only with the form.
    */
-  private async loadGoal(): Promise<void> {
+  /** Re-run the initial load; wired to the error state's (retry) output. */
+  retryLoad(): void {
+    void this.loadGoal();
+  }
+
+  /**
+   * @param skeleton show the loading skeleton and the retryable error state. Suppressed for every
+   *                 background caller - SSE refresh, post-save refetch, 409 recovery and the
+   *                 relation-table refreshes - where blanking the form the user is looking at
+   *                 would be worse than a stale moment, and where a failure belongs in the inline
+   *                 message rather than in place of the form. Mirrors `scenario-editor`.
+   */
+  private async loadGoal(skeleton = true): Promise<void> {
+    if (skeleton) {
+      this.loading.set(true);
+      this.loadError.set(null);
+    }
     try {
       const g = await this.goalService.getGoal(this.projectName, this.goalId!);
       // Always take the version. The entity moved on, and holding the stale one guarantees a
@@ -458,13 +495,21 @@ export class GoalEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
         this.detailsForm.reset({ name: g.name, text: g.text });
       }
     } catch {
-      this.errorMessage.set('Failed to load goal.');
+      if (skeleton) {
+        this.loadError.set('Failed to load goal.');
+      } else {
+        this.errorMessage.set('Failed to load goal.');
+      }
+    } finally {
+      if (skeleton) {
+        this.loading.set(false);
+      }
     }
     if (this.goalId && !this.sseSub) {
       void this.eventStreamService.addSubscription('Goal', this.goalId);
       this.sseSub = this.eventStreamService.events$.subscribe(envelope => {
         if (envelope.targetType === 'Goal' && envelope.targetId === this.goalId) {
-          void this.loadGoal();
+          void this.loadGoal(false);
         }
       });
     }
@@ -556,7 +601,7 @@ export class GoalEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
       // Hydrate relations / referencedBy (and start the SSE subscription) the first
       // time the goal exists, so steps 2 and 3 have something to render.
       if (wasCreate && this.goalId != null) {
-        await this.loadGoal();
+        await this.loadGoal(false);
       }
       return result;
     } catch {
@@ -581,7 +626,7 @@ export class GoalEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
     if (result.status !== 409 || this.goalId == null) {
       return false;
     }
-    await this.loadGoal();
+    await this.loadGoal(false);
     return true;
   }
 
@@ -676,7 +721,7 @@ export class GoalEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
     });
     if (result.success) {
       this.messageService.add({ severity: 'success', summary: 'Relation added', detail: 'Goal relation added.' });
-      await this.loadGoal();
+      await this.loadGoal(false);
     } else {
       this.errorMessage.set(result.error ?? 'Failed to add relation.');
     }
@@ -690,7 +735,7 @@ export class GoalEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
     });
     if (result.success) {
       this.messageService.add({ severity: 'success', summary: 'Relation removed', detail: 'Goal relation removed.' });
-      await this.loadGoal();
+      await this.loadGoal(false);
     } else {
       this.errorMessage.set(result.error ?? 'Failed to delete relation.');
     }

--- a/requel-angular/src/app/features/reports/report-editor.spec.ts
+++ b/requel-angular/src/app/features/reports/report-editor.spec.ts
@@ -143,6 +143,93 @@ describe('ReportEditorComponent', () => {
     expect(comp.form.pristine).toBe(true);
   });
 
+  // #185. The gate is the structural half of the fix: with the form absent until the detail GET
+  // resolves, there is no input for a user - or a fast e2e test - to type into before the load
+  // lands. The dirty-guard in loadReport() is then belt-and-braces for the SSE / post-save paths.
+  describe('render gate (#185, finishing #131)', () => {
+    function el(): HTMLElement {
+      return fixture.nativeElement as HTMLElement;
+    }
+
+    it('shows the skeleton and no form until the detail GET resolves', async () => {
+      let resolveGet: (report: unknown) => void = () => {};
+      reportServiceMock.getReport.mockImplementation(
+        () => new Promise(resolve => { resolveGet = resolve; })
+      );
+
+      paramMap$.next(convertToParamMap({ name: 'proj1', reportId: '7' }));
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="report-editor-loading"]')).not.toBeNull();
+      // The point of the gate: nothing to type into yet.
+      expect(el().querySelector('input#name')).toBeNull();
+
+      resolveGet(MOCK_REPORT);
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="report-editor-loading"]')).toBeNull();
+      expect(el().querySelector('input#name')).not.toBeNull();
+    });
+
+    // The create route never loads, so the gate has to be resolved synchronously in ngOnInit -
+    // otherwise a new document sits behind the skeleton forever.
+    it('renders the create form immediately, with no skeleton', async () => {
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+
+      expect(comp.loading()).toBe(false);
+      expect(el().querySelector('[data-testid="report-editor-loading"]')).toBeNull();
+      expect(el().querySelector('input#name')).not.toBeNull();
+    });
+
+    it('shows a retryable error state when the load fails, and recovers on retry', async () => {
+      reportServiceMock.getReport.mockRejectedValueOnce(new Error('boom'));
+
+      paramMap$.next(convertToParamMap({ name: 'proj1', reportId: '7' }));
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="report-editor-load-error"]')).not.toBeNull();
+      expect(el().querySelector('input#name')).toBeNull();
+
+      reportServiceMock.getReport.mockResolvedValue(MOCK_REPORT);
+      comp.retryLoad();
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="report-editor-load-error"]')).toBeNull();
+      expect(comp.form.controls.name.value).toBe('Requirements Doc');
+    });
+
+    // The post-save refetch passes skeleton=false: blanking the form the user just saved would be
+    // worse than a stale moment, and a failure there belongs inline rather than in place of it.
+    it('does not blank the form for the post-save refetch', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', reportId: '7' }));
+      fixture.detectChanges();
+      await flush();
+
+      let resolveGet: (report: unknown) => void = () => {};
+      reportServiceMock.getReport.mockImplementation(
+        () => new Promise(resolve => { resolveGet = resolve; })
+      );
+      fill('Edited', '<xsl:edited/>');
+      const saving = comp.onSave();
+      await flush();
+      fixture.detectChanges();
+
+      expect(comp.loading()).toBe(false);
+      expect(el().querySelector('input#name')).not.toBeNull();
+
+      resolveGet(MOCK_REPORT);
+      await saving;
+    });
+  });
+
   describe('reactive form (issue #132)', () => {
     it('loads the document into the form and leaves it pristine', async () => {
       paramMap$.next(convertToParamMap({ name: 'proj1', reportId: '7' }));

--- a/requel-angular/src/app/features/reports/report-editor.spec.ts
+++ b/requel-angular/src/app/features/reports/report-editor.spec.ts
@@ -100,6 +100,49 @@ describe('ReportEditorComponent', () => {
     expect(comp.running()).toBe(false);
   });
 
+  // #185: the edit route renders before the detail GET resolves, so the reset had a window to
+  // overwrite whatever the user typed into it - and clearing `dirty` left Save disabled with
+  // nothing on screen explaining why.
+  it('does not clobber a value typed while the initial load is still in flight', async () => {
+    let resolveGet: (report: unknown) => void = () => {};
+    reportServiceMock.getReport.mockImplementation(
+      () => new Promise(resolve => { resolveGet = resolve; })
+    );
+
+    paramMap$.next(convertToParamMap({ name: 'proj1', reportId: '7' }));
+    fixture.detectChanges();
+    await flush();
+
+    // The user is faster than the network.
+    comp.form.controls.name.setValue('Typed while loading');
+    comp.form.controls.name.markAsDirty();
+
+    resolveGet(MOCK_REPORT);
+    await flush();
+
+    expect(comp.form.controls.name.value).toBe('Typed while loading');
+    expect(comp.form.dirty).toBe(true);
+    // Server state still landed, so the editor knows which document it is holding.
+    expect(comp.report()?.id).toBe(7);
+    expect(comp.reportId()).toBe(7);
+  });
+
+  // Guards the ordering inside onSave: the post-save refetch has to run against a form already
+  // marked pristine, or the #185 guard makes loadReport skip its own result. term-editor had a
+  // test for this; report-editor did not.
+  it('marks the form pristine after a successful save of an existing document', async () => {
+    paramMap$.next(convertToParamMap({ name: 'proj1', reportId: '7' }));
+    fixture.detectChanges();
+    await flush();
+    comp.form.controls.text.setValue('<xsl:edited/>');
+    comp.form.controls.text.markAsDirty();
+
+    await comp.onSave();
+    await flush();
+
+    expect(comp.form.pristine).toBe(true);
+  });
+
   describe('reactive form (issue #132)', () => {
     it('loads the document into the form and leaves it pristine', async () => {
       paramMap$.next(convertToParamMap({ name: 'proj1', reportId: '7' }));

--- a/requel-angular/src/app/features/reports/report-editor.ts
+++ b/requel-angular/src/app/features/reports/report-editor.ts
@@ -250,15 +250,32 @@ export class ReportEditorComponent implements OnInit, OnDestroy, DirtyCheckable 
     this.paramSub?.unsubscribe();
   }
 
+  /**
+   * Reads the document and applies it in two parts: server state always, form state only when the
+   * user has nothing unsaved.
+   *
+   * The patch/`markAsPristine()` pair used to run unconditionally. `page.goto()` on the edit route
+   * returns long before this fetch does, so anything typed in that gap was silently discarded and
+   * the form went back to pristine - Save then stayed disabled with no explanation (#185).
+   * `ngOnInit`'s create path already resets synchronously to dodge exactly this; the edit path had
+   * no equivalent. The check sits after the await on purpose, so it catches edits made while the
+   * request was still in flight.
+   *
+   * `reportName` is the *persisted* name - it titles the page, names the download, and is quoted
+   * in the delete confirmation - so it moves only with the form, matching `goal-editor`.
+   * `submitted` likewise: clearing it would hide validation errors the user is looking at.
+   */
   private async loadReport(id: number): Promise<void> {
     try {
       const r = await this.reportService.getReport(this.projectName, id);
       this.report.set(r);
       this.reportId.set(r.id);
-      this.reportName.set(r.name);
-      this.form.patchValue({ name: r.name, text: r.text ?? '' });
-      this.form.markAsPristine();
-      this.submitted.set(false);
+      if (!this.hasUnsavedChanges()) {
+        this.reportName.set(r.name);
+        this.form.patchValue({ name: r.name, text: r.text ?? '' });
+        this.form.markAsPristine();
+        this.submitted.set(false);
+      }
     } catch {
       this.errorMessage.set('Failed to load document.');
     }
@@ -298,6 +315,12 @@ export class ReportEditorComponent implements OnInit, OnDestroy, DirtyCheckable 
         this.form.markAsPristine();
         this.router.navigate(['/projects', this.projectName, 'reports', saved.id], { replaceUrl: true });
       } else {
+        // Mark pristine BEFORE the refetch. The load method only adopts server state into the
+        // form when the form has nothing unsaved (#185), and what was "unsaved" a moment ago is
+        // exactly what we just persisted - leaving it dirty would make the reload skip its own
+        // result, so Save stayed enabled on a freshly saved form. Same ordering scenario-editor
+        // uses around its post-save refetch.
+        this.form.markAsPristine();
         await this.loadReport(this.reportId()!);
       }
       return;

--- a/requel-angular/src/app/features/reports/report-editor.ts
+++ b/requel-angular/src/app/features/reports/report-editor.ts
@@ -37,6 +37,8 @@ import { PermissionService } from '../../core/permission.service';
 import { AnnotationsSectionComponent } from '../../shared/annotations-section';
 import { FileUploadButtonComponent } from '../../shared/file-upload-button';
 import { AppFieldComponent, AppFieldControlDirective } from '../../shared/app-field';
+import { LoadingStateComponent } from '../../shared/loading-state';
+import { ErrorStateComponent } from '../../shared/error-state';
 import { applyCommandErrors, clearServerErrors } from '../../shared/form-errors';
 import { ARTIFACT_NAME_MAX_LENGTH } from '../../shared/validation-limits';
 
@@ -65,6 +67,8 @@ const REPORT_FIELD_MAP: Record<string, string> = {};
     FileUploadButtonComponent,
     AppFieldComponent,
     AppFieldControlDirective,
+    LoadingStateComponent,
+    ErrorStateComponent,
   ],
   providers: [ConfirmationService],
   template: `
@@ -89,71 +93,81 @@ const REPORT_FIELD_MAP: Record<string, string> = {};
         <p-message severity="error" [text]="errorMessage()!" />
       }
 
-      <app-card>
-        <form [formGroup]="form" (ngSubmit)="onSave()">
-          <!-- controlId "name" / "text": ReportEditorPage and BaseListPage's default
-               readySelector locate #name and #text, so those ids stay stable. -->
-          <app-field
-            label="Name"
-            controlId="name"
-            [control]="form.controls.name"
-            [submitted]="submitted()"
-          >
-            <input
-              id="name"
-              pInputText
-              appFieldControl
-              formControlName="name"
-              [attr.maxlength]="nameMaxLength"
-              placeholder="Template name"
-            />
-          </app-field>
-
-          <app-field
-            label="XSLT Template"
-            controlId="text"
-            [control]="form.controls.text"
-            [submitted]="submitted()"
-            [divider]="false"
-          >
-            <div class="xslt-field">
-              <textarea
-                id="text"
-                pTextarea
+      @if (loading()) {
+        <app-card>
+          <app-loading-state label="Loading document…" [lines]="4" testid="report-editor-loading" />
+        </app-card>
+      } @else if (loadError()) {
+        <app-error-state [message]="loadError()!" testid="report-editor-load-error"
+                         (retry)="retryLoad()" />
+      } @else {
+        <app-card>
+          <form [formGroup]="form" (ngSubmit)="onSave()">
+            <!-- controlId "name" / "text": ReportEditorPage and BaseListPage's default
+                 readySelector locate #name and #text, so those ids stay stable. -->
+            <app-field
+              label="Name"
+              controlId="name"
+              [control]="form.controls.name"
+              [submitted]="submitted()"
+            >
+              <input
+                id="name"
+                pInputText
                 appFieldControl
-                formControlName="text"
-                rows="20"
-                placeholder="Paste XSLT stylesheet here..."
-                class="xslt-textarea"
-              ></textarea>
-              <div class="upload-row">
-                <app-file-upload-button label="Upload XSLT" [outlined]="true" size="small"
-                                        accept=".xsl,.xslt,.xml" (fileSelected)="onFileUpload($event)" />
-                <span class="upload-hint">Upload a .xsl/.xslt file to replace the template text.</span>
+                formControlName="name"
+                [attr.maxlength]="nameMaxLength"
+                placeholder="Template name"
+              />
+            </app-field>
+
+            <app-field
+              label="XSLT Template"
+              controlId="text"
+              [control]="form.controls.text"
+              [submitted]="submitted()"
+              [divider]="false"
+            >
+              <div class="xslt-field">
+                <textarea
+                  id="text"
+                  pTextarea
+                  appFieldControl
+                  formControlName="text"
+                  rows="20"
+                  placeholder="Paste XSLT stylesheet here..."
+                  class="xslt-textarea"
+                ></textarea>
+                <div class="upload-row">
+                  <app-file-upload-button label="Upload XSLT" [outlined]="true" size="small"
+                                          accept=".xsl,.xslt,.xml" (fileSelected)="onFileUpload($event)" />
+                  <span class="upload-hint">Upload a .xsl/.xslt file to replace the template text.</span>
+                </div>
               </div>
+            </app-field>
+
+            <div class="form-actions">
+              <p-button
+                type="submit"
+                label="Save"
+                icon="pi pi-check"
+                data-testid="report-save"
+                [loading]="saving()"
+                [disabled]="form.invalid || form.pristine || saving()"
+              />
             </div>
-          </app-field>
+          </form>
+        </app-card>
 
-          <div class="form-actions">
-            <p-button
-              type="submit"
-              label="Save"
-              icon="pi pi-check"
-              data-testid="report-save"
-              [loading]="saving()"
-              [disabled]="form.invalid || form.pristine || saving()"
-            />
-          </div>
-        </form>
-      </app-card>
-
-      @if (!isNew()) {
-        <app-annotations-section
-          [projectName]="projectName"
-          entityType="ReportGenerator"
-          [entityId]="reportId()"
-          [canEdit]="canEdit()" />
+        @if (!isNew()) {
+          <app-annotations-section
+            [projectName]="projectName"
+            entityType="ReportGenerator"
+            [entityId]="reportId()"
+            [canEdit]="canEdit()" />
+        }
       }
+
     </div>
 
     <p-confirmDialog />
@@ -178,6 +192,14 @@ export class ReportEditorComponent implements OnInit, OnDestroy, DirtyCheckable 
   submitted = signal(false);
   running = signal(false);
   errorMessage = signal<string | null>(null);
+  /**
+   * #185. The edit form renders only once the detail GET resolves, so there is no window in which
+   * a user can type into a form the load is about to reset. Starts true: an edit route is loading
+   * from the first frame, and the create path clears it synchronously in ngOnInit.
+   */
+  loading = signal(true);
+  loadError = signal<string | null>(null);
+  private lastReportId: number | null = null;
 
   /**
    * Mirrors the backend `@Size(max = ValidationLimits.ARTIFACT_NAME_MAX)` (#171). Bound with
@@ -229,6 +251,10 @@ export class ReportEditorComponent implements OnInit, OnDestroy, DirtyCheckable 
         this.reportId.set(null);
         this.submitted.set(false);
         this.form.reset({ name: '', text: '' });
+        // Nothing to load, so resolve the gate synchronously (#185) - otherwise the create form
+        // would sit behind the skeleton forever. Same reason the reset above is synchronous.
+        this.loading.set(false);
+        this.loadError.set(null);
       }
 
       await this.permissionService.loadForProject(this.projectName);
@@ -265,7 +291,25 @@ export class ReportEditorComponent implements OnInit, OnDestroy, DirtyCheckable 
    * in the delete confirmation - so it moves only with the form, matching `goal-editor`.
    * `submitted` likewise: clearing it would hide validation errors the user is looking at.
    */
-  private async loadReport(id: number): Promise<void> {
+  /** Re-run the last attempted load; wired to the error state's (retry) output. */
+  retryLoad(): void {
+    if (this.lastReportId != null) {
+      void this.loadReport(this.lastReportId);
+    }
+  }
+
+  /**
+   * @param skeleton show the loading skeleton and the retryable error state. Suppressed for the
+   *                 post-save refetch, where blanking the form the user is looking at would be
+   *                 worse than a stale moment, and where a failure belongs in the inline message
+   *                 rather than in place of the form. Mirrors `scenario-editor`.
+   */
+  private async loadReport(id: number, skeleton = true): Promise<void> {
+    this.lastReportId = id;
+    if (skeleton) {
+      this.loading.set(true);
+      this.loadError.set(null);
+    }
     try {
       const r = await this.reportService.getReport(this.projectName, id);
       this.report.set(r);
@@ -277,7 +321,15 @@ export class ReportEditorComponent implements OnInit, OnDestroy, DirtyCheckable 
         this.submitted.set(false);
       }
     } catch {
-      this.errorMessage.set('Failed to load document.');
+      if (skeleton) {
+        this.loadError.set('Failed to load document.');
+      } else {
+        this.errorMessage.set('Failed to load document.');
+      }
+    } finally {
+      if (skeleton) {
+        this.loading.set(false);
+      }
     }
   }
 
@@ -321,7 +373,7 @@ export class ReportEditorComponent implements OnInit, OnDestroy, DirtyCheckable 
         // result, so Save stayed enabled on a freshly saved form. Same ordering scenario-editor
         // uses around its post-save refetch.
         this.form.markAsPristine();
-        await this.loadReport(this.reportId()!);
+        await this.loadReport(this.reportId()!, false);
       }
       return;
     }

--- a/requel-angular/src/app/features/scenarios/scenario-editor.spec.ts
+++ b/requel-angular/src/app/features/scenarios/scenario-editor.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter, Router, ActivatedRoute, convertToParamMap } from '@angular/router';
 import { Location } from '@angular/common';
-import { BehaviorSubject, EMPTY } from 'rxjs';
+import { BehaviorSubject, EMPTY, Subject } from 'rxjs';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ScenarioEditorComponent } from './scenario-editor';
 import { ScenarioService } from '../../core/scenario.service';
@@ -332,6 +332,128 @@ describe('ScenarioEditorComponent', () => {
 
       expect(request.complete).not.toHaveBeenCalled();
       expect(request.fail).toHaveBeenCalledWith(expect.stringContaining('changed elsewhere'));
+    });
+  });
+
+  // #185. Unlike the other editors in this issue, scenario-editor is render-gated - the form sits
+  // behind @if (loading()), so the "typed before the detail GET returned" race cannot happen here.
+  // Its unguarded callers were the post-save refetch and the 409 recovery, both of which passed
+  // fromSSE = false and so reset unconditionally.
+  describe('unsaved work survives a load (#185)', () => {
+    it('a 409 recovery keeps the edit being retried and adopts the new version', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', scenarioId: '15' }));
+      fixture.detectChanges();
+      await flush();
+
+      comp.detailsForm.controls.name.setValue('My retried rename');
+      comp.detailsForm.controls.name.markAsDirty();
+
+      // The save conflicts; the recovery refetch returns a scenario that moved on.
+      commandServiceMock.execute.mockResolvedValue({ success: false, status: 409, error: 'Conflict' });
+      scenarioServiceMock.getScenario.mockResolvedValue({
+        ...MOCK_SCENARIO, version: 9, name: 'Renamed elsewhere'
+      });
+
+      await comp.onSave();
+
+      // The whole point of a retry: the user's edit is still there to resend...
+      expect(comp.detailsForm.controls.name.value).toBe('My retried rename');
+      expect(comp.detailsForm.dirty).toBe(true);
+      // ...against a version that will not 409 again.
+      expect(comp.scenario()?.version).toBe(9);
+    });
+
+    it('the post-save refetch gives new steps their server ids without replacing the list',
+      async () => {
+        fixture.detectChanges();
+        await flush();
+
+        comp.detailsForm.controls.name.setValue('Created');
+        comp.addStep();
+        comp.stepNodes()[0].name = 'Step one';
+        expect(comp.stepNodes()[0].stepId).toBeNull();
+        expect(comp.stepNodes()[0].isNew).toBe(true);
+
+        // The save succeeds and the refetch reports the step the server just created. That
+        // refetch runs while saving() is still true, so it takes the merge path.
+        //
+        // The server's copy is deliberately given a DIFFERENT name here. In production the two
+        // agree, but that makes the merge path and the old wholesale `stepNodes.set(...)`
+        // indistinguishable - both end up with stepId 77 and the test passes either way. Making
+        // them differ is what pins which path actually ran: the merge keeps the user's node and
+        // only fills in the id, a wholesale replace adopts the server's name.
+        commandServiceMock.execute.mockResolvedValue({
+          success: true, entity: { ...MOCK_SCENARIO, id: 15, version: 1 }
+        });
+        scenarioServiceMock.getScenario.mockResolvedValue({
+          ...MOCK_SCENARIO, id: 15, version: 1,
+          steps: [{ id: 77, name: 'Server copy', text: null, scenarioType: 'Primary', isScenario: false }]
+        });
+
+        const request = { step: { key: 'details' }, complete: vi.fn(), fail: vi.fn() };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await comp.onStepCommit(request as any);
+        await flush();
+
+        // Without the merge the node keeps stepId null and the next EditScenario recreates it.
+        expect(comp.stepNodes()).toHaveLength(1);
+        expect(comp.stepNodes()[0].stepId).toBe(77);
+        expect(comp.stepNodes()[0].isNew).toBe(false);
+        expect(comp.stepNodes()[0].name).toBe('Step one');
+      });
+
+    // Pins the known gap in the position-based merge rather than claiming it is handled: a node
+    // that already has an id is never re-keyed, so a reorder cannot corrupt saved steps - but an
+    // id-less node sitting at a position now held by a different server step takes that step's id.
+    it('only fills in id-less step nodes, leaving already-identified ones alone', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', scenarioId: '15' }));
+      fixture.detectChanges();
+      await flush();
+
+      // Two loaded steps (ids 1 and 2) plus one the user just added.
+      comp.addStep();
+      comp.stepNodes()[2].name = 'Third';
+      comp.detailsForm.controls.name.setValue('Dirty');
+      comp.detailsForm.controls.name.markAsDirty();
+
+      scenarioServiceMock.getScenario.mockResolvedValue({
+        ...MOCK_SCENARIO,
+        steps: [
+          { id: 1, name: 'User opens login page', text: null, scenarioType: 'Primary', isScenario: false },
+          { id: 2, name: 'User submits credentials', text: null, scenarioType: 'Primary', isScenario: false },
+          { id: 3, name: 'Third', text: null, scenarioType: 'Primary', isScenario: false }
+        ]
+      });
+
+      const events$ = new Subject<{ targetType: string; targetId: number }>();
+      eventStreamServiceMock.events$ = events$.asObservable() as typeof EMPTY;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (comp as any).loadScenario(false);
+
+      expect(comp.stepNodes().map(n => n.stepId)).toEqual([1, 2, 3]);
+      expect(comp.stepNodes()[2].isNew).toBe(false);
+      // The form itself is untouched - this ran with the guard closed.
+      expect(comp.detailsForm.controls.name.value).toBe('Dirty');
+      expect(comp.detailsForm.dirty).toBe(true);
+    });
+
+    it('an SSE refresh while the step popup is open does not orphan the edited node', async () => {
+      const events$ = new Subject<{ targetType: string; targetId: number }>();
+      eventStreamServiceMock.events$ = events$.asObservable() as typeof EMPTY;
+
+      paramMap$.next(convertToParamMap({ name: 'proj1', scenarioId: '15' }));
+      fixture.detectChanges();
+      await flush();
+
+      comp.openStepEdit(comp.stepNodes()[0]);
+      const editing = comp.editingStep();
+
+      events$.next({ targetType: 'Scenario', targetId: 15 });
+      await flush();
+
+      // Same object identity - a wholesale stepNodes.set() would have replaced it.
+      expect(comp.editingStep()).toBe(editing);
+      expect(comp.stepNodes()[0]).toBe(editing);
     });
   });
 

--- a/requel-angular/src/app/features/scenarios/scenario-editor.ts
+++ b/requel-angular/src/app/features/scenarios/scenario-editor.ts
@@ -553,11 +553,29 @@ export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckabl
   }
 
   /**
-   * @param fromSSE  background refresh driven by an event, not by the user.
-   * @param skeleton show the loading skeleton. Suppressed after a save, where blanking the
-   *                 wizard panel the user is standing in would be worse than a stale moment.
+   * Reads the scenario and applies it in two parts: server state always, form and step state only
+   * when the user has nothing in progress.
+   *
+   * The guard used to be `fromSSE && (...)`, so only a background refresh protected the user's
+   * work. Unlike the other editors in #185 the initial load was never the problem here - this
+   * editor is render-gated (`loading = signal(true)` with the form behind `@if (loading())`), so
+   * there is no window to type into before the fetch returns. The unprotected callers were the
+   * *other* two: the post-save refetch and the 409 recovery, both of which passed `fromSSE = false`
+   * and so reset unconditionally. The 409 one is the live bug - it threw away the edit the user
+   * was retrying, which is the opposite of what #184 established for goal/story/actor.
+   *
+   * `fromSSE` is gone; the guard no longer varies by caller. `skeleton` keeps its own default.
+   *
+   * The three conditions are unchanged. `saving()` matters more than it looks: the post-save
+   * refetch runs while `saving()` is still true, so it now deterministically takes the merge path
+   * below - which is exactly the path it wants, since the form was marked pristine and the step
+   * list settled before it was issued. `editingStep() !== null` means the step-detail popup is
+   * open, and replacing `stepNodes` would orphan the object it points at.
+   *
+   * @param skeleton show the loading skeleton. Suppressed for background refreshes, where blanking
+   *                 the wizard panel the user is standing in would be worse than a stale moment.
    */
-  private async loadScenario(fromSSE = false, skeleton = !fromSSE): Promise<void> {
+  private async loadScenario(skeleton = true): Promise<void> {
     // Only the user-initiated load drives the skeleton / retryable error state; a background
     // refresh must not blank the form the user is looking at.
     if (skeleton) {
@@ -566,25 +584,21 @@ export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckabl
     }
     try {
       const s = await this.scenarioService.getScenario(this.projectName, this.scenarioId!);
-      // Don't overwrite unsaved user edits when called from an SSE notification.
-      // Check after the async fetch so we catch edits made while the request was in-flight.
-      // editingStep() !== null means the step-detail popup is open: replacing stepNodes
-      // would orphan the object that editingStep points to, losing any in-progress edits.
-      if (fromSSE && (this.hasUnsavedChanges() || this.saving() || this.editingStep() !== null)) {
-        // Still take the new version: the entity moved on, and holding the stale one
-        // guarantees a 409 on the user's next save.
-        this.version = s.version;
-        this.scenario.set(s);
+      // Always take the version. The entity moved on, and holding the stale one guarantees a
+      // 409 on the user's next save.
+      this.version = s.version;
+      this.scenario.set(s);
+      // Checked after the fetch so it catches edits made while the request was in flight.
+      if (this.hasUnsavedChanges() || this.saving() || this.editingStep() !== null) {
+        this.mergeStepIds(s.steps ?? []);
         return;
       }
-      this.scenario.set(s);
       this.scenarioName.set(s.name);
       this.detailsForm.reset({
         name: s.name,
         scenarioType: s.scenarioType ?? 'Primary',
         text: s.text ?? '',
       });
-      this.version = s.version;
       this.stepsSaveNeeded.set(false);
       this.stepNodes.set(this.stepsToNodes(s.steps ?? []));
     } catch {
@@ -604,10 +618,37 @@ export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckabl
       void this.eventStreamService.addSubscription('Scenario', this.scenarioId);
       this.sseSub = this.eventStreamService.events$.subscribe(envelope => {
         if (envelope.targetType === 'Scenario' && envelope.targetId === this.scenarioId) {
-          void this.loadScenario(true);
+          void this.loadScenario(false);
         }
       });
     }
+  }
+
+  /**
+   * Copy server-assigned ids onto the nodes the user is already holding, instead of replacing the
+   * array wholesale.
+   *
+   * `stepNodes` is not display state like `actor-editor`'s tables - it is editable state submitted
+   * with `EditScenario`, so it can go neither inside the guard nor outside it. The post-save
+   * refetch exists precisely so newly created steps pick up their ids; if the user types during it
+   * the guard skips `stepNodes.set(...)` and those nodes keep `stepId: null` / `isNew: true`, and
+   * the next `EditScenario` sends them as new again - duplicating them server-side.
+   *
+   * Only id-less nodes are filled in, and matching is by position, which is how `EditScenario`
+   * submits the list: sent and rebuilt wholesale, in order. Known gap: if the user reorders steps
+   * between the save and this refetch, an id-less node can sit at a position now held by a
+   * different server step and take the wrong id. Pinned by a test rather than fixed - the ids are
+   * only unknown for the brief window just after a create, and an identity match would need a key
+   * the client does not have for a step the server has never seen.
+   */
+  private mergeStepIds(steps: StepDto[]): void {
+    this.stepNodes.update(nodes => nodes.map((node, i) => {
+      const step = steps[i];
+      if (!step || node.stepId != null) {
+        return node;
+      }
+      return { ...node, stepId: step.id, isNew: false };
+    }));
   }
 
   private stepsToNodes(steps: StepDto[]): StepNodeData[] {
@@ -816,7 +857,7 @@ export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckabl
       // starts the first time the scenario exists. No skeleton: in the wizard that would
       // blank the panel the user is standing in.
       if (this.scenarioId != null) {
-        await this.loadScenario(false, false);
+        await this.loadScenario(false);
       }
       return result;
     } catch {
@@ -841,7 +882,7 @@ export class ScenarioEditorComponent implements OnInit, OnDestroy, DirtyCheckabl
     if (result.status !== 409 || this.scenarioId == null) {
       return false;
     }
-    await this.loadScenario(false, false);
+    await this.loadScenario(false);
     return true;
   }
 

--- a/requel-angular/src/app/features/stakeholders/stakeholder-editor.spec.ts
+++ b/requel-angular/src/app/features/stakeholders/stakeholder-editor.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter, Router, ActivatedRoute, convertToParamMap } from '@angular/router';
-import { BehaviorSubject, EMPTY } from 'rxjs';
+import { BehaviorSubject, EMPTY, Subject } from 'rxjs';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { StakeholderEditorComponent } from './stakeholder-editor';
 import { StakeholderService } from '../../core/stakeholder.service';
@@ -172,6 +172,66 @@ describe('StakeholderEditorComponent', () => {
       expect(comp.detailsForm.dirty).toBe(false);
       expect(comp.hasUnsavedChanges()).toBe(true);
       expect(comp.getSelectedPermissionKeys().sort()).toEqual(['delete_goal', 'edit_goal']);
+    });
+  });
+
+  // #185. Two forms to protect here rather than one, and an unusually wide window: loadUsers()
+  // and loadPermissions() are awaited inside loadStakeholder(), so on the user path the form is
+  // typeable across three round trips.
+  describe('unsaved edits survive a load (#185)', () => {
+    it('does not clobber a value typed while the initial load is still in flight', async () => {
+      let resolveGet: (stakeholder: unknown) => void = () => {};
+      stakeholderServiceMock.getStakeholder.mockImplementation(
+        () => new Promise(resolve => { resolveGet = resolve; })
+      );
+
+      paramMap$.next(convertToParamMap({ name: 'proj1', stakeholderId: '51' }));
+      fixture.detectChanges();
+      await flush();
+
+      // The user is faster than the network.
+      comp.detailsForm.controls.name.setValue('Typed while loading');
+      comp.detailsForm.controls.name.markAsDirty();
+
+      resolveGet({ ...MOCK_STAKEHOLDER_NONUSER, version: 4 });
+      await flush();
+
+      expect(comp.detailsForm.controls.name.value).toBe('Typed while loading');
+      expect(comp.detailsForm.dirty).toBe(true);
+      // Server state still landed, so Save has a usable version to send.
+      expect(comp.isUserType()).toBe(false);
+    });
+
+    // The distinguishing case for this editor: loadPermissions() rebuilds the checkbox controls
+    // from the server's key set, so running it over a half-ticked matrix silently reverts the
+    // ticks. detailsForm is pristine throughout - only permissionsForm is dirty.
+    it('does not revert permission ticks when an SSE refresh lands', async () => {
+      const events$ = new Subject<{ targetType: string; targetId: number }>();
+      eventStreamServiceMock.events$ = events$.asObservable() as typeof EMPTY;
+
+      paramMap$.next(convertToParamMap({ name: 'proj1', stakeholderId: '50' }));
+      fixture.detectChanges();
+      await flush();
+
+      comp.permissionControl('delete_goal').setValue(true);
+      comp.permissionControl('delete_goal').markAsDirty();
+      expect(comp.detailsForm.dirty).toBe(false);
+
+      // A refresh whose server state still has only edit_goal selected.
+      stakeholderServiceMock.getStakeholder.mockResolvedValue({
+        ...MOCK_STAKEHOLDER_USER,
+        version: 7,
+        goals: [{ id: 1, name: 'Added elsewhere', entityType: 'Goal' }]
+      });
+
+      events$.next({ targetType: 'Stakeholder', targetId: 50 });
+      await flush();
+
+      // The tick survives...
+      expect(comp.permissionControl('delete_goal').value).toBe(true);
+      expect(comp.permissionsForm.dirty).toBe(true);
+      // ...while the goals table still refreshed, rather than sitting stale behind the edit.
+      expect(comp.goals().length).toBe(1);
     });
   });
 

--- a/requel-angular/src/app/features/stakeholders/stakeholder-editor.spec.ts
+++ b/requel-angular/src/app/features/stakeholders/stakeholder-editor.spec.ts
@@ -408,4 +408,96 @@ describe('StakeholderEditorComponent', () => {
       expect.objectContaining({ stakeholderId: 50 }));
     expect(router.navigate).toHaveBeenCalled();
   });
+  // #185. The gate is the structural half of the fix: with the form absent until the detail GET
+  // resolves, there is no input for a user - or a fast e2e test - to type into before the load
+  // lands. The dirty-guard in loadStakeholder() is then belt-and-braces for the background callers.
+  // Finishes the #131 / #168 migration for this editor.
+  describe('render gate (#185, finishing #131)', () => {
+    function el(): HTMLElement {
+      return fixture.nativeElement as HTMLElement;
+    }
+
+    it('shows the skeleton and no form until the detail GET resolves', async () => {
+      let resolveGet: (entity: unknown) => void = () => {};
+      stakeholderServiceMock.getStakeholder.mockImplementation(
+        () => new Promise(resolve => { resolveGet = resolve; })
+      );
+
+      paramMap$.next(convertToParamMap({ name: 'proj1', stakeholderId: '51' }));
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="stakeholder-editor-loading"]')).not.toBeNull();
+      // The point of the gate: nothing to type into yet.
+      expect(el().querySelector('[data-testid="stakeholder-name"]')).toBeNull();
+
+      resolveGet(MOCK_STAKEHOLDER_NONUSER);
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="stakeholder-editor-loading"]')).toBeNull();
+      expect(el().querySelector('[data-testid="stakeholder-name"]')).not.toBeNull();
+    });
+
+    // The create route never loads, so the gate has to be resolved there explicitly - otherwise
+    // the wizard sits behind the skeleton forever and create becomes unreachable.
+    it('renders the create wizard, with no skeleton', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', stakeholderId: 'new-nonuser' }));
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+
+      expect(comp.loading()).toBe(false);
+      expect(el().querySelector('[data-testid="stakeholder-editor-loading"]')).toBeNull();
+      expect(el().querySelector('[data-testid="stakeholder-wizard"]')).not.toBeNull();
+    });
+
+    it('shows a retryable error state when the load fails, and recovers on retry', async () => {
+      stakeholderServiceMock.getStakeholder.mockRejectedValueOnce(new Error('boom'));
+
+      paramMap$.next(convertToParamMap({ name: 'proj1', stakeholderId: '51' }));
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="stakeholder-editor-load-error"]')).not.toBeNull();
+      expect(el().querySelector('[data-testid="stakeholder-name"]')).toBeNull();
+
+      stakeholderServiceMock.getStakeholder.mockResolvedValue(MOCK_STAKEHOLDER_NONUSER);
+      comp.retryLoad();
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="stakeholder-editor-load-error"]')).toBeNull();
+      expect(el().querySelector('[data-testid="stakeholder-name"]')).not.toBeNull();
+    });
+
+    // Background callers pass skeleton=false. Blanking the form under a user who is reading it
+    // because someone else touched the entity would be its own bug.
+    it('does not blank the form for a background reload', async () => {
+      // Explicitly a non-user stakeholder: the default mock is the user type, whose Details step
+      // renders username/team instead of the name field this test asserts on.
+      stakeholderServiceMock.getStakeholder.mockResolvedValue(MOCK_STAKEHOLDER_NONUSER);
+      paramMap$.next(convertToParamMap({ name: 'proj1', stakeholderId: '51' }));
+      fixture.detectChanges();
+      await flush();
+
+      let resolveGet: (entity: unknown) => void = () => {};
+      stakeholderServiceMock.getStakeholder.mockImplementation(
+        () => new Promise(resolve => { resolveGet = resolve; })
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const reload = (comp as any).loadStakeholder(false);
+      await flush();
+      fixture.detectChanges();
+
+      expect(comp.loading()).toBe(false);
+      expect(el().querySelector('[data-testid="stakeholder-name"]')).not.toBeNull();
+
+      resolveGet(MOCK_STAKEHOLDER_NONUSER);
+      await reload;
+    });
+  });
+
 });

--- a/requel-angular/src/app/features/stakeholders/stakeholder-editor.ts
+++ b/requel-angular/src/app/features/stakeholders/stakeholder-editor.ts
@@ -45,6 +45,8 @@ import { PermissionService } from '../../core/permission.service';
 import { EventStreamService } from '../../core/event-stream.service';
 import { EntitySelectorDialogComponent } from '../../shared/entity-selector-dialog';
 import { AppFieldComponent, AppFieldControlDirective } from '../../shared/app-field';
+import { LoadingStateComponent } from '../../shared/loading-state';
+import { ErrorStateComponent } from '../../shared/error-state';
 import {
   AppFormWizardComponent,
   AppWizardStepComponent,
@@ -85,7 +87,8 @@ interface PermissionGroup {
             ButtonModule, InputText, TextareaModule, SelectModule,
             CheckboxModule, MessageModule, ConfirmDialogModule, TableModule,
             EntitySelectorDialogComponent, AppFieldComponent, AppFieldControlDirective,
-            AppFormWizardComponent, AppWizardStepComponent],
+            AppFormWizardComponent, AppWizardStepComponent,
+            LoadingStateComponent, ErrorStateComponent],
   providers: [ConfirmationService],
   template: `
     <div class="stakeholder-editor">
@@ -105,7 +108,14 @@ interface PermissionGroup {
         <p-message severity="error" [text]="errorMessage()!" />
       }
 
-      @if (isNew()) {
+      @if (loading()) {
+        <app-card>
+          <app-loading-state label="Loading stakeholder…" [lines]="4" testid="stakeholder-editor-loading" />
+        </app-card>
+      } @else if (loadError()) {
+        <app-error-state [message]="loadError()!" testid="stakeholder-editor-load-error"
+                         (retry)="retryLoad()" />
+      } @else if (isNew()) {
         <!--
           Create runs as a wizard (#173) so Goals is reachable before the first save. The User
           select stays on step 1 and stays [disabled]="!isNew()" - it is the mode selector, and
@@ -311,6 +321,14 @@ export class StakeholderEditorComponent implements OnInit, OnDestroy, DirtyCheck
   isUserType = signal(true);
   stakeholderName = signal('');
   errorMessage = signal<string | null>(null);
+  /**
+   * #185. The edit form renders only once the detail GET resolves, so there is no window in which
+   * a user can type into a form the load is about to reset. Starts true: an edit route is loading
+   * from the first frame, and the create path clears it as soon as it knows there is nothing to
+   * load.
+   */
+  loading = signal(true);
+  loadError = signal<string | null>(null);
   saving = signal(false);
   canDelete = signal(false);
   userOptions = signal<{ label: string; value: string }[]>([]);
@@ -407,6 +425,11 @@ export class StakeholderEditorComponent implements OnInit, OnDestroy, DirtyCheck
     this.goals.set([]);
     this.detailsForm.reset({ username: '', teamName: '', name: '', text: '' });
     this.applyMode(isUser);
+    // Nothing to load, so resolve the gate (#185) - otherwise the create wizard sits behind the
+    // skeleton forever and create becomes unreachable. Both create routes - new-user and
+    // new-nonuser - come through here.
+    this.loading.set(false);
+    this.loadError.set(null);
   }
 
   /**
@@ -487,7 +510,23 @@ export class StakeholderEditorComponent implements OnInit, OnDestroy, DirtyCheck
    * dropdown options. Skipping the goals table behind a dirty form is the stale-table trap #184
    * found in `actor-editor`. `stakeholderName` is the *persisted* name, so it moves with the form.
    */
-  private async loadStakeholder(): Promise<void> {
+  /** Re-run the initial load; wired to the error state's (retry) output. */
+  retryLoad(): void {
+    void this.loadStakeholder();
+  }
+
+  /**
+   * @param skeleton show the loading skeleton and the retryable error state. Suppressed for every
+   *                 background caller - SSE refresh, post-save refetch and 409 recovery and the association refreshes - where
+   *                 blanking the form the user is looking at would be worse than a stale moment,
+   *                 and where a failure belongs in the inline message rather than in place of the
+   *                 form. Mirrors `scenario-editor`.
+   */
+  private async loadStakeholder(skeleton = true): Promise<void> {
+    if (skeleton) {
+      this.loading.set(true);
+      this.loadError.set(null);
+    }
     try {
       const s = await this.stakeholderService.getStakeholder(this.projectName, this.stakeholderId!);
       // Server state, always.
@@ -520,13 +559,21 @@ export class StakeholderEditorComponent implements OnInit, OnDestroy, DirtyCheck
         this.permissionsForm.markAsPristine();
       }
     } catch {
-      this.errorMessage.set('Failed to load stakeholder.');
+      if (skeleton) {
+        this.loadError.set('Failed to load stakeholder.');
+      } else {
+        this.errorMessage.set('Failed to load stakeholder.');
+      }
+    } finally {
+      if (skeleton) {
+        this.loading.set(false);
+      }
     }
     if (this.stakeholderId && !this.sseSub) {
       void this.eventStreamService.addSubscription('Stakeholder', this.stakeholderId);
       this.sseSub = this.eventStreamService.events$.subscribe(envelope => {
         if (envelope.targetType === 'Stakeholder' && envelope.targetId === this.stakeholderId) {
-          void this.loadStakeholder();
+          void this.loadStakeholder(false);
         }
       });
     }
@@ -746,7 +793,7 @@ export class StakeholderEditorComponent implements OnInit, OnDestroy, DirtyCheck
       this.messageService.add({ severity: 'success', summary: 'Saved', detail: 'Stakeholder saved.' });
 
       if (wasCreate && this.stakeholderId != null) {
-        await this.loadStakeholder();
+        await this.loadStakeholder(false);
       }
       return result;
     } catch {
@@ -770,7 +817,7 @@ export class StakeholderEditorComponent implements OnInit, OnDestroy, DirtyCheck
     if (result.status !== 409 || this.stakeholderId == null) {
       return false;
     }
-    await this.loadStakeholder();
+    await this.loadStakeholder(false);
     return true;
   }
 

--- a/requel-angular/src/app/features/stakeholders/stakeholder-editor.ts
+++ b/requel-angular/src/app/features/stakeholders/stakeholder-editor.ts
@@ -463,32 +463,62 @@ export class StakeholderEditorComponent implements OnInit, OnDestroy, DirtyCheck
     }
   }
 
+  /**
+   * Reads the stakeholder and applies it in two parts: server state always, form state only when
+   * the user has nothing unsaved.
+   *
+   * This editor had no guard, so every caller - initial load, SSE refresh, 409 recovery - patched
+   * over whatever the user was typing and then marked both forms pristine, leaving Save disabled
+   * with nothing on screen explaining why (#185). The window here is unusually wide even before
+   * the detail GET: `loadUsers()` and `loadPermissions()` are awaited *inside* this method, so on
+   * the user-stakeholder path the form is on screen and typeable across three round trips.
+   *
+   * The check therefore sits after those awaits rather than immediately after the detail GET, so
+   * it catches edits made at any point while the load was still running.
+   *
+   * `hasUnsavedChanges()` is `detailsForm.dirty || permissionsForm.dirty`, so a user who has only
+   * ticked a permission box is protected too - which is why `loadPermissions()` moved inside the
+   * guard. It rebuilds the checkbox controls from the server's key set, so running it over a
+   * half-ticked matrix would silently revert the ticks.
+   *
+   * Unconditional, because none of it is user-editable state: `version` (holding a stale one
+   * guarantees a 409 on the next save), the user/non-user mode and the enable/disable pattern that
+   * follows from it, the goals table, `loadedUserDetails` (template display only), and the user
+   * dropdown options. Skipping the goals table behind a dirty form is the stale-table trap #184
+   * found in `actor-editor`. `stakeholderName` is the *persisted* name, so it moves with the form.
+   */
   private async loadStakeholder(): Promise<void> {
     try {
       const s = await this.stakeholderService.getStakeholder(this.projectName, this.stakeholderId!);
-      this.stakeholderName.set(s.name);
+      // Server state, always.
       this.version = s.version;
       const isUser = s.type === 'user';
       this.isUserType.set(isUser);
       this.applyMode(isUser);
       this.goals.set(s.goals ?? []);
-
       if (s.userDetails) {
         this.loadedUserDetails.set(s.userDetails);
-        this.detailsForm.patchValue({
-          username: s.userDetails.username,
-          teamName: s.userDetails.teamName ?? '',
-        }, { emitEvent: false });
         await this.loadUsers();
-        await this.loadPermissions(s.userDetails.permissionKeys);
-      } else if (s.nonUserDetails) {
-        this.detailsForm.patchValue({
-          name: s.name,
-          text: s.nonUserDetails.text,
-        }, { emitEvent: false });
       }
-      this.detailsForm.markAsPristine();
-      this.permissionsForm.markAsPristine();
+
+      // Form state, only when the user has nothing unsaved - in either form.
+      if (!this.hasUnsavedChanges()) {
+        this.stakeholderName.set(s.name);
+        if (s.userDetails) {
+          this.detailsForm.patchValue({
+            username: s.userDetails.username,
+            teamName: s.userDetails.teamName ?? '',
+          }, { emitEvent: false });
+          await this.loadPermissions(s.userDetails.permissionKeys);
+        } else if (s.nonUserDetails) {
+          this.detailsForm.patchValue({
+            name: s.name,
+            text: s.nonUserDetails.text,
+          }, { emitEvent: false });
+        }
+        this.detailsForm.markAsPristine();
+        this.permissionsForm.markAsPristine();
+      }
     } catch {
       this.errorMessage.set('Failed to load stakeholder.');
     }

--- a/requel-angular/src/app/features/stories/story-editor.spec.ts
+++ b/requel-angular/src/app/features/stories/story-editor.spec.ts
@@ -552,4 +552,92 @@ describe('StoryEditorComponent', () => {
     }));
     expect(router.navigate).toHaveBeenCalledWith(['/projects', 'proj1', 'stories']);
   });
+  // #185. The gate is the structural half of the fix: with the form absent until the detail GET
+  // resolves, there is no input for a user - or a fast e2e test - to type into before the load
+  // lands. The dirty-guard in loadStory() is then belt-and-braces for the background callers.
+  // Finishes the #131 / #168 migration for this editor.
+  describe('render gate (#185, finishing #131)', () => {
+    function el(): HTMLElement {
+      return fixture.nativeElement as HTMLElement;
+    }
+
+    it('shows the skeleton and no form until the detail GET resolves', async () => {
+      let resolveGet: (story: unknown) => void = () => {};
+      storyServiceMock.getStory.mockImplementation(
+        () => new Promise(resolve => { resolveGet = resolve; })
+      );
+
+      paramMap$.next(convertToParamMap({ name: 'proj1', storyId: '20' }));
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="story-editor-loading"]')).not.toBeNull();
+      // The point of the gate: nothing to type into yet.
+      expect(el().querySelector('[data-testid="story-name"]')).toBeNull();
+
+      resolveGet(MOCK_STORY);
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="story-editor-loading"]')).toBeNull();
+      expect(el().querySelector('[data-testid="story-name"]')).not.toBeNull();
+    });
+
+    // The create route never loads, so the gate has to be resolved synchronously in ngOnInit -
+    // otherwise the wizard sits behind the skeleton forever and create is unreachable.
+    it('renders the create wizard immediately, with no skeleton', async () => {
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+
+      expect(comp.loading()).toBe(false);
+      expect(el().querySelector('[data-testid="story-editor-loading"]')).toBeNull();
+      expect(el().querySelector('[data-testid="story-wizard"]')).not.toBeNull();
+    });
+
+    it('shows a retryable error state when the load fails, and recovers on retry', async () => {
+      storyServiceMock.getStory.mockRejectedValueOnce(new Error('boom'));
+
+      paramMap$.next(convertToParamMap({ name: 'proj1', storyId: '20' }));
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="story-editor-load-error"]')).not.toBeNull();
+      expect(el().querySelector('[data-testid="story-name"]')).toBeNull();
+
+      storyServiceMock.getStory.mockResolvedValue(MOCK_STORY);
+      comp.retryLoad();
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="story-editor-load-error"]')).toBeNull();
+      expect(el().querySelector('[data-testid="story-name"]')).not.toBeNull();
+    });
+
+    // Background callers pass skeleton=false. Blanking the form under a user who is reading it
+    // because someone else touched the entity would be its own bug.
+    it('does not blank the form for a background reload', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', storyId: '20' }));
+      fixture.detectChanges();
+      await flush();
+
+      let resolveGet: (story: unknown) => void = () => {};
+      storyServiceMock.getStory.mockImplementation(
+        () => new Promise(resolve => { resolveGet = resolve; })
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const reload = (comp as any).loadStory(false);
+      await flush();
+      fixture.detectChanges();
+
+      expect(comp.loading()).toBe(false);
+      expect(el().querySelector('[data-testid="story-name"]')).not.toBeNull();
+
+      resolveGet(MOCK_STORY);
+      await reload;
+    });
+  });
+
 });

--- a/requel-angular/src/app/features/stories/story-editor.ts
+++ b/requel-angular/src/app/features/stories/story-editor.ts
@@ -46,6 +46,8 @@ import { EventStreamService } from '../../core/event-stream.service';
 import { EntitySelectorDialogComponent } from '../../shared/entity-selector-dialog';
 import { AnnotationsSectionComponent } from '../../shared/annotations-section';
 import { AppFieldComponent, AppFieldControlDirective } from '../../shared/app-field';
+import { LoadingStateComponent } from '../../shared/loading-state';
+import { ErrorStateComponent } from '../../shared/error-state';
 import {
   AppFormWizardComponent,
   AppWizardStepComponent,
@@ -64,7 +66,8 @@ const STALE_VERSION_MESSAGE =
             ButtonModule, InputText, TextareaModule, SelectModule,
             TableModule, MessageModule, ConfirmDialogModule, EntitySelectorDialogComponent,
             AnnotationsSectionComponent, AppFieldComponent, AppFieldControlDirective,
-            AppFormWizardComponent, AppWizardStepComponent],
+            AppFormWizardComponent, AppWizardStepComponent,
+            LoadingStateComponent, ErrorStateComponent],
   providers: [ConfirmationService],
   template: `
     <div class="story-editor" data-testid="story-editor">
@@ -93,7 +96,14 @@ const STALE_VERSION_MESSAGE =
         <p-message severity="error" [text]="errorMessage()!" />
       }
 
-      @if (isNew()) {
+      @if (loading()) {
+        <app-card>
+          <app-loading-state label="Loading story…" [lines]="4" testid="story-editor-loading" />
+        </app-card>
+      } @else if (loadError()) {
+        <app-error-state [message]="loadError()!" testid="story-editor-load-error"
+                         (retry)="retryLoad()" />
+      } @else if (isNew()) {
         <!--
           Create runs as a wizard so Goals and Additional Actors are reachable before
           the first save. Step 1 commits EditStory on Continue, which is what gives the
@@ -325,6 +335,13 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
   storyName = signal('');
   story = signal<StoryDto | null>(null);
   errorMessage = signal<string | null>(null);
+  /**
+   * #185. The edit form renders only once the detail GET resolves, so there is no window in which
+   * a user can type into a form the load is about to reset. Starts true: an edit route is loading
+   * from the first frame, and the create path clears it synchronously in ngOnInit.
+   */
+  loading = signal(true);
+  loadError = signal<string | null>(null);
   saving = signal(false);
   canEdit = signal(false);
   canDelete = signal(false);
@@ -413,6 +430,10 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
         this.wizardStep = 'details';
         this.submitted.set(false);
         this.detailsForm.reset({ name: '', storyType: 'Success', primaryActorName: '', text: '' });
+        // Nothing to load, so resolve the gate synchronously (#185) - otherwise the create wizard
+        // would sit behind the skeleton forever. Same reason the reset above is synchronous.
+        this.loading.set(false);
+        this.loadError.set(null);
       }
 
       await this.permissionService.loadForProject(this.projectName);
@@ -462,7 +483,23 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
    * Server state stays unconditional so a refresh triggered while the form is dirty still
    * refreshes what it was called for.
    */
-  private async loadStory(): Promise<void> {
+  /** Re-run the initial load; wired to the error state's (retry) output. */
+  retryLoad(): void {
+    void this.loadStory();
+  }
+
+  /**
+   * @param skeleton show the loading skeleton and the retryable error state. Suppressed for every
+   *                 background caller - SSE refresh, post-save refetch and 409 recovery - where
+   *                 blanking the form the user is looking at would be worse than a stale moment,
+   *                 and where a failure belongs in the inline message rather than in place of the
+   *                 form. Mirrors `scenario-editor`.
+   */
+  private async loadStory(skeleton = true): Promise<void> {
+    if (skeleton) {
+      this.loading.set(true);
+      this.loadError.set(null);
+    }
     try {
       const s = await this.storyService.getStory(this.projectName, this.storyId!);
       // A full load supersedes any association refresh still in flight: whichever of the two
@@ -482,13 +519,21 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
         });
       }
     } catch {
-      this.errorMessage.set('Failed to load story.');
+      if (skeleton) {
+        this.loadError.set('Failed to load story.');
+      } else {
+        this.errorMessage.set('Failed to load story.');
+      }
+    } finally {
+      if (skeleton) {
+        this.loading.set(false);
+      }
     }
     if (this.storyId && !this.sseSub) {
       void this.eventStreamService.addSubscription('Story', this.storyId);
       this.sseSub = this.eventStreamService.events$.subscribe(envelope => {
         if (envelope.targetType === 'Story' && envelope.targetId === this.storyId) {
-          void this.loadStory();
+          void this.loadStory(false);
         }
       });
     }
@@ -628,7 +673,7 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
       // Hydrate goals / actors (and start the SSE subscription) the first time the
       // story exists, so the later steps have something to render.
       if (wasCreate && this.storyId != null) {
-        await this.loadStory();
+        await this.loadStory(false);
       }
       return result;
     } catch {
@@ -653,7 +698,7 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
     if (result.status !== 409 || this.storyId == null) {
       return false;
     }
-    await this.loadStory();
+    await this.loadStory(false);
     return true;
   }
 

--- a/requel-angular/src/app/features/terms/term-editor.spec.ts
+++ b/requel-angular/src/app/features/terms/term-editor.spec.ts
@@ -356,7 +356,11 @@ describe('TermEditorComponent', () => {
       eventStreamServiceMock.events$ = events$.asObservable();
     });
 
-    it('does not clobber in-progress edits when a remote change arrives', async () => {
+    // #185 changed the shape of this guarantee. The guard used to be an early `return` on this
+    // subscription, so a remote change while dirty issued no fetch at all and `term` / `termId`
+    // went stale behind the edit - the same trap #184 found in `actor-editor`. The reload now
+    // always runs and always adopts server state; only the form is protected.
+    it('refetches on a remote change but does not clobber in-progress edits', async () => {
       paramMap$.next(convertToParamMap({ name: 'proj1', termId: '2' }));
       fixture.detectChanges();
       await flush();
@@ -364,12 +368,43 @@ describe('TermEditorComponent', () => {
       comp.form.controls.text.setValue('My unsaved edit');
       comp.form.controls.text.markAsDirty();
       const callsBefore = termServiceMock.getTerm.mock.calls.length;
+      termServiceMock.getTerm.mockResolvedValue({
+        ...MOCK_TERM, name: 'Renamed remotely', text: 'Remote definition.'
+      });
 
       events$.next({ targetType: 'GlossaryTerm', targetId: 2 });
       await flush();
 
-      expect(termServiceMock.getTerm.mock.calls.length).toBe(callsBefore);
+      // Server state landed...
+      expect(termServiceMock.getTerm.mock.calls.length).toBeGreaterThan(callsBefore);
+      expect(comp.term()?.name).toBe('Renamed remotely');
+      // ...but the form and its dirty flag are untouched.
       expect(comp.form.controls.text.value).toBe('My unsaved edit');
+      expect(comp.form.dirty).toBe(true);
+    });
+
+    it('does not clobber a value typed while the initial load is still in flight', async () => {
+      let resolveGet: (term: unknown) => void = () => {};
+      termServiceMock.getTerm.mockImplementation(
+        () => new Promise(resolve => { resolveGet = resolve; })
+      );
+
+      paramMap$.next(convertToParamMap({ name: 'proj1', termId: '2' }));
+      fixture.detectChanges();
+      await flush();
+
+      // The user is faster than the network.
+      comp.form.controls.name.setValue('Typed while loading');
+      comp.form.controls.name.markAsDirty();
+
+      resolveGet({ ...MOCK_TERM, name: 'Goal' });
+      await flush();
+
+      expect(comp.form.controls.name.value).toBe('Typed while loading');
+      expect(comp.form.dirty).toBe(true);
+      // Server state still landed, so the editor knows which term it is holding.
+      expect(comp.term()?.id).toBe(2);
+      expect(comp.termId()).toBe(2);
     });
 
     it('reloads when the form is clean', async () => {

--- a/requel-angular/src/app/features/terms/term-editor.spec.ts
+++ b/requel-angular/src/app/features/terms/term-editor.spec.ts
@@ -117,6 +117,95 @@ describe('TermEditorComponent', () => {
     );
   });
 
+  // #185. The gate is the structural half of the fix: with the form absent until the detail GET
+  // resolves, there is no input for a user - or a fast e2e test - to type into before the load
+  // lands. The dirty-guard in loadTerm() is then belt-and-braces for the SSE / post-save paths.
+  describe('render gate (#185, finishing #131)', () => {
+    function el(): HTMLElement {
+      return fixture.nativeElement as HTMLElement;
+    }
+
+    it('shows the skeleton and no form until the detail GET resolves', async () => {
+      let resolveGet: (term: unknown) => void = () => {};
+      termServiceMock.getTerm.mockImplementation(
+        () => new Promise(resolve => { resolveGet = resolve; })
+      );
+
+      paramMap$.next(convertToParamMap({ name: 'proj1', termId: '2' }));
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="term-editor-loading"]')).not.toBeNull();
+      // The point of the gate: nothing to type into yet.
+      expect(el().querySelector('input#name')).toBeNull();
+
+      resolveGet(MOCK_TERM);
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="term-editor-loading"]')).toBeNull();
+      expect(el().querySelector('input#name')).not.toBeNull();
+    });
+
+    // The create route never loads, so the gate has to be resolved synchronously in ngOnInit -
+    // otherwise a new term sits behind the skeleton forever.
+    it('renders the create form immediately, with no skeleton', async () => {
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+
+      expect(comp.loading()).toBe(false);
+      expect(el().querySelector('[data-testid="term-editor-loading"]')).toBeNull();
+      expect(el().querySelector('input#name')).not.toBeNull();
+    });
+
+    it('shows a retryable error state when the load fails, and recovers on retry', async () => {
+      termServiceMock.getTerm.mockRejectedValueOnce(new Error('boom'));
+
+      paramMap$.next(convertToParamMap({ name: 'proj1', termId: '2' }));
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="term-editor-load-error"]')).not.toBeNull();
+      expect(el().querySelector('input#name')).toBeNull();
+
+      termServiceMock.getTerm.mockResolvedValue(MOCK_TERM);
+      comp.retryLoad();
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="term-editor-load-error"]')).toBeNull();
+      expect(comp.form.controls.name.value).toBe('Goal');
+    });
+
+    // An SSE refresh passes skeleton=false. Blanking the form under a user who is reading it
+    // because someone else touched the term would be its own bug.
+    it('does not blank the form for an SSE refresh', async () => {
+      eventStreamServiceMock.events$ = events$.asObservable();
+
+      paramMap$.next(convertToParamMap({ name: 'proj1', termId: '2' }));
+      fixture.detectChanges();
+      await flush();
+
+      let resolveGet: (term: unknown) => void = () => {};
+      termServiceMock.getTerm.mockImplementation(
+        () => new Promise(resolve => { resolveGet = resolve; })
+      );
+
+      events$.next({ targetType: 'GlossaryTerm', targetId: 2 });
+      await flush();
+      fixture.detectChanges();
+
+      expect(comp.loading()).toBe(false);
+      expect(el().querySelector('input#name')).not.toBeNull();
+
+      resolveGet(MOCK_TERM);
+      await flush();
+    });
+  });
+
   describe('reactive form (issue #132)', () => {
     it('loads the term into the form and leaves it pristine', async () => {
       paramMap$.next(convertToParamMap({ name: 'proj1', termId: '2' }));

--- a/requel-angular/src/app/features/terms/term-editor.ts
+++ b/requel-angular/src/app/features/terms/term-editor.ts
@@ -346,22 +346,40 @@ export class TermEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
     }
   }
 
+  /**
+   * Reads the term and applies it in two parts: server state always, form state only when the
+   * user has nothing unsaved.
+   *
+   * The guard used to live on the SSE subscription below, as an early `return` before the reload
+   * was even issued. That protected the SSE path and left the *initial* load free to patch over
+   * whatever the user had typed - `page.goto()` on the edit route returns long before this fetch
+   * does, so anything typed in that gap was silently discarded and the form went back to pristine
+   * (#185). Moving the check in here covers every caller, and the early `return` is gone so a
+   * remote change still refreshes `term` / `termId` even while the form is dirty - the stale-
+   * collection trap #184 hit in `actor-editor`.
+   *
+   * The check sits after the await on purpose, so it catches edits made while the request was
+   * still in flight.
+   *
+   * `termName` is the *persisted* name - it titles the page and is quoted in the delete
+   * confirmation - so it moves only with the form, matching `goal-editor`. `submitted` likewise:
+   * clearing it would hide validation errors the user is looking at.
+   */
   private async loadTerm(id: number): Promise<void> {
     try {
       const t = await this.termService.getTerm(this.projectName, id);
       this.term.set(t);
       this.termId.set(t.id);
-      this.termName.set(t.name);
-      // An SSE-driven reload must not throw away what the user is editing. The guard
-      // is on the caller side for the SSE path below; here we only refresh a form the
-      // user has not touched.
-      this.form.patchValue({
-        name: t.name,
-        text: t.text ?? '',
-        canonicalTermId: t.canonicalTermId ?? null,
-      });
-      this.form.markAsPristine();
-      this.submitted.set(false);
+      if (!this.hasUnsavedChanges()) {
+        this.termName.set(t.name);
+        this.form.patchValue({
+          name: t.name,
+          text: t.text ?? '',
+          canonicalTermId: t.canonicalTermId ?? null,
+        });
+        this.form.markAsPristine();
+        this.submitted.set(false);
+      }
     } catch {
       this.errorMessage.set('Failed to load term.');
     }
@@ -369,11 +387,6 @@ export class TermEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
       void this.eventStreamService.addSubscription('GlossaryTerm', id);
       this.sseSub = this.eventStreamService.events$.subscribe(envelope => {
         if (envelope.targetType === 'GlossaryTerm' && envelope.targetId === id) {
-          // Don't clobber in-progress edits with a remote change (same guard the N5
-          // editors use). The user's copy wins until they save or navigate away.
-          if (this.hasUnsavedChanges()) {
-            return;
-          }
           void this.loadTerm(id);
         }
       });
@@ -414,6 +427,12 @@ export class TermEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
         this.form.markAsPristine();
         this.router.navigate(['/projects', this.projectName, 'terms', saved.id], { replaceUrl: true });
       } else {
+        // Mark pristine BEFORE the refetch. The load method only adopts server state into the
+        // form when the form has nothing unsaved (#185), and what was "unsaved" a moment ago is
+        // exactly what we just persisted - leaving it dirty would make the reload skip its own
+        // result, so Save stayed enabled on a freshly saved form. Same ordering scenario-editor
+        // uses around its post-save refetch.
+        this.form.markAsPristine();
         await this.loadTerm(this.termId()!);
       }
       return;

--- a/requel-angular/src/app/features/terms/term-editor.ts
+++ b/requel-angular/src/app/features/terms/term-editor.ts
@@ -39,6 +39,8 @@ import { EventStreamService } from '../../core/event-stream.service';
 import { AnnotationsSectionComponent } from '../../shared/annotations-section';
 import { AppCardComponent } from '../../shared/app-card';
 import { AppFieldComponent, AppFieldControlDirective } from '../../shared/app-field';
+import { LoadingStateComponent } from '../../shared/loading-state';
+import { ErrorStateComponent } from '../../shared/error-state';
 import { applyCommandErrors, clearServerErrors } from '../../shared/form-errors';
 import { ARTIFACT_NAME_MAX_LENGTH } from '../../shared/validation-limits';
 
@@ -79,6 +81,8 @@ const SEPARATOR = '; ';
     AnnotationsSectionComponent,
     AppFieldComponent,
     AppFieldControlDirective,
+    LoadingStateComponent,
+    ErrorStateComponent,
   ],
   providers: [ConfirmationService],
   template: `
@@ -99,126 +103,136 @@ const SEPARATOR = '; ';
         <p-message severity="error" [text]="errorMessage()!" data-testid="term-error" />
       }
 
-      <app-card>
-        <form [formGroup]="form" (ngSubmit)="onSave()">
-          <!--
-            controlId is "name" / "text" on purpose: those ids are an e2e contract, not
-            an implementation detail. TermEditorPage and BaseListPage's default
-            readySelector both locate #name, so letting app-field generate rq-field-{n}
-            here would break navigation in tests that have nothing to do with this form.
-          -->
-          <app-field
-            label="Term"
-            controlId="name"
-            [control]="form.controls.name"
-            [submitted]="submitted()"
-          >
-            <input
-              id="name"
-              pInputText
-              appFieldControl
-              formControlName="name"
-              [attr.maxlength]="nameMaxLength"
-              placeholder="Term name"
-            />
-          </app-field>
+      @if (loading()) {
+        <app-card>
+          <app-loading-state label="Loading term…" [lines]="4" testid="term-editor-loading" />
+        </app-card>
+      } @else if (loadError()) {
+        <app-error-state [message]="loadError()!" testid="term-editor-load-error"
+                         (retry)="retryLoad()" />
+      } @else {
+        <app-card>
+          <form [formGroup]="form" (ngSubmit)="onSave()">
+            <!--
+              controlId is "name" / "text" on purpose: those ids are an e2e contract, not
+              an implementation detail. TermEditorPage and BaseListPage's default
+              readySelector both locate #name, so letting app-field generate rq-field-{n}
+              here would break navigation in tests that have nothing to do with this form.
+            -->
+            <app-field
+              label="Term"
+              controlId="name"
+              [control]="form.controls.name"
+              [submitted]="submitted()"
+            >
+              <input
+                id="name"
+                pInputText
+                appFieldControl
+                formControlName="name"
+                [attr.maxlength]="nameMaxLength"
+                placeholder="Term name"
+              />
+            </app-field>
 
-          <app-field
-            label="Definition"
-            controlId="text"
-            [control]="form.controls.text"
-            [submitted]="submitted()"
-          >
-            <textarea
-              id="text"
-              pTextarea
-              appFieldControl
-              formControlName="text"
-              rows="5"
-              placeholder="Definition of this term"
-            ></textarea>
-          </app-field>
+            <app-field
+              label="Definition"
+              controlId="text"
+              [control]="form.controls.text"
+              [submitted]="submitted()"
+            >
+              <textarea
+                id="text"
+                pTextarea
+                appFieldControl
+                formControlName="text"
+                rows="5"
+                placeholder="Definition of this term"
+              ></textarea>
+            </app-field>
 
-          <app-field
-            label="Canonical Term"
-            controlId="canonical-term-input"
-            [control]="form.controls.canonicalTermId"
-            [submitted]="submitted()"
-            [divider]="false"
-          >
-            <p-select
-              appFieldControl
-              inputId="canonical-term-input"
-              data-testid="term-canonical-select"
-              formControlName="canonicalTermId"
-              [options]="canonicalOptions()"
-              optionLabel="label"
-              optionValue="value"
-              placeholder="None (this is a canonical term)"
-              [showClear]="true"
-            />
-          </app-field>
+            <app-field
+              label="Canonical Term"
+              controlId="canonical-term-input"
+              [control]="form.controls.canonicalTermId"
+              [submitted]="submitted()"
+              [divider]="false"
+            >
+              <p-select
+                appFieldControl
+                inputId="canonical-term-input"
+                data-testid="term-canonical-select"
+                formControlName="canonicalTermId"
+                [options]="canonicalOptions()"
+                optionLabel="label"
+                optionValue="value"
+                placeholder="None (this is a canonical term)"
+                [showClear]="true"
+              />
+            </app-field>
 
-          <div class="form-actions">
-            <p-button
-              type="submit"
-              label="Save"
-              icon="pi pi-check"
-              data-testid="term-save"
-              [loading]="saving()"
-              [disabled]="form.invalid || form.pristine || saving()"
-            />
+            <div class="form-actions">
+              <p-button
+                type="submit"
+                label="Save"
+                icon="pi pi-check"
+                data-testid="term-save"
+                [loading]="saving()"
+                [disabled]="form.invalid || form.pristine || saving()"
+              />
+            </div>
+          </form>
+        </app-card>
+
+        <!-- Alternate Terms (terms that point to this as their canonical) -->
+        @if (!isNew() && term()?.alternateTerms?.length) {
+          <div class="section" data-testid="term-alternate-terms-section">
+            <h2 class="rq-section-title">Alternate Terms</h2>
+            <p-table [value]="term()!.alternateTerms!" [rows]="10">
+              <ng-template #header>
+                <tr>
+                  <th>Term</th>
+                </tr>
+              </ng-template>
+              <ng-template #body let-a>
+                <tr class="clickable-row" data-testid="term-alternate-row"
+                    (click)="navigateToTerm(a.id)">
+                  <td>{{ a.name }}</td>
+                </tr>
+              </ng-template>
+            </p-table>
           </div>
-        </form>
-      </app-card>
+        }
 
-      <!-- Alternate Terms (terms that point to this as their canonical) -->
-      @if (!isNew() && term()?.alternateTerms?.length) {
-        <div class="section" data-testid="term-alternate-terms-section">
-          <h2 class="rq-section-title">Alternate Terms</h2>
-          <p-table [value]="term()!.alternateTerms!" [rows]="10">
-            <ng-template #header>
-              <tr>
-                <th>Term</th>
-              </tr>
-            </ng-template>
-            <ng-template #body let-a>
-              <tr class="clickable-row" data-testid="term-alternate-row"
-                  (click)="navigateToTerm(a.id)">
-                <td>{{ a.name }}</td>
-              </tr>
-            </ng-template>
-          </p-table>
-        </div>
+        <!-- Referenced By -->
+        @if (!isNew() && term()?.referers?.length) {
+          <div class="section" data-testid="term-referenced-by-section">
+            <h2 class="rq-section-title">Referenced By</h2>
+            <p-table [value]="term()!.referers!" [rows]="10">
+              <ng-template #header>
+                <tr>
+                  <th>Type</th>
+                  <th>Name</th>
+                </tr>
+              </ng-template>
+              <ng-template #body let-r>
+                <tr data-testid="term-referer-row">
+                  <td>{{ r.entityType }}</td>
+                  <td>{{ r.name }}</td>
+                </tr>
+              </ng-template>
+            </p-table>
+          </div>
+        }
+
+        <!-- Annotations -->
+        <app-annotations-section
+          [projectName]="projectName"
+          entityType="GlossaryTerm"
+          [entityId]="termId()"
+          [canEdit]="canEdit()" />
       }
 
-      <!-- Referenced By -->
-      @if (!isNew() && term()?.referers?.length) {
-        <div class="section" data-testid="term-referenced-by-section">
-          <h2 class="rq-section-title">Referenced By</h2>
-          <p-table [value]="term()!.referers!" [rows]="10">
-            <ng-template #header>
-              <tr>
-                <th>Type</th>
-                <th>Name</th>
-              </tr>
-            </ng-template>
-            <ng-template #body let-r>
-              <tr data-testid="term-referer-row">
-                <td>{{ r.entityType }}</td>
-                <td>{{ r.name }}</td>
-              </tr>
-            </ng-template>
-          </p-table>
-        </div>
-      }
-
-      <!-- Annotations -->
-      <app-annotations-section
-        [projectName]="projectName"
-        entityType="GlossaryTerm"
-        [entityId]="termId()"
-        [canEdit]="canEdit()" />
     </div>
 
     <p-confirmDialog />
@@ -243,6 +257,14 @@ export class TermEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
   saving = signal(false);
   submitted = signal(false);
   errorMessage = signal<string | null>(null);
+  /**
+   * #185. The edit form renders only once the detail GET resolves, so there is no window in which
+   * a user can type into a form the load is about to reset. Starts true: an edit route is loading
+   * from the first frame, and the create path clears it synchronously in ngOnInit.
+   */
+  loading = signal(true);
+  loadError = signal<string | null>(null);
+  private lastTermId: number | null = null;
   canonicalOptions = signal<{ label: string; value: number }[]>([]);
 
   /**
@@ -304,6 +326,10 @@ export class TermEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
         this.termId.set(null);
         this.submitted.set(false);
         this.form.reset({ name: '', text: '', canonicalTermId: null });
+        // Nothing to load, so resolve the gate synchronously (#185) - otherwise the create form
+        // would sit behind the skeleton forever. Same reason the reset above is synchronous.
+        this.loading.set(false);
+        this.loadError.set(null);
       }
 
       await this.permissionService.loadForProject(this.projectName);
@@ -365,7 +391,24 @@ export class TermEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
    * confirmation - so it moves only with the form, matching `goal-editor`. `submitted` likewise:
    * clearing it would hide validation errors the user is looking at.
    */
-  private async loadTerm(id: number): Promise<void> {
+  /** Re-run the last attempted load; wired to the error state's (retry) output. */
+  retryLoad(): void {
+    if (this.lastTermId != null) {
+      void this.loadTerm(this.lastTermId);
+    }
+  }
+
+  /**
+   * @param skeleton show the loading skeleton and the retryable error state. Suppressed for the
+   *                 post-save refetch and the SSE refresh, where blanking the form the user is
+   *                 looking at would be worse than a stale moment. Mirrors `scenario-editor`.
+   */
+  private async loadTerm(id: number, skeleton = true): Promise<void> {
+    this.lastTermId = id;
+    if (skeleton) {
+      this.loading.set(true);
+      this.loadError.set(null);
+    }
     try {
       const t = await this.termService.getTerm(this.projectName, id);
       this.term.set(t);
@@ -381,13 +424,21 @@ export class TermEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
         this.submitted.set(false);
       }
     } catch {
-      this.errorMessage.set('Failed to load term.');
+      if (skeleton) {
+        this.loadError.set('Failed to load term.');
+      } else {
+        this.errorMessage.set('Failed to load term.');
+      }
+    } finally {
+      if (skeleton) {
+        this.loading.set(false);
+      }
     }
     if (id && !this.sseSub) {
       void this.eventStreamService.addSubscription('GlossaryTerm', id);
       this.sseSub = this.eventStreamService.events$.subscribe(envelope => {
         if (envelope.targetType === 'GlossaryTerm' && envelope.targetId === id) {
-          void this.loadTerm(id);
+          void this.loadTerm(id, false);
         }
       });
     }
@@ -433,7 +484,7 @@ export class TermEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
         // result, so Save stayed enabled on a freshly saved form. Same ordering scenario-editor
         // uses around its post-save refetch.
         this.form.markAsPristine();
-        await this.loadTerm(this.termId()!);
+        await this.loadTerm(this.termId()!, false);
       }
       return;
     }

--- a/requel-angular/src/app/features/use-cases/use-case-editor.spec.ts
+++ b/requel-angular/src/app/features/use-cases/use-case-editor.spec.ts
@@ -377,4 +377,93 @@ describe('UseCaseEditorComponent', () => {
     comp.navigateTo('goals', 42);
     expect(router.navigate).toHaveBeenCalledWith(['/projects', 'proj1', 'goals', 42]);
   });
+  // #185. The gate is the structural half of the fix: with the form absent until the detail GET
+  // resolves, there is no input for a user - or a fast e2e test - to type into before the load
+  // lands. The dirty-guard in loadUseCase() is then belt-and-braces for the background callers.
+  // Finishes the #131 / #168 migration for this editor.
+  describe('render gate (#185, finishing #131)', () => {
+    function el(): HTMLElement {
+      return fixture.nativeElement as HTMLElement;
+    }
+
+    it('shows the skeleton and no form until the detail GET resolves', async () => {
+      let resolveGet: (entity: unknown) => void = () => {};
+      useCaseServiceMock.getUseCase.mockImplementation(
+        () => new Promise(resolve => { resolveGet = resolve; })
+      );
+
+      paramMap$.next(convertToParamMap({ name: 'proj1', useCaseId: '30' }));
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="use-case-editor-loading"]')).not.toBeNull();
+      // The point of the gate: nothing to type into yet.
+      expect(el().querySelector('[data-testid="use-case-name"]')).toBeNull();
+
+      resolveGet(MOCK_USE_CASE);
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="use-case-editor-loading"]')).toBeNull();
+      expect(el().querySelector('[data-testid="use-case-name"]')).not.toBeNull();
+    });
+
+    // The create route never loads, so the gate has to be resolved there explicitly - otherwise
+    // the wizard sits behind the skeleton forever and create becomes unreachable.
+    it('renders the create wizard, with no skeleton', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', useCaseId: 'new' }));
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+
+      expect(comp.loading()).toBe(false);
+      expect(el().querySelector('[data-testid="use-case-editor-loading"]')).toBeNull();
+      expect(el().querySelector('[data-testid="use-case-wizard"]')).not.toBeNull();
+    });
+
+    it('shows a retryable error state when the load fails, and recovers on retry', async () => {
+      useCaseServiceMock.getUseCase.mockRejectedValueOnce(new Error('boom'));
+
+      paramMap$.next(convertToParamMap({ name: 'proj1', useCaseId: '30' }));
+      fixture.detectChanges();
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="use-case-editor-load-error"]')).not.toBeNull();
+      expect(el().querySelector('[data-testid="use-case-name"]')).toBeNull();
+
+      useCaseServiceMock.getUseCase.mockResolvedValue(MOCK_USE_CASE);
+      comp.retryLoad();
+      await flush();
+      fixture.detectChanges();
+
+      expect(el().querySelector('[data-testid="use-case-editor-load-error"]')).toBeNull();
+      expect(el().querySelector('[data-testid="use-case-name"]')).not.toBeNull();
+    });
+
+    // Background callers pass skeleton=false. Blanking the form under a user who is reading it
+    // because someone else touched the entity would be its own bug.
+    it('does not blank the form for a background reload', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', useCaseId: '30' }));
+      fixture.detectChanges();
+      await flush();
+
+      let resolveGet: (entity: unknown) => void = () => {};
+      useCaseServiceMock.getUseCase.mockImplementation(
+        () => new Promise(resolve => { resolveGet = resolve; })
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const reload = (comp as any).loadUseCase(false);
+      await flush();
+      fixture.detectChanges();
+
+      expect(comp.loading()).toBe(false);
+      expect(el().querySelector('[data-testid="use-case-name"]')).not.toBeNull();
+
+      resolveGet(MOCK_USE_CASE);
+      await reload;
+    });
+  });
+
 });

--- a/requel-angular/src/app/features/use-cases/use-case-editor.spec.ts
+++ b/requel-angular/src/app/features/use-cases/use-case-editor.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter, Router, ActivatedRoute, convertToParamMap } from '@angular/router';
 import { Location } from '@angular/common';
-import { BehaviorSubject, EMPTY } from 'rxjs';
+import { BehaviorSubject, EMPTY, Subject } from 'rxjs';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { UseCaseEditorComponent } from './use-case-editor';
 import { UseCaseService } from '../../core/use-case.service';
@@ -170,6 +170,65 @@ describe('UseCaseEditorComponent', () => {
   // #173 required test (§10.3). refreshCollections() refetched every collection but never the
   // version, so an association left it stale and the next save 409'd. All eight association
   // commands on this editor bump the use case, so this is the editor where it mattered most.
+  // #185. This editor had no guard at all, and the widest window of any of them: ngOnInit awaits
+  // loadForProject() and listActors() before the detail GET is even issued.
+  it('does not clobber a value typed while the initial load is still in flight', async () => {
+    let resolveGet: (useCase: unknown) => void = () => {};
+    useCaseServiceMock.getUseCase.mockImplementation(
+      () => new Promise(resolve => { resolveGet = resolve; })
+    );
+
+    paramMap$.next(convertToParamMap({ name: 'proj1', useCaseId: '30' }));
+    fixture.detectChanges();
+    await flush();
+
+    // The user is faster than the network.
+    comp.detailsForm.controls.name.setValue('Typed while loading');
+    comp.detailsForm.controls.name.markAsDirty();
+
+    resolveGet({ ...MOCK_USE_CASE, version: 4 });
+    await flush();
+
+    expect(comp.detailsForm.controls.name.value).toBe('Typed while loading');
+    expect(comp.detailsForm.dirty).toBe(true);
+    // Server state still landed, so Save has a usable version to send.
+    expect(comp.useCase()?.id).toBe(30);
+    expect(comp.goals().length).toBe(1);
+  });
+
+  // The SSE subscription called loadUseCase() directly, so a remote change reset the form under
+  // the user. The guard now covers that caller too - but the collections must still refresh, or
+  // the tables sit stale behind an unsaved rename (the trap #184 found in actor-editor).
+  it('refetches on a remote change but does not clobber in-progress edits', async () => {
+    const events$ = new Subject<{ targetType: string; targetId: number }>();
+    eventStreamServiceMock.events$ = events$.asObservable() as typeof EMPTY;
+
+    paramMap$.next(convertToParamMap({ name: 'proj1', useCaseId: '30' }));
+    fixture.detectChanges();
+    await flush();
+
+    comp.detailsForm.controls.name.setValue('My unsaved rename');
+    comp.detailsForm.controls.name.markAsDirty();
+    useCaseServiceMock.getUseCase.mockResolvedValue({
+      ...MOCK_USE_CASE,
+      version: 9,
+      goals: [
+        { id: 1, name: 'Buy product', entityType: 'Goal' },
+        { id: 2, name: 'Added elsewhere', entityType: 'Goal' }
+      ]
+    });
+
+    events$.next({ targetType: 'UseCase', targetId: 30 });
+    await flush();
+
+    // Form untouched...
+    expect(comp.detailsForm.controls.name.value).toBe('My unsaved rename');
+    expect(comp.detailsForm.dirty).toBe(true);
+    // ...while the goals table and the held version both moved on.
+    expect(comp.goals().length).toBe(2);
+    expect(comp.useCase()?.version).toBe(9);
+  });
+
   describe('wizard version contract (#173)', () => {
     it('re-reads version after an association, so a later save does not 409', async () => {
       paramMap$.next(convertToParamMap({ name: 'proj1', useCaseId: '30' }));

--- a/requel-angular/src/app/features/use-cases/use-case-editor.ts
+++ b/requel-angular/src/app/features/use-cases/use-case-editor.ts
@@ -646,17 +646,40 @@ export class UseCaseEditorComponent implements OnInit, OnDestroy, DirtyCheckable
     this.sseSub?.unsubscribe();
   }
 
+  /**
+   * Reads the use case and applies it in two parts: server state always, form state only when the
+   * user has nothing unsaved.
+   *
+   * This editor had no guard of any kind, so every caller reset the form - including the SSE
+   * subscription below, which meant a remote change discarded whatever the user was typing. The
+   * initial load was worse still: `ngOnInit` awaits `loadForProject()` *and* `listActors()` before
+   * this fetch is even issued, so the window between the form rendering and the reset landing is
+   * the widest of any editor here (#185).
+   *
+   * The check sits after the await on purpose, so it catches edits made while the request was
+   * still in flight. Applying it to every caller also means a 409 recovery keeps the edit the user
+   * is retrying rather than throwing it away, matching #184.
+   *
+   * The five collections stay unconditional: they render their own tables, so a refresh after an
+   * association still lands even with a rename sitting in the Name field - the stale-table trap
+   * #184 found in `actor-editor`. `useCaseName` is the *persisted* name, so it moves only with the
+   * form.
+   */
   private async loadUseCase(): Promise<void> {
     try {
       const uc = await this.useCaseService.getUseCase(this.projectName, this.useCaseId!);
+      // Always take the version. The entity moved on, and holding the stale one guarantees a
+      // 409 on the user's next save.
       this.useCase.set(uc);
-      this.useCaseName.set(uc.name);
-      this.detailsForm.reset({
-        name: uc.name,
-        primaryActorName: uc.primaryActorName ?? '',
-        text: uc.text ?? '',
-      });
       this.version = uc.version;
+      if (!this.hasUnsavedChanges()) {
+        this.useCaseName.set(uc.name);
+        this.detailsForm.reset({
+          name: uc.name,
+          primaryActorName: uc.primaryActorName ?? '',
+          text: uc.text ?? '',
+        });
+      }
       this.goals.set(uc.goals ?? []);
       this.stories.set(uc.stories ?? []);
       this.actors.set(uc.actors ?? []);

--- a/requel-angular/src/app/features/use-cases/use-case-editor.ts
+++ b/requel-angular/src/app/features/use-cases/use-case-editor.ts
@@ -51,6 +51,8 @@ import { EventStreamService } from '../../core/event-stream.service';
 import { EntitySelectorDialogComponent } from '../../shared/entity-selector-dialog';
 import { AnnotationsSectionComponent } from '../../shared/annotations-section';
 import { AppFieldComponent, AppFieldControlDirective } from '../../shared/app-field';
+import { LoadingStateComponent } from '../../shared/loading-state';
+import { ErrorStateComponent } from '../../shared/error-state';
 import {
   AppFormWizardComponent,
   AppWizardStepComponent,
@@ -86,7 +88,8 @@ const STALE_VERSION_MESSAGE =
             ConfirmDialogModule, TableModule, TooltipModule, SelectModule,
             EntitySelectorDialogComponent, AnnotationsSectionComponent,
             AppFieldComponent, AppFieldControlDirective,
-            AppFormWizardComponent, AppWizardStepComponent],
+            AppFormWizardComponent, AppWizardStepComponent,
+            LoadingStateComponent, ErrorStateComponent],
   providers: [ConfirmationService],
   template: `
     <div class="use-case-editor" data-testid="use-case-editor">
@@ -112,7 +115,14 @@ const STALE_VERSION_MESSAGE =
         <p-message severity="error" [text]="errorMessage()!" />
       }
 
-      @if (isNew()) {
+      @if (loading()) {
+        <app-card>
+          <app-loading-state label="Loading use case…" [lines]="4" testid="use-case-editor-loading" />
+        </app-card>
+      } @else if (loadError()) {
+        <app-error-state [message]="loadError()!" testid="use-case-editor-load-error"
+                         (retry)="retryLoad()" />
+      } @else if (isNew()) {
         <!--
           Create runs as a wizard (#173). Four steps because this editor gates five separate
           sections; grouping Goals with Stories keeps the count at four without putting six
@@ -519,6 +529,14 @@ export class UseCaseEditorComponent implements OnInit, OnDestroy, DirtyCheckable
   useCaseName = signal('');
   useCase = signal<UseCaseDto | null>(null);
   errorMessage = signal<string | null>(null);
+  /**
+   * #185. The edit form renders only once the detail GET resolves, so there is no window in which
+   * a user can type into a form the load is about to reset. Starts true: an edit route is loading
+   * from the first frame, and the create path clears it as soon as it knows there is nothing to
+   * load.
+   */
+  loading = signal(true);
+  loadError = signal<string | null>(null);
   saving = signal(false);
   canEdit = signal(false);
   canDelete = signal(false);
@@ -621,6 +639,10 @@ export class UseCaseEditorComponent implements OnInit, OnDestroy, DirtyCheckable
         this.actors.set([]);
         this.additionalScenarios.set([]);
         this.primaryScenario.set(null);
+        // Nothing to load, so resolve the gate (#185) - otherwise the create wizard sits behind
+        // the skeleton forever and create becomes unreachable.
+        this.loading.set(false);
+        this.loadError.set(null);
       } else {
         this.isNew.set(false);
         this.useCaseId = +idParam;
@@ -665,7 +687,23 @@ export class UseCaseEditorComponent implements OnInit, OnDestroy, DirtyCheckable
    * #184 found in `actor-editor`. `useCaseName` is the *persisted* name, so it moves only with the
    * form.
    */
-  private async loadUseCase(): Promise<void> {
+  /** Re-run the initial load; wired to the error state's (retry) output. */
+  retryLoad(): void {
+    void this.loadUseCase();
+  }
+
+  /**
+   * @param skeleton show the loading skeleton and the retryable error state. Suppressed for every
+   *                 background caller - SSE refresh, post-save refetch and 409 recovery - where
+   *                 blanking the form the user is looking at would be worse than a stale moment,
+   *                 and where a failure belongs in the inline message rather than in place of the
+   *                 form. Mirrors `scenario-editor`.
+   */
+  private async loadUseCase(skeleton = true): Promise<void> {
+    if (skeleton) {
+      this.loading.set(true);
+      this.loadError.set(null);
+    }
     try {
       const uc = await this.useCaseService.getUseCase(this.projectName, this.useCaseId!);
       // Always take the version. The entity moved on, and holding the stale one guarantees a
@@ -690,13 +728,21 @@ export class UseCaseEditorComponent implements OnInit, OnDestroy, DirtyCheckable
         this.primaryScenario.set(null);
       }
     } catch {
-      this.errorMessage.set('Failed to load use case.');
+      if (skeleton) {
+        this.loadError.set('Failed to load use case.');
+      } else {
+        this.errorMessage.set('Failed to load use case.');
+      }
+    } finally {
+      if (skeleton) {
+        this.loading.set(false);
+      }
     }
     if (this.useCaseId && !this.sseSub) {
       void this.eventStreamService.addSubscription('UseCase', this.useCaseId);
       this.sseSub = this.eventStreamService.events$.subscribe(envelope => {
         if (envelope.targetType === 'UseCase' && envelope.targetId === this.useCaseId) {
-          void this.loadUseCase();
+          void this.loadUseCase(false);
         }
       });
     }
@@ -781,7 +827,7 @@ export class UseCaseEditorComponent implements OnInit, OnDestroy, DirtyCheckable
       this.messageService.add({ severity: 'success', summary: 'Saved', detail: 'Use case saved.' });
 
       if (wasCreate && this.useCaseId != null) {
-        await this.loadUseCase();
+        await this.loadUseCase(false);
       }
       return result;
     } catch {
@@ -805,7 +851,7 @@ export class UseCaseEditorComponent implements OnInit, OnDestroy, DirtyCheckable
     if (result.status !== 409 || this.useCaseId == null) {
       return false;
     }
-    await this.loadUseCase();
+    await this.loadUseCase(false);
     return true;
   }
 


### PR DESCRIPTION
Closes #185.

## Summary

Open an entity editor by URL, start typing before the page finishes loading, and your input
vanishes — with Save disabled and nothing on screen explaining why. The detail GET lands after the
form has rendered and resets it, which also clears `dirty`, so the form ends up pristine and
holding the server's values and Save cannot be re-enabled without another edit.

#184 fixed this in goal, story and actor. This PR finishes the job: five more editors carry the
guard, and all ten now render their form only once the detail GET resolves.

## Two defences, not one

**The guard** — a load never resets a form with unsaved changes. Server state (version especially)
is still adopted, so a skipped reset does not leave a stale version to 409 on. This is the only
protection on the callers that fire long after render: SSE refresh, 409 recovery, post-save
refetch.

**The gate** — the form is not rendered until the detail GET resolves, so there is no input to type
into during the load. This removes the window rather than defending it, and closes the hazard that
made the original bug expensive to diagnose: assertions an editor route satisfies while still empty
— element counts, a disabled Save on a pristine form — passed just as well against a form that had
not loaded. With the gate a racing test fails loudly instead of passing for the wrong reason.

The gate is not new work. #131 (#168) built `app-loading-state` / `app-error-state` /
`app-empty-state` and wired them into project, scenario and user, then stopped. This finishes that
migration for the other seven, following `project-editor.ts` as the reference shape.

## Commits

| | |
|---|---|
| `fcca7c4` | Guard report-editor, term-editor |
| `f47d895` | Guard use-case-editor |
| `99c5745` | CLAUDE.md process rule (see below) |
| `111b28b` | Guard stakeholder-editor |
| `aeaec2e` | scenario-editor: caller-independent guard + step-id merge |
| `db82cd6` | Gate report-editor, term-editor + 2 e2e fixes |
| `23f70ec` | Gate goal, story, actor + 1 e2e fix |
| `5b9ba46` | Gate use-case, stakeholder |
| `86c7c0f` | Backfill the two missing guard tests |

`99c5745` is a process change riding along rather than its own ticket: it records in CLAUDE.md that
Claude prepares `git` / `gh` commands rather than running them. It came out of working this issue
(the Cowork device bridge cannot delete files, so any git command Claude ran stranded
`.git/index.lock`) and it changed how the rest of the branch landed. Happy to split it out if you'd
rather.

## The ticket was wrong about scenario-editor

Worth reading if you reviewed the original issue text, which listed `scenario-editor.ts:560` as
"same bug, different shape". It isn't. Scenario has been render-gated since #173 —
`loading = signal(true)` with the form behind `@if (loading())` — so the typing race cannot happen
there. Its real defect was the two callers that passed `fromSSE = false` and therefore skipped the
guard entirely: the 409 recovery, which threw away the edit the user was retrying, and the
post-save refetch. The issue was rewritten to say so before any code was written; anyone working
from the original text would have chased a race that isn't there and written an e2e test that
cannot fail.

## Behaviour changes to notice in review

- **A 409 recovery now keeps the edit being retried** instead of resetting to the server's values.
  #184 made this change for three editors deliberately; it now applies to all of them. This is the
  point of a retry, but it is a visible change.
- **A failed *initial* load renders a retryable error state in place of the form**, rather than
  annotating the form with the inline `errorMessage` — there is no form to annotate. Background
  failures keep the inline message. `actor-editor.spec.ts`'s existing error test is what surfaced
  this; it now asserts `loadError`, with a sibling pinning the background half.
- **Create wizards appear a beat later on `stakeholder-editor`.** Its `ngOnInit` awaits
  `loadForProject()` before branching on the route param, so unlike the other six there is no
  synchronous create block to resolve the gate in; it resolves in `resetForCreate()` instead. The
  form it used to render early was one nobody should have been typing into.
- **A refresh arriving while the form is dirty now updates the association tables.** Collections
  sit outside the guard deliberately — the old early-return left goals / referenced-by tables stale
  behind an unsaved rename.

## Decisions with trade-offs

**`scenario-editor`'s `stepNodes`.** Unlike `actor-editor`'s tables this is editable state
submitted wholesale with `EditScenario`, so it belongs neither inside the guard nor outside it. The
post-save refetch exists so newly created steps pick up their server ids; with a caller-independent
guard and nothing else, a user typing during that refetch would leave those nodes `isNew` and the
next save would duplicate them server-side. Resolved by merging ids onto the nodes the user holds
rather than replacing the array. Only id-less nodes are filled in, matched by position — so a
reorder cannot corrupt already-saved steps, but an id-less node sitting where a different server
step now sits can take the wrong id. That gap is documented at the call site and pinned by a test
rather than papered over; an identity match would need a key the client does not have for a step
the server has never seen.

**`stakeholder-editor`'s `loadPermissions()` sits inside the guard.** It rebuilds the checkbox
controls from the server's key set, so running it over a half-ticked matrix silently reverts the
ticks. The cost is that the *set* of available permissions can sit stale behind a dirty form; that
set changes far less often than the ticks do, and splitting the group list from the control rebuild
would risk the template looking up a control that no longer exists.

**A post-save ordering bug the ticket did not anticipate.** `report-editor` and `term-editor` were
relying on their post-save refetch to mark the form pristine. Once the guard is in, the form is
still dirty when that refetch lands, so the load skips its own result and Save stays enabled on a
freshly saved document. Both now mark pristine before the refetch — the ordering `scenario-editor`,
goal, story, actor, use-case and stakeholder all already used. `term-editor.spec.ts` caught it;
`report-editor.spec.ts` had no equivalent test and would have shipped it silently, so it has one
now.

## Reading the diff

- **`term-editor.ts` (+342) and `report-editor.ts` (+211) are mostly whitespace.** Those two have
  no create wizard, so wrapping the body in the gate's `@else` re-indented it. `git diff -w` on
  those files shows the real change. The other five editors already branched on `@if (isNew())`, so
  the gate slotted in ahead of it and their diffs are additive.
- The guard is the same shape everywhere: server state unconditional, form state behind
  `if (!this.hasUnsavedChanges())`, checked *after* the await so it catches edits made while the
  request was in flight.
- Every editor's `*-editor.spec.ts` gained a `render gate (#185, finishing #131)` block of four
  tests. They query the DOM rather than the component's signals — a signal assertion would pass
  against a template that never used it.

## Verification

- **Unit:** 864 passing, 89 files. `npx tsc --noEmit` clean on both `tsconfig.json` and
  `tsconfig.e2e.json` (the latter apart from a pre-existing TS4111 in `projects.e2e.ts`).
- **e2e:** run green in three targeted passes as the gate landed — `terms`/`reports`, then
  `goals`/`stories`/`actors`/`sse-refresh`/`form-wizard`, then
  `use-cases`/`projects`/`form-wizard`. A whole-suite run before merge is still worth it to catch
  anything reaching an editor route by a path none of those exercised.
- Guard and gate tests were each confirmed to **fail against the unfixed code** before being
  committed. That check earned its keep twice: one scenario test passed against the old behaviour
  because the mocked server step carried the same name as the user's node, making the merge path
  and the old wholesale replace indistinguishable — it now gives them different names.

## Not in scope

- The association / `@Version` work in #179, #178 and #180.
- `terms-editor`'s save and validation behaviour. Its load path is in scope.

`release/2.0` is not the default branch, so `Closes #185` will not fire on merge — the issue needs
closing by hand afterwards.
