### PR TITLE
187: Fix Stakeholder->StoryContainer cast; non-container ids return INVALID_INPUT

### DIFF
--- a/modules/requel-app/src/test/java/com/rreganjr/requel/service/CommandGatewayIT.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/service/CommandGatewayIT.java
@@ -38,11 +38,13 @@ import com.rreganjr.requel.project.Scenario;
 import com.rreganjr.requel.project.Stakeholder;
 import com.rreganjr.requel.project.StakeholderPermissionType;
 import com.rreganjr.requel.project.Story;
+import com.rreganjr.requel.project.StoryType;
 import com.rreganjr.requel.project.UseCase;
 import com.rreganjr.requel.project.UserStakeholder;
 import com.rreganjr.requel.project.command.EditGoalCommand;
 import com.rreganjr.requel.project.command.EditNonUserStakeholderCommand;
 import com.rreganjr.requel.project.command.EditProjectCommand;
+import com.rreganjr.requel.project.command.EditStoryCommand;
 import com.rreganjr.requel.project.command.EditUserStakeholderCommand;
 import com.rreganjr.requel.project.impl.StakeholderPermissionImpl;
 import com.rreganjr.requel.service.api.CommandRegistration;
@@ -66,6 +68,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -92,6 +95,7 @@ public class CommandGatewayIT extends AbstractIntegrationTestCase {
     private Long goalId;
     private Long nonUserStakeholderId;
     private Long userStakeholderId;
+    private Long storyId;
 
     @BeforeAll
     void setUpFixture() throws Exception {
@@ -149,6 +153,16 @@ public class CommandGatewayIT extends AbstractIntegrationTestCase {
         goalCmd.setText("initial");
         goalCmd = getCommandHandler().execute(goalCmd);
         goalId = goalCmd.getGoal().getId();
+
+        // A real story, so story-container resolution tests fail only on the container id.
+        EditStoryCommand storyCmd = getProjectCommandFactory().newEditStoryCommand();
+        storyCmd.setEditedBy(admin);
+        storyCmd.setStoryContainer(project);
+        storyCmd.setName("gw-story-" + ts);
+        storyCmd.setText("gateway story-container test story");
+        storyCmd.setStoryTypeName(StoryType.Success.name());
+        storyCmd = getCommandHandler().execute(storyCmd);
+        storyId = storyCmd.getStory().getId();
     }
 
     @AfterEach
@@ -200,6 +214,46 @@ public class CommandGatewayIT extends AbstractIntegrationTestCase {
         GatewayException ex = assertThrows(GatewayException.class, () -> gateway.execute(
                 new GatewayRequest("EditGoal",
                         Map.of("projectName", projectName, "goalId", "not-a-number", "name", "x"))));
+        assertEquals(GatewayException.Kind.INVALID_INPUT, ex.getKind());
+    }
+
+    @Test
+    void addStoryToStakeholderContainerIsInvalid() {
+        authenticate(editorUsername);
+        // A stakeholder is not a StoryContainer (issue #187). Passing its id as
+        // storyContainerId is a caller error, so the gateway must map it to INVALID_INPUT
+        // rather than a ClassCastException surfaced as EXECUTION_ERROR.
+        Project project = getProjectRepository().findProjectByName(projectName);
+        assertNotEquals(project.getId(), userStakeholderId,
+                "fixture precondition: stakeholder id must not collide with the project id");
+        GatewayException ex = assertThrows(GatewayException.class, () -> gateway.execute(
+                new GatewayRequest("AddStoryToStoryContainer",
+                        Map.of("projectName", projectName, "storyContainerId", userStakeholderId,
+                                "storyId", storyId))));
+        assertEquals(GatewayException.Kind.INVALID_INPUT, ex.getKind());
+    }
+
+    @Test
+    void removeStoryFromStakeholderContainerIsInvalid() {
+        authenticate(editorUsername);
+        Project project = getProjectRepository().findProjectByName(projectName);
+        assertNotEquals(project.getId(), userStakeholderId,
+                "fixture precondition: stakeholder id must not collide with the project id");
+        GatewayException ex = assertThrows(GatewayException.class, () -> gateway.execute(
+                new GatewayRequest("RemoveStoryFromStoryContainer",
+                        Map.of("projectName", projectName, "storyContainerId", userStakeholderId,
+                                "storyId", storyId))));
+        assertEquals(GatewayException.Kind.INVALID_INPUT, ex.getKind());
+    }
+
+    @Test
+    void storyContainerWithUnknownIdIsInvalid() {
+        authenticate(editorUsername);
+        // An id matching neither the project nor any use case is not a story container.
+        GatewayException ex = assertThrows(GatewayException.class, () -> gateway.execute(
+                new GatewayRequest("AddStoryToStoryContainer",
+                        Map.of("projectName", projectName, "storyContainerId", 999_999_999L,
+                                "storyId", storyId))));
         assertEquals(GatewayException.Kind.INVALID_INPUT, ex.getKind());
     }
 

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/command/ProjectCommandRegistrar.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/command/ProjectCommandRegistrar.java
@@ -44,6 +44,7 @@ import com.rreganjr.requel.project.Step;
 import com.rreganjr.requel.project.Story;
 import com.rreganjr.requel.project.StoryContainer;
 import com.rreganjr.requel.project.UseCase;
+import com.rreganjr.validator.EntityValidationException;
 import com.rreganjr.requel.project.UserStakeholder;
 import com.rreganjr.requel.project.command.AddActorToActorContainerCommand;
 import com.rreganjr.requel.project.command.AddGoalToGoalContainerCommand;
@@ -777,13 +778,14 @@ public class ProjectCommandRegistrar {
 
     private static StoryContainer findStoryContainerById(Project project, Long containerId) {
         if (project.getId().equals(containerId)) return project;
-        for (Stakeholder s : project.getStakeholders()) {
-            if (s.getId().equals(containerId)) return (StoryContainer) s;
-        }
         for (UseCase uc : project.getUseCases()) {
             if (uc.getId().equals(containerId)) return uc;
         }
-        throw new IllegalArgumentException("StoryContainer not found: " + containerId);
+        // Only Project and UseCase implement StoryContainer. Any other id
+        // (stakeholder, goal, actor, or a typo) is a caller error -> INVALID_INPUT/400.
+        throw EntityValidationException.validationFailed(
+                StoryContainer.class, "storyContainerId",
+                "id " + containerId + " does not identify a story container");
     }
 
     private static ActorContainer findActorContainerById(Project project, Long containerId) {


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/187

Fix findStoryContainerById casting a Stakeholder to StoryContainer, and surface a
non-story-container id as INVALID_INPUT (HTTP 400) instead of EXECUTION_ERROR (HTTP 422).

Closes #187

Stakeholder does not implement StoryContainer (it extends ProjectOrDomainEntity,
GoalContainer, Comparable<Stakeholder>), so the stakeholder-scan loop in
findStoryContainerById performed an impossible (StoryContainer) cast. Whenever a
stakeholder id was supplied as storyContainerId -- deterministically over the command
gateway, or via a stakeholder/use-case id collision over HTTP -- the cast threw
ClassCastException. InProcessCommandGateway funneled that through its catch-all to
EXECUTION_ERROR (HTTP 422), reporting a caller error as a server-side failure. Both
AddStoryToStoryContainer and RemoveStoryFromStoryContainer were affected.

modules/service-impl/src/main/java/com/rreganjr/requel/service/command/ProjectCommandRegistrar.java
- Remove the `for (Stakeholder s : project.getStakeholders())` loop and its
  `(StoryContainer) s` cast. Only Project and UseCase implement StoryContainer and both
  are already handled in the method.
- Replace the terminal `throw new IllegalArgumentException(...)` with
  `EntityValidationException.validationFailed(StoryContainer.class, "storyContainerId", ...)`,
  which InProcessCommandGateway already maps to INVALID_INPUT (HTTP 400). Any id that is
  neither the project nor a use case (a stakeholder, goal, actor, or a typo) is now a bad
  request rather than a 422.
- Add the com.rreganjr.validator.EntityValidationException import.

modules/requel-app/src/test/java/com/rreganjr/requel/service/CommandGatewayIT.java
- Add a fixture story (storyId) so story-container resolution tests fail only on the
  container id, not the story id.
- addStoryToStakeholderContainerIsInvalid / removeStoryFromStakeholderContainerIsInvalid:
  a stakeholder id passed as storyContainerId now yields INVALID_INPUT.
- storyContainerWithUnknownIdIsInvalid: an id matching no story container yields INVALID_INPUT.

The sibling findActorContainerById intentionally keeps its Story -> ActorContainer cast
(Story does implement ActorContainer). Normalizing the same IllegalArgumentException ->
EXECUTION_ERROR pattern in the other id resolvers in this file is left to a follow-up ticket.
