### PR TITLE
Type-scope story/actor/goal container lookups by containerType (#189)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ permissions:
   contents: read
   id-token: write
 
+env:
+  # nlp-jpa packages ~210MB of NLP data into its jar; maven-jar-plugin
+  # assembles it in memory and OOMs on the CI default heap. Externalizing
+  # that data is tracked separately; this raises the heap in the meantime.
+  MAVEN_OPTS: -Xmx4g
+
 jobs:
   build-and-test:
     name: Build & test

--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -22,6 +22,12 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # nlp-jpa packages ~210MB of NLP data into its jar; maven-jar-plugin
+  # assembles it in memory and OOMs on the CI default heap. Externalizing
+  # that data is tracked separately; this raises the heap in the meantime.
+  MAVEN_OPTS: -Xmx4g
+
 jobs:
   publish:
     name: Build, smoke test, push image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,12 @@ concurrency:
 permissions:
   contents: write   # required by softprops/action-gh-release to create the Release
 
+env:
+  # nlp-jpa packages ~210MB of NLP data into its jar; maven-jar-plugin
+  # assembles it in memory and OOMs on the CI default heap. Externalizing
+  # that data is tracked separately; this raises the heap in the meantime.
+  MAVEN_OPTS: -Xmx4g
+
 jobs:
   release:
     name: Build & release

--- a/doc/UI_REFACTOR_PLAN.md
+++ b/doc/UI_REFACTOR_PLAN.md
@@ -1421,10 +1421,10 @@ with `draggableNodes`/`droppableNodes` as the foundation.
 - `EditUseCaseInput` — `projectName, useCaseId, name, text, primaryActorName, version`
 - `DeleteUseCaseInput` — `projectName, useCaseId, version`
 - `CopyUseCaseInput` — `projectName, useCaseId`
-- `AddStoryToStoryContainerInput` — `projectName, storyContainerId, storyId`
-- `RemoveStoryFromStoryContainerInput` — `projectName, storyContainerId, storyId`
-- `AddActorToActorContainerInput` — `projectName, actorContainerId, actorId`
-- `RemoveActorFromActorContainerInput` — `projectName, actorContainerId, actorId`
+- `AddStoryToStoryContainerInput` — `projectName, storyContainerId, storyId, containerType`
+- `RemoveStoryFromStoryContainerInput` — `projectName, storyContainerId, storyId, containerType`
+- `AddActorToActorContainerInput` — `projectName, actorContainerId, actorId, containerType`
+- `RemoveActorFromActorContainerInput` — `projectName, actorContainerId, actorId, containerType`
 
 **Backend work — Commands (in `ProjectCommandRegistrar`):**
 1. Wire `EditUseCase` — fields: projectName, useCaseId (null = create), name, text,

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/service/CommandGatewayIT.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/service/CommandGatewayIT.java
@@ -41,10 +41,12 @@ import com.rreganjr.requel.project.Story;
 import com.rreganjr.requel.project.StoryType;
 import com.rreganjr.requel.project.UseCase;
 import com.rreganjr.requel.project.UserStakeholder;
+import com.rreganjr.requel.project.command.EditActorCommand;
 import com.rreganjr.requel.project.command.EditGoalCommand;
 import com.rreganjr.requel.project.command.EditNonUserStakeholderCommand;
 import com.rreganjr.requel.project.command.EditProjectCommand;
 import com.rreganjr.requel.project.command.EditStoryCommand;
+import com.rreganjr.requel.project.command.EditUseCaseCommand;
 import com.rreganjr.requel.project.command.EditUserStakeholderCommand;
 import com.rreganjr.requel.project.impl.StakeholderPermissionImpl;
 import com.rreganjr.requel.service.api.CommandRegistration;
@@ -96,6 +98,9 @@ public class CommandGatewayIT extends AbstractIntegrationTestCase {
     private Long nonUserStakeholderId;
     private Long userStakeholderId;
     private Long storyId;
+    private Long actorId;
+    private Long useCaseId;
+    private Long storyId2;
 
     @BeforeAll
     void setUpFixture() throws Exception {
@@ -163,6 +168,36 @@ public class CommandGatewayIT extends AbstractIntegrationTestCase {
         storyCmd.setStoryTypeName(StoryType.Success.name());
         storyCmd = getCommandHandler().execute(storyCmd);
         storyId = storyCmd.getStory().getId();
+
+        // A second story, so there is a story id that is NOT also a use case id (ids are
+        // per-table auto-increment and the first story/use case collide at 1). issue #189
+        EditStoryCommand storyCmd2 = getProjectCommandFactory().newEditStoryCommand();
+        storyCmd2.setEditedBy(admin);
+        storyCmd2.setStoryContainer(project);
+        storyCmd2.setName("gw-story2-" + ts);
+        storyCmd2.setText("second gateway story-container test story");
+        storyCmd2.setStoryTypeName(StoryType.Success.name());
+        storyCmd2 = getCommandHandler().execute(storyCmd2);
+        storyId2 = storyCmd2.getStory().getId();
+
+        // An actor and a use case, so actor/goal-container resolution tests can target a use case
+        // (and an actor) by id with an explicit containerType (issue #189).
+        EditActorCommand actorCmd = getProjectCommandFactory().newEditActorCommand();
+        actorCmd.setEditedBy(admin);
+        actorCmd.setActorContainer(project);
+        actorCmd.setName("gw-actor-" + ts);
+        actorCmd.setText("gateway actor-container test actor");
+        actorCmd = getCommandHandler().execute(actorCmd);
+        actorId = actorCmd.getActor().getId();
+
+        EditUseCaseCommand useCaseCmd = getProjectCommandFactory().newEditUseCaseCommand();
+        useCaseCmd.setEditedBy(admin);
+        useCaseCmd.setProjectOrDomain(project);
+        useCaseCmd.setName("gw-usecase-" + ts);
+        useCaseCmd.setText("gateway use-case-container test use case");
+        useCaseCmd.setPrimaryActorName(actorCmd.getActor().getName());
+        useCaseCmd = getCommandHandler().execute(useCaseCmd);
+        useCaseId = useCaseCmd.getUseCase().getId();
     }
 
     @AfterEach
@@ -229,7 +264,7 @@ public class CommandGatewayIT extends AbstractIntegrationTestCase {
         GatewayException ex = assertThrows(GatewayException.class, () -> gateway.execute(
                 new GatewayRequest("AddStoryToStoryContainer",
                         Map.of("projectName", projectName, "storyContainerId", userStakeholderId,
-                                "storyId", storyId))));
+                                "storyId", storyId, "containerType", "Stakeholder"))));
         assertEquals(GatewayException.Kind.INVALID_INPUT, ex.getKind());
     }
 
@@ -242,7 +277,7 @@ public class CommandGatewayIT extends AbstractIntegrationTestCase {
         GatewayException ex = assertThrows(GatewayException.class, () -> gateway.execute(
                 new GatewayRequest("RemoveStoryFromStoryContainer",
                         Map.of("projectName", projectName, "storyContainerId", userStakeholderId,
-                                "storyId", storyId))));
+                                "storyId", storyId, "containerType", "Stakeholder"))));
         assertEquals(GatewayException.Kind.INVALID_INPUT, ex.getKind());
     }
 
@@ -253,8 +288,48 @@ public class CommandGatewayIT extends AbstractIntegrationTestCase {
         GatewayException ex = assertThrows(GatewayException.class, () -> gateway.execute(
                 new GatewayRequest("AddStoryToStoryContainer",
                         Map.of("projectName", projectName, "storyContainerId", 999_999_999L,
+                                "storyId", storyId, "containerType", "UseCase"))));
+        assertEquals(GatewayException.Kind.INVALID_INPUT, ex.getKind());
+    }
+
+    @Test
+    void storyContainerMissingContainerTypeIsInvalid() {
+        authenticate(editorUsername);
+        // containerType is required (issue #189); omitting it is a caller error even when the id
+        // names a real story container.
+        GatewayException ex = assertThrows(GatewayException.class, () -> gateway.execute(
+                new GatewayRequest("AddStoryToStoryContainer",
+                        Map.of("projectName", projectName, "storyContainerId", useCaseId,
                                 "storyId", storyId))));
         assertEquals(GatewayException.Kind.INVALID_INPUT, ex.getKind());
+    }
+
+    @Test
+    void actorContainerLookupIsScopedToNamedType() {
+        authenticate(editorUsername);
+        // Issue #189 core regression: the type-scoped lookup must not fall through to other
+        // collections the way the pre-fix scan-all lookup did. storyId2 exists only as a story
+        // (there is no use case with that id), so requesting it as a "UseCase" actor container is
+        // rejected. The old lookup would have matched the story (a valid ActorContainer) and
+        // silently attached the actor to the wrong parent.
+        assertNotEquals(useCaseId, storyId2,
+                "fixture precondition: the second story id must not also be a use case id");
+        GatewayException ex = assertThrows(GatewayException.class, () -> gateway.execute(
+                new GatewayRequest("AddActorToActorContainer",
+                        Map.of("projectName", projectName, "actorContainerId", storyId2,
+                                "actorId", actorId, "containerType", "UseCase"))));
+        assertEquals(GatewayException.Kind.INVALID_INPUT, ex.getKind());
+    }
+
+    @Test
+    void goalContainerResolvesUseCaseByExplicitType() throws Exception {
+        authenticate(editorUsername);
+        // Positive path for the type-scoped goal lookup (issue #189): resolving a use case goal
+        // container by its named type executes without a resolution error.
+        GatewayResult result = gateway.execute(new GatewayRequest("AddGoalToGoalContainer",
+                Map.of("projectName", projectName, "goalContainerId", useCaseId,
+                        "goalId", goalId, "containerType", "UseCase")));
+        assertEquals("AddGoalToGoalContainer", result.commandType());
     }
 
     @Test

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/service/CommandGatewayIT.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/service/CommandGatewayIT.java
@@ -99,6 +99,7 @@ public class CommandGatewayIT extends AbstractIntegrationTestCase {
     private Long userStakeholderId;
     private Long storyId;
     private Long actorId;
+    private Long actorId2;
     private Long useCaseId;
     private Long storyId2;
 
@@ -189,6 +190,15 @@ public class CommandGatewayIT extends AbstractIntegrationTestCase {
         actorCmd.setText("gateway actor-container test actor");
         actorCmd = getCommandHandler().execute(actorCmd);
         actorId = actorCmd.getActor().getId();
+
+        // A second actor that is nobody's primary actor, safe to add as a secondary member.
+        EditActorCommand actorCmd2 = getProjectCommandFactory().newEditActorCommand();
+        actorCmd2.setEditedBy(admin);
+        actorCmd2.setActorContainer(project);
+        actorCmd2.setName("gw-actor2-" + ts);
+        actorCmd2.setText("gateway secondary-actor test actor");
+        actorCmd2 = getCommandHandler().execute(actorCmd2);
+        actorId2 = actorCmd2.getActor().getId();
 
         EditUseCaseCommand useCaseCmd = getProjectCommandFactory().newEditUseCaseCommand();
         useCaseCmd.setEditedBy(admin);
@@ -330,6 +340,115 @@ public class CommandGatewayIT extends AbstractIntegrationTestCase {
                 Map.of("projectName", projectName, "goalContainerId", useCaseId,
                         "goalId", goalId, "containerType", "UseCase")));
         assertEquals("AddGoalToGoalContainer", result.commandType());
+    }
+
+    // ---- issue #189: type-scoped container resolution ------------------------------------------
+    // These exercise each branch of findStoryContainerById / findActorContainerById /
+    // findGoalContainerById through the gateway. The backend coverage is measured from this Java
+    // run (JaCoCo), not the Playwright e2e suite, so the happy paths must be pinned here too.
+
+    @Test
+    void storyContainerResolvesUseCaseByExplicitType() throws Exception {
+        authenticate(editorUsername);
+        GatewayResult result = gateway.execute(new GatewayRequest("AddStoryToStoryContainer",
+                Map.of("projectName", projectName, "storyContainerId", useCaseId,
+                        "storyId", storyId, "containerType", "UseCase")));
+        assertEquals("AddStoryToStoryContainer", result.commandType());
+    }
+
+    @Test
+    void actorContainerResolvesUseCaseByExplicitType() throws Exception {
+        authenticate(editorUsername);
+        GatewayResult result = gateway.execute(new GatewayRequest("AddActorToActorContainer",
+                Map.of("projectName", projectName, "actorContainerId", useCaseId,
+                        "actorId", actorId2, "containerType", "UseCase")));
+        assertEquals("AddActorToActorContainer", result.commandType());
+    }
+
+    @Test
+    void actorContainerResolvesStoryByExplicitType() throws Exception {
+        authenticate(editorUsername);
+        GatewayResult result = gateway.execute(new GatewayRequest("AddActorToActorContainer",
+                Map.of("projectName", projectName, "actorContainerId", storyId,
+                        "actorId", actorId2, "containerType", "Story")));
+        assertEquals("AddActorToActorContainer", result.commandType());
+    }
+
+    @Test
+    void goalContainerResolvesStoryByExplicitType() throws Exception {
+        authenticate(editorUsername);
+        GatewayResult result = gateway.execute(new GatewayRequest("AddGoalToGoalContainer",
+                Map.of("projectName", projectName, "goalContainerId", storyId,
+                        "goalId", goalId, "containerType", "Story")));
+        assertEquals("AddGoalToGoalContainer", result.commandType());
+    }
+
+    @Test
+    void goalContainerResolvesActorByExplicitType() throws Exception {
+        authenticate(editorUsername);
+        GatewayResult result = gateway.execute(new GatewayRequest("AddGoalToGoalContainer",
+                Map.of("projectName", projectName, "goalContainerId", actorId,
+                        "goalId", goalId, "containerType", "Actor")));
+        assertEquals("AddGoalToGoalContainer", result.commandType());
+    }
+
+    @Test
+    void goalContainerResolvesStakeholderByExplicitType() throws Exception {
+        authenticate(editorUsername);
+        GatewayResult result = gateway.execute(new GatewayRequest("AddGoalToGoalContainer",
+                Map.of("projectName", projectName, "goalContainerId", userStakeholderId,
+                        "goalId", goalId, "containerType", "Stakeholder")));
+        assertEquals("AddGoalToGoalContainer", result.commandType());
+    }
+
+    @Test
+    void storyContainerRejectsUnknownProjectId() {
+        assertContainerRequestInvalid("AddStoryToStoryContainer",
+                Map.of("projectName", projectName, "storyContainerId", 999_999_999L,
+                        "storyId", storyId, "containerType", "Project"));
+    }
+
+    @Test
+    void actorContainerRejectsUnknownProjectId() {
+        assertContainerRequestInvalid("AddActorToActorContainer",
+                Map.of("projectName", projectName, "actorContainerId", 999_999_999L,
+                        "actorId", actorId, "containerType", "Project"));
+    }
+
+    @Test
+    void actorContainerRejectsUnknownStoryId() {
+        assertContainerRequestInvalid("AddActorToActorContainer",
+                Map.of("projectName", projectName, "actorContainerId", 999_999_999L,
+                        "actorId", actorId, "containerType", "Story"));
+    }
+
+    @Test
+    void actorContainerRejectsUnknownType() {
+        assertContainerRequestInvalid("AddActorToActorContainer",
+                Map.of("projectName", projectName, "actorContainerId", useCaseId,
+                        "actorId", actorId, "containerType", "Bogus"));
+    }
+
+    @Test
+    void goalContainerRejectsUnknownIdForEachType() {
+        // Not-found within each named type -> INVALID_INPUT (covers every branch throw), plus the
+        // terminal unknown-type throw.
+        for (String type : new String[] { "Project", "UseCase", "Story", "Actor", "Stakeholder" }) {
+            assertContainerRequestInvalid("AddGoalToGoalContainer",
+                    Map.of("projectName", projectName, "goalContainerId", 999_999_999L,
+                            "goalId", goalId, "containerType", type));
+        }
+        assertContainerRequestInvalid("AddGoalToGoalContainer",
+                Map.of("projectName", projectName, "goalContainerId", useCaseId,
+                        "goalId", goalId, "containerType", "Bogus"));
+    }
+
+    private void assertContainerRequestInvalid(String commandType, Map<String, Object> input) {
+        authenticate(editorUsername);
+        GatewayException ex = assertThrows(GatewayException.class,
+                () -> gateway.execute(new GatewayRequest(commandType, input)));
+        assertEquals(GatewayException.Kind.INVALID_INPUT, ex.getKind(),
+                commandType + " " + input.get("containerType") + " should map to INVALID_INPUT");
     }
 
     @Test

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/AddActorToActorContainerInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/AddActorToActorContainerInput.java
@@ -23,4 +23,10 @@ package com.rreganjr.requel.service.api.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-public record AddActorToActorContainerInput(@NotBlank String projectName, @NotNull Long actorContainerId, @NotNull Long actorId) {}
+public record AddActorToActorContainerInput(
+        @NotBlank String projectName,
+        @NotNull Long actorContainerId,
+        @NotNull Long actorId,
+        @NotBlank String containerType
+) {
+}

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/AddStoryToStoryContainerInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/AddStoryToStoryContainerInput.java
@@ -23,4 +23,10 @@ package com.rreganjr.requel.service.api.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-public record AddStoryToStoryContainerInput(@NotBlank String projectName, @NotNull Long storyContainerId, @NotNull Long storyId) {}
+public record AddStoryToStoryContainerInput(
+        @NotBlank String projectName,
+        @NotNull Long storyContainerId,
+        @NotNull Long storyId,
+        @NotBlank String containerType
+) {
+}

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/RemoveActorFromActorContainerInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/RemoveActorFromActorContainerInput.java
@@ -23,4 +23,10 @@ package com.rreganjr.requel.service.api.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-public record RemoveActorFromActorContainerInput(@NotBlank String projectName, @NotNull Long actorContainerId, @NotNull Long actorId) {}
+public record RemoveActorFromActorContainerInput(
+        @NotBlank String projectName,
+        @NotNull Long actorContainerId,
+        @NotNull Long actorId,
+        @NotBlank String containerType
+) {
+}

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/RemoveStoryFromStoryContainerInput.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/dto/RemoveStoryFromStoryContainerInput.java
@@ -23,4 +23,10 @@ package com.rreganjr.requel.service.api.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-public record RemoveStoryFromStoryContainerInput(@NotBlank String projectName, @NotNull Long storyContainerId, @NotNull Long storyId) {}
+public record RemoveStoryFromStoryContainerInput(
+        @NotBlank String projectName,
+        @NotNull Long storyContainerId,
+        @NotNull Long storyId,
+        @NotBlank String containerType
+) {
+}

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/command/ProjectCommandRegistrar.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/command/ProjectCommandRegistrar.java
@@ -394,7 +394,7 @@ public class ProjectCommandRegistrar {
                     AddStoryToStoryContainerCommand c = (AddStoryToStoryContainerCommand) cmd;
                     AddStoryToStoryContainerInput i = (AddStoryToStoryContainerInput) input;
                     Project project = projectRepository.findProjectByName(i.projectName());
-                    c.setStoryContainer(findStoryContainerById(project, i.storyContainerId()));
+                    c.setStoryContainer(findStoryContainerById(project, i.storyContainerId(), i.containerType()));
                     c.setStory(findStoryById(project, i.storyId()));
                 });
 
@@ -404,7 +404,7 @@ public class ProjectCommandRegistrar {
                     RemoveStoryFromStoryContainerCommand c = (RemoveStoryFromStoryContainerCommand) cmd;
                     RemoveStoryFromStoryContainerInput i = (RemoveStoryFromStoryContainerInput) input;
                     Project project = projectRepository.findProjectByName(i.projectName());
-                    c.setStoryContainer(findStoryContainerById(project, i.storyContainerId()));
+                    c.setStoryContainer(findStoryContainerById(project, i.storyContainerId(), i.containerType()));
                     c.setStory(findStoryById(project, i.storyId()));
                 });
 
@@ -434,7 +434,7 @@ public class ProjectCommandRegistrar {
                     AddActorToActorContainerCommand c = (AddActorToActorContainerCommand) cmd;
                     AddActorToActorContainerInput i = (AddActorToActorContainerInput) input;
                     Project project = projectRepository.findProjectByName(i.projectName());
-                    c.setActorContainer(findActorContainerById(project, i.actorContainerId()));
+                    c.setActorContainer(findActorContainerById(project, i.actorContainerId(), i.containerType()));
                     c.setActor(findActorById(project, i.actorId()));
                 });
 
@@ -444,7 +444,7 @@ public class ProjectCommandRegistrar {
                     RemoveActorFromActorContainerCommand c = (RemoveActorFromActorContainerCommand) cmd;
                     RemoveActorFromActorContainerInput i = (RemoveActorFromActorContainerInput) input;
                     Project project = projectRepository.findProjectByName(i.projectName());
-                    c.setActorContainer(findActorContainerById(project, i.actorContainerId()));
+                    c.setActorContainer(findActorContainerById(project, i.actorContainerId(), i.containerType()));
                     c.setActor(findActorById(project, i.actorId()));
                 });
         registry.register("CopyActor", CopyActorInput.class,
@@ -733,70 +733,88 @@ public class ProjectCommandRegistrar {
     }
 
     private static GoalContainer findGoalContainerById(Project project, Long containerId, String containerType) {
-        // When the caller knows the entity type, skip straight to that collection to avoid
-        // ID collisions between entity types (all tables use per-table auto-increment).
+        // Resolve strictly within the named type to avoid cross-type ID collisions
+        // (all tables use per-table auto-increment). issue #189
+        if ("Project".equalsIgnoreCase(containerType)) {
+            if (project.getId().equals(containerId)) return project;
+            throw EntityValidationException.validationFailed(GoalContainer.class, "goalContainerId",
+                    "id " + containerId + " does not identify the project");
+        }
         if ("UseCase".equalsIgnoreCase(containerType)) {
             for (UseCase uc : project.getUseCases()) {
                 if (uc.getId().equals(containerId)) return (GoalContainer) uc;
             }
-            throw new IllegalArgumentException("UseCase GoalContainer not found: " + containerId);
+            throw EntityValidationException.validationFailed(GoalContainer.class, "goalContainerId",
+                    "id " + containerId + " does not identify a use case goal container");
         }
         if ("Story".equalsIgnoreCase(containerType)) {
             for (Story s : project.getStories()) {
                 if (s.getId().equals(containerId)) return (GoalContainer) s;
             }
-            throw new IllegalArgumentException("Story GoalContainer not found: " + containerId);
+            throw EntityValidationException.validationFailed(GoalContainer.class, "goalContainerId",
+                    "id " + containerId + " does not identify a story goal container");
         }
         if ("Actor".equalsIgnoreCase(containerType)) {
             for (Actor a : project.getActors()) {
                 if (a.getId().equals(containerId)) return (GoalContainer) a;
             }
-            throw new IllegalArgumentException("Actor GoalContainer not found: " + containerId);
+            throw EntityValidationException.validationFailed(GoalContainer.class, "goalContainerId",
+                    "id " + containerId + " does not identify an actor goal container");
         }
         if ("Stakeholder".equalsIgnoreCase(containerType) || "UserStakeholder".equalsIgnoreCase(containerType)
                 || "NonUserStakeholder".equalsIgnoreCase(containerType)) {
             for (Stakeholder s : project.getStakeholders()) {
                 if (s.getId().equals(containerId)) return (GoalContainer) s;
             }
-            throw new IllegalArgumentException("Stakeholder GoalContainer not found: " + containerId);
+            throw EntityValidationException.validationFailed(GoalContainer.class, "goalContainerId",
+                    "id " + containerId + " does not identify a stakeholder goal container");
         }
-        // Fall back: search all (legacy path, may hit ID collisions)
-        for (Stakeholder s : project.getStakeholders()) {
-            if (s.getId().equals(containerId)) return (GoalContainer) s;
-        }
-        for (Story s : project.getStories()) {
-            if (s.getId().equals(containerId)) return (GoalContainer) s;
-        }
-        for (Actor a : project.getActors()) {
-            if (a.getId().equals(containerId)) return (GoalContainer) a;
-        }
-        for (UseCase uc : project.getUseCases()) {
-            if (uc.getId().equals(containerId)) return (GoalContainer) uc;
-        }
-        throw new IllegalArgumentException("GoalContainer not found: " + containerId);
+        throw EntityValidationException.validationFailed(GoalContainer.class, "containerType",
+                "'" + containerType + "' is not a valid goal container type "
+                        + "(expected Project, UseCase, Story, Actor, or Stakeholder)");
     }
 
-    private static StoryContainer findStoryContainerById(Project project, Long containerId) {
-        if (project.getId().equals(containerId)) return project;
-        for (UseCase uc : project.getUseCases()) {
-            if (uc.getId().equals(containerId)) return uc;
+    private static StoryContainer findStoryContainerById(Project project, Long containerId, String containerType) {
+        // Resolve strictly within the named type. Only Project and UseCase are StoryContainers. issue #189
+        if ("Project".equalsIgnoreCase(containerType)) {
+            if (project.getId().equals(containerId)) return project;
+            throw EntityValidationException.validationFailed(StoryContainer.class, "storyContainerId",
+                    "id " + containerId + " does not identify the project");
         }
-        // Only Project and UseCase implement StoryContainer. Any other id
-        // (stakeholder, goal, actor, or a typo) is a caller error -> INVALID_INPUT/400.
-        throw EntityValidationException.validationFailed(
-                StoryContainer.class, "storyContainerId",
-                "id " + containerId + " does not identify a story container");
+        if ("UseCase".equalsIgnoreCase(containerType)) {
+            for (UseCase uc : project.getUseCases()) {
+                if (uc.getId().equals(containerId)) return uc;
+            }
+            throw EntityValidationException.validationFailed(StoryContainer.class, "storyContainerId",
+                    "id " + containerId + " does not identify a use case story container");
+        }
+        throw EntityValidationException.validationFailed(StoryContainer.class, "containerType",
+                "'" + containerType + "' is not a valid story container type (expected Project or UseCase)");
     }
 
-    private static ActorContainer findActorContainerById(Project project, Long containerId) {
-        if (project.getId().equals(containerId)) return project;
-        for (UseCase uc : project.getUseCases()) {
-            if (uc.getId().equals(containerId)) return uc;
+    private static ActorContainer findActorContainerById(Project project, Long containerId, String containerType) {
+        // Resolve strictly within the named type. Project, UseCase, and Story are ActorContainers. issue #189
+        if ("Project".equalsIgnoreCase(containerType)) {
+            if (project.getId().equals(containerId)) return project;
+            throw EntityValidationException.validationFailed(ActorContainer.class, "actorContainerId",
+                    "id " + containerId + " does not identify the project");
         }
-        for (Story s : project.getStories()) {
-            if (s.getId().equals(containerId)) return (ActorContainer) s;
+        if ("UseCase".equalsIgnoreCase(containerType)) {
+            for (UseCase uc : project.getUseCases()) {
+                if (uc.getId().equals(containerId)) return uc;
+            }
+            throw EntityValidationException.validationFailed(ActorContainer.class, "actorContainerId",
+                    "id " + containerId + " does not identify a use case actor container");
         }
-        throw new IllegalArgumentException("ActorContainer not found: " + containerId);
+        if ("Story".equalsIgnoreCase(containerType)) {
+            for (Story s : project.getStories()) {
+                if (s.getId().equals(containerId)) return (ActorContainer) s;
+            }
+            throw EntityValidationException.validationFailed(ActorContainer.class, "actorContainerId",
+                    "id " + containerId + " does not identify a story actor container");
+        }
+        throw EntityValidationException.validationFailed(ActorContainer.class, "containerType",
+                "'" + containerType + "' is not a valid actor container type (expected Project, UseCase, or Story)");
     }
 
     private static UseCase findUseCaseById(Project project, Long useCaseId) {

--- a/requel-angular/e2e/fixtures/api-helper.ts
+++ b/requel-angular/e2e/fixtures/api-helper.ts
@@ -305,6 +305,7 @@ export async function addActorToStory(
     projectName,
     actorContainerId: storyId,
     actorId,
+    containerType: 'Story',
   });
 }
 
@@ -319,6 +320,7 @@ export async function addActorToUseCase(
     projectName,
     actorContainerId: useCaseId,
     actorId,
+    containerType: 'UseCase',
   });
 }
 
@@ -334,10 +336,10 @@ export async function addGoalToUseCase(
     goalContainerId: useCaseId,
     goalId,
     // Required by AddGoalToGoalContainerInput, and the value the SPA sends
-    // (use-case-editor.ts). ProjectCommandRegistrar:737 resolves it case-insensitively to pick
-    // the container out of the project. Omitting it was silently tolerated until #171 turned DTO
-    // validation on; it now fails with 422 "containerType: must not be blank". Note the Actor and
-    // Story container inputs have no equivalent field, so only this call needed it.
+    // (use-case-editor.ts). ProjectCommandRegistrar resolves it case-insensitively to pick
+    // the container out of the named type. Omitting it fails with 422 "containerType: must not be
+    // blank". As of #189 the Actor and Story container inputs carry the same required field, so the
+    // addActorTo*/addStoryTo* helpers below set it too.
     containerType: 'UseCase',
   });
 }
@@ -368,6 +370,7 @@ export async function addStoryToUseCase(
     projectName,
     storyContainerId: useCaseId,
     storyId,
+    containerType: 'UseCase',
   });
 }
 

--- a/requel-angular/src/app/features/stories/story-editor.spec.ts
+++ b/requel-angular/src/app/features/stories/story-editor.spec.ts
@@ -466,6 +466,32 @@ describe('StoryEditorComponent', () => {
       expect(await saveAndReadVersion()).toBe(bumped);
     });
 
+    it('onActorSelected sends AddActorToActorContainer with containerType Story', async () => {
+      await renderExisting();
+      associationSucceeds();
+      await comp.onActorSelected(ACTOR_A);
+      expect(commandServiceMock.execute).toHaveBeenCalledWith('AddActorToActorContainer',
+        expect.objectContaining({
+          projectName: 'proj1',
+          actorContainerId: 20,
+          actorId: 1,
+          containerType: 'Story'
+        }));
+    });
+
+    it('onRemoveActor sends RemoveActorFromActorContainer with containerType Story', async () => {
+      await renderExisting();
+      associationSucceeds();
+      await comp.onRemoveActor(ACTOR_A);
+      expect(commandServiceMock.execute).toHaveBeenCalledWith('RemoveActorFromActorContainer',
+        expect.objectContaining({
+          projectName: 'proj1',
+          actorContainerId: 20,
+          actorId: 1,
+          containerType: 'Story'
+        }));
+    });
+
     it('takes the goals list from the response instead of patching it locally', async () => {
       await renderExisting();
       associationSucceeds();

--- a/requel-angular/src/app/features/stories/story-editor.ts
+++ b/requel-angular/src/app/features/stories/story-editor.ts
@@ -806,7 +806,8 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
       const result = await this.commandService.execute('AddActorToActorContainer', {
         projectName: this.projectName,
         actorContainerId: this.storyId,
-        actorId: ref.id
+        actorId: ref.id,
+        containerType: 'Story'
       });
       if (result.success) {
         await this.refreshAfterAssociation();
@@ -824,7 +825,8 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
       const result = await this.commandService.execute('RemoveActorFromActorContainer', {
         projectName: this.projectName,
         actorContainerId: this.storyId,
-        actorId: actorRef.id
+        actorId: actorRef.id,
+        containerType: 'Story'
       });
       if (result.success) {
         await this.refreshAfterAssociation();

--- a/requel-angular/src/app/features/use-cases/use-case-editor.spec.ts
+++ b/requel-angular/src/app/features/use-cases/use-case-editor.spec.ts
@@ -324,7 +324,8 @@ describe('UseCaseEditorComponent', () => {
     expect(commandServiceMock.execute).toHaveBeenCalledWith('AddStoryToStoryContainer', expect.objectContaining({
       projectName: 'proj1',
       storyContainerId: 30,
-      storyId: 5
+      storyId: 5,
+      containerType: 'UseCase'
     }));
   });
 
@@ -337,7 +338,8 @@ describe('UseCaseEditorComponent', () => {
     await comp.removeStory(story);
     expect(commandServiceMock.execute).toHaveBeenCalledWith('RemoveStoryFromStoryContainer', expect.objectContaining({
       storyContainerId: 30,
-      storyId: 5
+      storyId: 5,
+      containerType: 'UseCase'
     }));
   });
 

--- a/requel-angular/src/app/features/use-cases/use-case-editor.ts
+++ b/requel-angular/src/app/features/use-cases/use-case-editor.ts
@@ -920,7 +920,8 @@ export class UseCaseEditorComponent implements OnInit, OnDestroy, DirtyCheckable
   async addStory(ref: EntityReferenceDto): Promise<void> {
     this.showStorySelector = false;
     const result = await this.commandService.execute('AddStoryToStoryContainer', {
-      projectName: this.projectName, storyContainerId: this.useCaseId, storyId: ref.id
+      projectName: this.projectName, storyContainerId: this.useCaseId, storyId: ref.id,
+      containerType: 'UseCase'
     });
     if (result.success) await this.refreshCollections();
     else this.errorMessage.set(result.error ?? 'Failed to add story.');
@@ -928,7 +929,8 @@ export class UseCaseEditorComponent implements OnInit, OnDestroy, DirtyCheckable
 
   async removeStory(story: StoryDto): Promise<void> {
     const result = await this.commandService.execute('RemoveStoryFromStoryContainer', {
-      projectName: this.projectName, storyContainerId: this.useCaseId, storyId: story.id
+      projectName: this.projectName, storyContainerId: this.useCaseId, storyId: story.id,
+      containerType: 'UseCase'
     });
     if (result.success) await this.refreshCollections();
     else this.errorMessage.set(result.error ?? 'Failed to remove story.');
@@ -937,7 +939,8 @@ export class UseCaseEditorComponent implements OnInit, OnDestroy, DirtyCheckable
   async addActorToList(ref: EntityReferenceDto): Promise<void> {
     this.showActorSelector = false;
     const result = await this.commandService.execute('AddActorToActorContainer', {
-      projectName: this.projectName, actorContainerId: this.useCaseId, actorId: ref.id
+      projectName: this.projectName, actorContainerId: this.useCaseId, actorId: ref.id,
+      containerType: 'UseCase'
     });
     if (result.success) await this.refreshCollections();
     else this.errorMessage.set(result.error ?? 'Failed to add actor.');
@@ -945,7 +948,8 @@ export class UseCaseEditorComponent implements OnInit, OnDestroy, DirtyCheckable
 
   async removeActor(actor: ActorDto): Promise<void> {
     const result = await this.commandService.execute('RemoveActorFromActorContainer', {
-      projectName: this.projectName, actorContainerId: this.useCaseId, actorId: actor.id
+      projectName: this.projectName, actorContainerId: this.useCaseId, actorId: actor.id,
+      containerType: 'UseCase'
     });
     if (result.success) await this.refreshCollections();
     else this.errorMessage.set(result.error ?? 'Failed to remove actor.');


### PR DESCRIPTION
Closes #185.

## Summary

Open an entity editor by URL, start typing before the page finishes loading, and your input
vanishes — with Save disabled and nothing on screen explaining why. The detail GET lands after the
form has rendered and resets it, which also clears `dirty`, so the form ends up pristine and
holding the server's values and Save cannot be re-enabled without another edit.

#184 fixed this in goal, story and actor. This PR finishes the job: five more editors carry the
guard, and all ten now render their form only once the detail GET resolves.

## Two defences, not one

**The guard** — a load never resets a form with unsaved changes. Server state (version especially)
is still adopted, so a skipped reset does not leave a stale version to 409 on. This is the only
protection on the callers that fire long after render: SSE refresh, 409 recovery, post-save
refetch.

**The gate** — the form is not rendered until the detail GET resolves, so there is no input to type
into during the load. This removes the window rather than defending it, and closes the hazard that
made the original bug expensive to diagnose: assertions an editor route satisfies while still empty
— element counts, a disabled Save on a pristine form — passed just as well against a form that had
not loaded. With the gate a racing test fails loudly instead of passing for the wrong reason.

The gate is not new work. #131 (#168) built `app-loading-state` / `app-error-state` /
`app-empty-state` and wired them into project, scenario and user, then stopped. This finishes that
migration for the other seven, following `project-editor.ts` as the reference shape.

## Commits

| | |
|---|---|
| `fcca7c4` | Guard report-editor, term-editor |
| `f47d895` | Guard use-case-editor |
| `99c5745` | CLAUDE.md process rule (see below) |
| `111b28b` | Guard stakeholder-editor |
| `aeaec2e` | scenario-editor: caller-independent guard + step-id merge |
| `db82cd6` | Gate report-editor, term-editor + 2 e2e fixes |
| `23f70ec` | Gate goal, story, actor + 1 e2e fix |
| `5b9ba46` | Gate use-case, stakeholder |
| `86c7c0f` | Backfill the two missing guard tests |

`99c5745` is a process change riding along rather than its own ticket: it records in CLAUDE.md that
Claude prepares `git` / `gh` commands rather than running them. It came out of working this issue
(the Cowork device bridge cannot delete files, so any git command Claude ran stranded
`.git/index.lock`) and it changed how the rest of the branch landed. Happy to split it out if you'd
rather.

## The ticket was wrong about scenario-editor

Worth reading if you reviewed the original issue text, which listed `scenario-editor.ts:560` as
"same bug, different shape". It isn't. Scenario has been render-gated since #173 —
`loading = signal(true)` with the form behind `@if (loading())` — so the typing race cannot happen
there. Its real defect was the two callers that passed `fromSSE = false` and therefore skipped the
guard entirely: the 409 recovery, which threw away the edit the user was retrying, and the
post-save refetch. The issue was rewritten to say so before any code was written; anyone working
from the original text would have chased a race that isn't there and written an e2e test that
cannot fail.

## Behaviour changes to notice in review

- **A 409 recovery now keeps the edit being retried** instead of resetting to the server's values.
  #184 made this change for three editors deliberately; it now applies to all of them. This is the
  point of a retry, but it is a visible change.
- **A failed *initial* load renders a retryable error state in place of the form**, rather than
  annotating the form with the inline `errorMessage` — there is no form to annotate. Background
  failures keep the inline message. `actor-editor.spec.ts`'s existing error test is what surfaced
  this; it now asserts `loadError`, with a sibling pinning the background half.
- **Create wizards appear a beat later on `stakeholder-editor`.** Its `ngOnInit` awaits
  `loadForProject()` before branching on the route param, so unlike the other six there is no
  synchronous create block to resolve the gate in; it resolves in `resetForCreate()` instead. The
  form it used to render early was one nobody should have been typing into.
- **A refresh arriving while the form is dirty now updates the association tables.** Collections
  sit outside the guard deliberately — the old early-return left goals / referenced-by tables stale
  behind an unsaved rename.

## Decisions with trade-offs

**`scenario-editor`'s `stepNodes`.** Unlike `actor-editor`'s tables this is editable state
submitted wholesale with `EditScenario`, so it belongs neither inside the guard nor outside it. The
post-save refetch exists so newly created steps pick up their server ids; with a caller-independent
guard and nothing else, a user typing during that refetch would leave those nodes `isNew` and the
next save would duplicate them server-side. Resolved by merging ids onto the nodes the user holds
rather than replacing the array. Only id-less nodes are filled in, matched by position — so a
reorder cannot corrupt already-saved steps, but an id-less node sitting where a different server
step now sits can take the wrong id. That gap is documented at the call site and pinned by a test
rather than papered over; an identity match would need a key the client does not have for a step
the server has never seen.

**`stakeholder-editor`'s `loadPermissions()` sits inside the guard.** It rebuilds the checkbox
controls from the server's key set, so running it over a half-ticked matrix silently reverts the
ticks. The cost is that the *set* of available permissions can sit stale behind a dirty form; that
set changes far less often than the ticks do, and splitting the group list from the control rebuild
would risk the template looking up a control that no longer exists.

**A post-save ordering bug the ticket did not anticipate.** `report-editor` and `term-editor` were
relying on their post-save refetch to mark the form pristine. Once the guard is in, the form is
still dirty when that refetch lands, so the load skips its own result and Save stays enabled on a
freshly saved document. Both now mark pristine before the refetch — the ordering `scenario-editor`,
goal, story, actor, use-case and stakeholder all already used. `term-editor.spec.ts` caught it;
`report-editor.spec.ts` had no equivalent test and would have shipped it silently, so it has one
now.

## Reading the diff

- **`term-editor.ts` (+342) and `report-editor.ts` (+211) are mostly whitespace.** Those two have
  no create wizard, so wrapping the body in the gate's `@else` re-indented it. `git diff -w` on
  those files shows the real change. The other five editors already branched on `@if (isNew())`, so
  the gate slotted in ahead of it and their diffs are additive.
- The guard is the same shape everywhere: server state unconditional, form state behind
  `if (!this.hasUnsavedChanges())`, checked *after* the await so it catches edits made while the
  request was in flight.
- Every editor's `*-editor.spec.ts` gained a `render gate (#185, finishing #131)` block of four
  tests. They query the DOM rather than the component's signals — a signal assertion would pass
  against a template that never used it.

## Verification

- **Unit:** 864 passing, 89 files. `npx tsc --noEmit` clean on both `tsconfig.json` and
  `tsconfig.e2e.json` (the latter apart from a pre-existing TS4111 in `projects.e2e.ts`).
- **e2e:** run green in three targeted passes as the gate landed — `terms`/`reports`, then
  `goals`/`stories`/`actors`/`sse-refresh`/`form-wizard`, then
  `use-cases`/`projects`/`form-wizard`. A whole-suite run before merge is still worth it to catch
  anything reaching an editor route by a path none of those exercised.
- Guard and gate tests were each confirmed to **fail against the unfixed code** before being
  committed. That check earned its keep twice: one scenario test passed against the old behaviour
  because the mocked server step carried the same name as the user's node, making the merge path
  and the old wholesale replace indistinguishable — it now gives them different names.

## Not in scope

- The association / `@Version` work in #179, #178 and #180.
- `terms-editor`'s save and validation behaviour. Its load path is in scope.

`release/2.0` is not the default branch, so `Closes #185` will not fire on merge — the issue needs
closing by hand afterwards.
