### PR TITLE
178: Result extractors for the six association commands

### DIFF
--- a/doc/178-association-result-extractors-plan.md
+++ b/doc/178-association-result-extractors-plan.md
@@ -1,0 +1,207 @@
+# 178 — Result extractors for the six association commands
+
+Plan for https://github.com/rreganjr/Requel/issues/178. Written 2026-08-18, before any code.
+
+## Summary
+
+Six association commands register through the 4-arg `CommandRegistry.register`, which passes `null`
+for the result extractor. `ApiCommandFactory.extractResult` therefore returns `null`, so
+`CommandController.publishEntityChangedIfPresent` returns early and no targeted SSE event fires, and
+`result.entity` is empty so the client cannot read the container's bumped `@Version`. Registering
+extractors that return the merged container's **detail** DTO fixes both.
+
+Three things ride along, decided 2026-08-18 rather than deferred:
+
+1. The event must **not** go back to the session that issued the command.
+2. The associated child (the goal / story / actor) needs its own event, because its editor's
+   *Referenced By* table is what goes stale.
+3. The MCP gateway path must publish the same events as the HTTP path.
+
+The client-side half — deleting `refreshVersionAfterAssociation()` and the association
+`refreshCollections()` calls — stays in #180 and lands after this.
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| The issuing session receives its own targeted event | **Exclude the originator.** |
+| Container is the project itself (`ProjectOrDomain` is a `GoalContainer`, `StoryContainer` and `ActorContainer`) | **Extractor returns `null`.** No component subscribes to `Project:<realId>`; the sidebar's channel is the fixed `Project:0` broadcast, which `publishProjectChangedIfScoped` already fires for these project-scoped commands. Nothing to target, so nothing to publish. |
+| Publish an event for the associated child too | **In scope** (§4.3). |
+| MCP gateway (`InProcessCommandGateway`) parity | **In scope** (§4.5). |
+| Detail or summary DTO | **Detail** — `toActorDetailDto` / `toStoryDetailDto` / `toUseCaseDetailDto` / `toStakeholderDetailDto`. #180 needs the collections and `version`, both of which the detail form carries. |
+
+## Verified starting state
+
+Checked against `release/2.0` on 2026-08-18. Line numbers are for orientation, not contracts.
+
+| Fact | Where |
+|---|---|
+| The six 4-arg registrations | `ProjectCommandRegistrar` 326, 337, 390, 400, 430, 440 |
+| The three that already work, for contrast | same file, 490, 508, 519 — each passes `cmd -> ProjectQueryController.toUseCaseDetailDto(...)` |
+| Targeted publish derives type from the DTO class name and id from `id()` | `CommandController.publishEntityChangedIfPresent`, 178–191 |
+| `Project:0` broadcast — fixed channel, id `0` is not an entity | `CommandController.PROJECT_BROADCAST_ID` 61, publish at 222; client joins it in `layout.ts:175` (`connect(['Project:0'])`); consumed in `sidebar-nav.ts:259` |
+| No originator exclusion anywhere in the push path | `StreamService.pushToSubscribedSessions` 161–181 iterates every subscribed session |
+| The client already has a session id, and already sends it — but only on subscribe / unsubscribe | `event-stream.service.ts` 39, 99, 118, 268; `command.service.ts` sends no such header |
+| Editors reload unconditionally on a matching envelope | `actor-editor.ts:477`, `story-editor.ts:534`, `use-case-editor.ts:745`, `stakeholder-editor.ts:574` |
+| Detail DTOs carry `version` and the association collections | `toActorDetailDto` (`ProjectQueryController` 696) returns `version`, `goals`, `referencedByUseCases`, `referencedByStories` |
+| The child's editor really does render the stale table | `goal-editor.ts:153` renders `goal().referencedBy`, fed by `goal.getReferers()` in `toGoalDetailDto` |
+| The gateway extracts a result but publishes nothing | `InProcessCommandGateway` 100–105 |
+
+## 4. Work items
+
+### 4.1 Polymorphic container → DTO helper
+
+One static helper, next to the other mappers in `ProjectQueryController` (it already owns every
+`toXxxDetailDto` and is already imported by the registrar):
+
+```java
+/** null when the container is the project itself — see the plan doc, §Decisions. */
+public static Object toContainerDetailDto(Object container)
+```
+
+Arms, most specific first, because `UseCase` and `Story` implement several of these interfaces:
+`UseCase` → `toUseCaseDetailDto`, `Story` → `toStoryDetailDto`, `Actor` → `toActorDetailDto`,
+`Stakeholder` → `toStakeholderDetailDto`, `ProjectOrDomain` → `null`. Anything else → `null` plus a
+`log.warn`, so a future container type shows up in the logs instead of silently going quiet.
+
+Order matters and is not incidental: `Stakeholder` extends `GoalContainer` only, while `UseCase`
+extends `GoalContainer`, `ActorContainer` and `StoryContainer`. Write the test to pin the order.
+
+### 4.2 Register the extractors
+
+The six registrations move from the 4-arg to the 5-arg overload, passing `null` for the file
+applicator and `cmd -> ProjectQueryController.toContainerDetailDto(((XCommand) cmd).getYContainer())`.
+`AddScenarioToUseCase` at 490 is the shape to copy.
+
+Nothing in `CommandController` changes for this item — `publishEntityChangedIfPresent` derives
+`"Actor"` from `ActorDto` on its own, and returning `null` for the project case lands on the existing
+early return.
+
+### 4.3 Publish for the associated child as well
+
+The response body must stay the container, because #180 reads `result.entity` for the container's
+version. So the child is **publish-only** and never enters the response.
+
+Add an eighth component to `CommandRegistration`, `Function<Command, Object> secondaryResultExtractor`,
+plus one new full `register` signature. Every existing overload default passes `null`, so no other
+registration changes. `ApiCommandFactory` gains `extractSecondaryResult`; `CommandController` publishes
+for both extractions, skipping the second when it resolves to the same `(type, id)` as the first.
+
+For these six, the child is on the command already — `getGoal()`, `getStory()`, `getActor()` — so the
+extractors are `cmd -> toGoalDetailDto(((AddGoalToGoalContainerCommand) cmd).getGoal())` and siblings.
+Mapping a whole detail DTO only to read its `id()` is wasteful, but it keeps one code path in
+`publishEntityChangedIfPresent` and the mapping is in-session and cheap. Revisit only if it shows up
+in a profile.
+
+### 4.4 Exclude the originating session
+
+Half the plumbing exists: the client holds a `sessionId` and already sends `X-Session-Id` on the
+subscribe and unsubscribe calls. The command POST does not send it.
+
+- `command.service.ts` — add `X-Session-Id` from `eventStreamService.sessionId()` when it is
+  non-null. Omit the header entirely when null (no stream open yet) rather than sending an empty
+  value.
+- `CommandController` — `@RequestHeader(value = "X-Session-Id", required = false) String sessionId`
+  on both `@PostMapping`s, threaded into `dispatch`.
+- `StreamEventPublisher.publishTargetUpdate` — new overload taking `String excludeSessionId`; the
+  3-arg form delegates with `null`. `StreamService.pushToSubscribedSessions` skips that id.
+- **The `Project:0` broadcast keeps no exclusion.** The acting session's own sidebar counts do need
+  to change when it adds an association, so only the *targeted* events are filtered.
+- The gateway has no HTTP session, so it excludes nothing (passes `null`).
+
+A missing or unknown header must degrade to "exclude nobody" — never to "publish nothing".
+
+### 4.5 Gateway parity
+
+`InProcessCommandGateway` (100–105) executes and extracts but never publishes. Add the same two
+publishes — targeted primary, targeted secondary, and the `Project:0` broadcast — so an association
+made over MCP refreshes open browser sessions. The two call sites now share enough logic to be worth
+lifting into one collaborator that both the controller and the gateway hold; that refactor is
+preferable to a second copy of the reflection block in `publishEntityChangedIfPresent`.
+
+Note #188 edits the catch arms of this same `execute` method. Whichever lands second rebases; the
+changes do not overlap in substance (publishing after the try, classification inside the catches).
+
+## 5. Test plan
+
+Unit, `ProjectQueryControllerTest` (or a new `ContainerDtoMappingTest`):
+
+- One case per arm of §4.1, including `UseCase` resolving to `toUseCaseDetailDto` rather than to a
+  `StoryContainer`/`ActorContainer` arm, and `ProjectOrDomain` → `null`.
+
+Unit, `CommandControllerTest` (already mocks `streamEventPublisher` — see its existing
+`publishTargetUpdate` verifications):
+
+- Per command, the extractor returns the expected DTO type and `result.entity` carries `version`.
+- A targeted event is published for the container with the expected `(type, id)`.
+- A targeted event is published for the child.
+- With `X-Session-Id` present, that session is excluded and the others still receive the event.
+- With the header absent, nobody is excluded.
+- Container is the project → no targeted event, no throw, `Project:0` still published.
+
+Unit, `StreamServiceTest`: `pushToSubscribedSessions` with an excluded id skips exactly that session.
+
+Unit, Angular: `command.service.spec.ts` — header present when `sessionId()` is set, absent when null.
+
+e2e, extending `sse-refresh.e2e.ts`: two sessions on the same actor; session A adds a goal; session B's
+Goals table updates without a reload; session A issues **no** second detail GET. The negative
+assertion is the point of §4.4 and should fail if the exclusion regresses.
+
+Whole-suite gate per CLAUDE.md step 3 before any commit.
+
+## 6. Acceptance criteria
+
+- All six commands return the merged container as its detail DTO in `result.entity`, carrying the
+  bumped `version`.
+- A session with the container open, other than the issuing one, receives exactly one targeted
+  refresh for that container per association.
+- The issuing session receives no targeted event for the container, and does not reload its form.
+- Sidebar counts still refresh in every session including the issuing one — the `Project:0`
+  broadcast is unchanged.
+- A session with the associated goal, story or actor open receives a targeted refresh, so its
+  *Referenced By* table no longer goes stale.
+- An association issued through the MCP gateway publishes the same events as the HTTP path.
+- When the container is the project itself, no targeted event fires and nothing throws.
+- A missing `X-Session-Id` excludes nobody rather than suppressing the event.
+
+## 7. Not in scope
+
+- Deleting `refreshVersionAfterAssociation()` and the association `refreshCollections()` calls —
+  that is #180, and it lands after this.
+- Editor form-reset guarding on SSE reload — #185 / #186. §4.4 reduces how often that guard is
+  reached; it does not replace it.
+- `AssignTag` (mutates `Tag`, no parent merge) and the four commands unreachable from the client per
+  `doc/173-create-flow-wizards-plan.md` §3.
+- Multi-instance fan-out. `StreamEventPublisherImpl` is deliberately local-only; its own comment
+  names Redis pub/sub as the eventual replacement.
+- How the gateway classifies a bad id (`EXECUTION_ERROR` vs `INVALID_INPUT`) — #188. §4.5 only adds
+  publishing to that method; it does not touch the catch arms.
+- The two container-lookup defects in §8 — both are pre-existing, neither blocks this work. Filed
+  as #187 and #189.
+
+## 8. Defects found while scoping, each wanting its own ticket
+
+**8.1 `findStoryContainerById` casts a `Stakeholder` to `StoryContainer`. Filed as #187.**
+`ProjectCommandRegistrar` 780–782 loops the project's stakeholders and casts a match. But
+`Stakeholder extends ProjectOrDomainEntity, GoalContainer` — not `StoryContainer` — and
+`AbstractStakeholder implements Stakeholder` alone, holding `Set<Goal> goals` and no stories. A
+stakeholder holds goals; a story's actors are a different relationship, on `Story`, which does
+extend `ActorContainer`. So that branch can only ever throw `ClassCastException`, and it is
+reachable: ids are per-table auto-increment and the stakeholder loop runs *before* the use-case
+loop, so a stakeholder sharing an id with the intended use-case wins the lookup. Delete the branch.
+
+**8.2 Story / actor container lookups have no `containerType`, so ids collide. Filed as #189.**
+`AddGoalToGoalContainerInput` carries `containerType` and `findGoalContainerById` (734) switches on
+it — its comment names the reason: "avoid ID collisions between entity types (all tables use
+per-table auto-increment)". `AddStoryToStoryContainerInput` and `AddActorToActorContainerInput` carry
+no such field, and `findActorContainerById` (789) scans use-cases before stories. Adding an actor to
+Story #5 therefore resolves to UseCase #5 when one exists — wrong entity, silently. Add
+`containerType` to both inputs and switch on it, matching the goal path.
+
+Both matter to this ticket only in that an extractor is only as correct as the container handed to
+it. Fixing them here would mean touching four input DTO records and every client call site, which is
+a different change with a different blast radius.
+
+Sequencing: #187 (delete the dead branch) → #189 (rewrite the helpers around `containerType`) →
+this ticket, which only reads whatever container those helpers return. None of the three blocks the
+others, but landing them in that order avoids rewriting the same helper twice.

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/service/command/CommandControllerTest.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/service/command/CommandControllerTest.java
@@ -47,6 +47,7 @@ import java.nio.charset.StandardCharsets;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -313,8 +314,66 @@ class CommandControllerTest {
                         .content("{}"))
                 .andExpect(status().isOk());
 
-        // Targeted event published: controller strips "Dto" suffix (GoalDto → "Goal")
-        verify(streamEventPublisher).publishTargetUpdate(eq("Goal"), eq(99L), any());
+        // Targeted event published via the exclusion-aware overload; no X-Session-Id header on this
+        // request, so excludeSessionId is null (exclude nobody). "GoalDto" is stripped to "Goal".
+        verify(streamEventPublisher).publishTargetUpdate(eq("Goal"), eq(99L), any(), isNull());
+    }
+
+    @Test
+    void targetedSseEventExcludesOriginatingSession() throws Exception {
+        record GoalDto(Long id, String name) {}
+        stubCommand("EditGoal", new GoalDto(99L, "SSE Goal"));
+
+        mockMvc.perform(post("/api/commands/EditGoal")
+                        .header("X-Session-Id", "sess-abc")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isOk());
+
+        verify(streamEventPublisher).publishTargetUpdate(eq("Goal"), eq(99L), any(), eq("sess-abc"));
+    }
+
+    @Test
+    void associationPublishesTargetedEventsForContainerAndChild() throws Exception {
+        record ActorDto(Long id, String name) {}
+        record GoalDto(Long id, String name) {}
+        Command cmd = mock(Command.class);
+        doReturn(Void.class).when(apiCommandFactory).getInputType("AddGoalToGoalContainer");
+        when(apiCommandFactory.newCommand(eq("AddGoalToGoalContainer"), any(), any())).thenReturn(cmd);
+        when(commandHandler.execute(cmd)).thenReturn(cmd);
+        when(apiCommandFactory.extractResult(eq("AddGoalToGoalContainer"), any()))
+                .thenReturn(new ActorDto(7L, "Container Actor"));
+        when(apiCommandFactory.extractSecondaryResult(eq("AddGoalToGoalContainer"), any()))
+                .thenReturn(new GoalDto(3L, "Child Goal"));
+
+        mockMvc.perform(post("/api/commands/AddGoalToGoalContainer")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isOk());
+
+        verify(streamEventPublisher).publishTargetUpdate(eq("Actor"), eq(7L), any(), isNull());
+        verify(streamEventPublisher).publishTargetUpdate(eq("Goal"), eq(3L), any(), isNull());
+    }
+
+    @Test
+    void nullResultPublishesNoTargetedEventButStillBroadcasts() throws Exception {
+        Project project = mock(Project.class);
+        when(project.getId()).thenReturn(55L);
+        Command cmd = mock(Command.class, withSettings().extraInterfaces(ProjectScopedCommand.class));
+        when(((ProjectScopedCommand) cmd).getProject()).thenReturn(project);
+        doReturn(Void.class).when(apiCommandFactory).getInputType("AddGoalToGoalContainer");
+        when(apiCommandFactory.newCommand(eq("AddGoalToGoalContainer"), any(), any())).thenReturn(cmd);
+        when(commandHandler.execute(cmd)).thenReturn(cmd);
+        when(apiCommandFactory.extractResult(eq("AddGoalToGoalContainer"), any())).thenReturn(null);
+        when(apiCommandFactory.extractSecondaryResult(eq("AddGoalToGoalContainer"), any())).thenReturn(null);
+
+        mockMvc.perform(post("/api/commands/AddGoalToGoalContainer")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isOk());
+
+        verify(streamEventPublisher).publishTargetUpdate(eq("Project"), eq(0L), any());
+        verify(streamEventPublisher, never()).publishTargetUpdate(any(), any(), any(), any());
     }
 
     @Test
@@ -323,7 +382,7 @@ class CommandControllerTest {
         GoalDto dto = new GoalDto(99L, "SSE Goal");
         Command cmd = stubCommand("EditGoal", dto);
         doThrow(new IllegalStateException("stream closed"))
-                .when(streamEventPublisher).publishTargetUpdate(eq("Goal"), eq(99L), any());
+                .when(streamEventPublisher).publishTargetUpdate(eq("Goal"), eq(99L), any(), any());
 
         mockMvc.perform(post("/api/commands/EditGoal")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/service/query/ProjectQueryControllerTest.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/service/query/ProjectQueryControllerTest.java
@@ -33,6 +33,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -263,6 +266,76 @@ class ProjectQueryControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(7))
                 .andExpect(jsonPath("$.name").value("Bob"));
+    }
+
+    // -------------------------------------------------------------------------
+    // toContainerDetailDto — polymorphic container → detail DTO (issue #178 §4.1)
+    // Entity interfaces are mutually exclusive, so arm order can't misclassify; these pin the
+    // mapping (and the project → null decision) so a future refactor can't silently change it.
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toContainerDetailDtoMapsUseCaseToUseCaseDetail() {
+        UseCase useCase = stubUseCase(40L, "Delta use case");
+        when(useCase.getGoals()).thenReturn(Collections.emptySet());
+        when(useCase.getActors()).thenReturn(Collections.emptySet());
+        when(useCase.getStories()).thenReturn(Collections.emptySet());
+        when(useCase.getAdditionalScenarios()).thenReturn(Collections.emptySet());
+
+        Object dto = ProjectQueryController.toContainerDetailDto(useCase);
+
+        assertInstanceOf(com.rreganjr.requel.service.api.dto.UseCaseDto.class, dto);
+        assertEquals(40L, ((com.rreganjr.requel.service.api.dto.UseCaseDto) dto).id().longValue());
+    }
+
+    @Test
+    void toContainerDetailDtoMapsStoryToStoryDetail() {
+        Story story = stubStory(41L, "A story");
+        when(story.getStoryType()).thenReturn(StoryType.Success);
+        when(story.getGoals()).thenReturn(Collections.emptySet());
+        when(story.getActors()).thenReturn(Collections.emptySet());
+
+        Object dto = ProjectQueryController.toContainerDetailDto(story);
+
+        assertInstanceOf(com.rreganjr.requel.service.api.dto.StoryDto.class, dto);
+        assertEquals(41L, ((com.rreganjr.requel.service.api.dto.StoryDto) dto).id().longValue());
+    }
+
+    @Test
+    void toContainerDetailDtoMapsActorToActorDetail() {
+        Actor actor = stubActor(42L, "Bob");
+        when(actor.getGoals()).thenReturn(Collections.emptySet());
+        when(actor.getReferers()).thenReturn(Collections.emptySet());
+
+        Object dto = ProjectQueryController.toContainerDetailDto(actor);
+
+        assertInstanceOf(com.rreganjr.requel.service.api.dto.ActorDto.class, dto);
+        assertEquals(42L, ((com.rreganjr.requel.service.api.dto.ActorDto) dto).id().longValue());
+    }
+
+    @Test
+    void toContainerDetailDtoMapsStakeholderToStakeholderDetail() {
+        UserStakeholder stakeholder = stubUserStakeholder(43L, "Alice");
+        when(stakeholder.getGoals()).thenReturn(Collections.emptySet());
+
+        Object dto = ProjectQueryController.toContainerDetailDto(stakeholder);
+
+        assertInstanceOf(com.rreganjr.requel.service.api.dto.StakeholderDto.class, dto);
+        assertEquals(43L, ((com.rreganjr.requel.service.api.dto.StakeholderDto) dto).id().longValue());
+    }
+
+    @Test
+    void toContainerDetailDtoReturnsNullForProjectContainer() {
+        // The project itself is a GoalContainer/StoryContainer/ActorContainer, but no component
+        // subscribes to a targeted Project:<id> channel — the sidebar uses the Project:0 broadcast.
+        assertNull(ProjectQueryController.toContainerDetailDto(
+                mock(com.rreganjr.requel.project.ProjectOrDomain.class)));
+    }
+
+    @Test
+    void toContainerDetailDtoReturnsNullForUnknownAndNullContainer() {
+        assertNull(ProjectQueryController.toContainerDetailDto(new Object()));
+        assertNull(ProjectQueryController.toContainerDetailDto(null));
     }
 
     // -------------------------------------------------------------------------

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/service/stream/StreamServiceTest.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/service/stream/StreamServiceTest.java
@@ -315,4 +315,37 @@ class StreamServiceTest {
         assertThatNoException().isThrownBy(
                 () -> streamService.pushToSubscribedSessions("Project", 0L, Map.of("type", "refresh")));
     }
+
+    // -------------------------------------------------------------------------
+    // pushToSubscribedSessions — originating-session exclusion (issue #178 §4.4)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void pushToSubscribedSessionsSkipsExcludedSession() throws Exception {
+        streamService.createStream("originator", "alice", 0L, List.of("Goal:1"));
+        streamService.createStream("other",      "alice", 0L, List.of("Goal:1"));
+
+        SseEmitter originator = swapInMockEmitter("originator");
+        SseEmitter other      = swapInMockEmitter("other");
+
+        streamService.pushToSubscribedSessions("Goal", 1L, Map.of("type", "refresh"), "originator");
+
+        // The originating session is skipped; every other subscriber still receives the event.
+        verify(originator, never()).send(any(SseEmitter.SseEventBuilder.class));
+        verify(other).send(any(SseEmitter.SseEventBuilder.class));
+    }
+
+    @Test
+    void pushToSubscribedSessionsWithNullExclusionDeliversToAll() throws Exception {
+        streamService.createStream("s1", "alice", 0L, List.of("Goal:1"));
+        streamService.createStream("s2", "alice", 0L, List.of("Goal:1"));
+
+        SseEmitter e1 = swapInMockEmitter("s1");
+        SseEmitter e2 = swapInMockEmitter("s2");
+
+        streamService.pushToSubscribedSessions("Goal", 1L, Map.of("type", "refresh"), null);
+
+        verify(e1).send(any(SseEmitter.SseEventBuilder.class));
+        verify(e2).send(any(SseEmitter.SseEventBuilder.class));
+    }
 }

--- a/modules/requel-app/src/test/java/com/rreganjr/requel/tagging/TagApiIT.java
+++ b/modules/requel-app/src/test/java/com/rreganjr/requel/tagging/TagApiIT.java
@@ -82,7 +82,7 @@ public class TagApiIT {
 	}
 
 	private void dispatchOk(String commandType, Map<String, Object> input) {
-		ResponseEntity<?> response = commandController.dispatchJson(commandType, input);
+		ResponseEntity<?> response = commandController.dispatchJson(commandType, null, input);
 		assertTrue(response.getStatusCode().is2xxSuccessful(),
 				commandType + " should dispatch successfully but was " + response.getStatusCode());
 	}

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/CommandRegistration.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/CommandRegistration.java
@@ -52,6 +52,9 @@ import java.util.function.Supplier;
  * @param inputApplicator  maps the deserialized input DTO onto the command; null if no input mapping
  * @param fileApplicator   maps a multipart file onto the command; null if the command doesn't accept files
  * @param resultExtractor  extracts and converts the command result to an API DTO; null if no result
+ * @param secondaryResultExtractor extracts a second entity to publish a targeted SSE event for
+ *                         (e.g. the associated child of an association command); null if none. This
+ *                         entity is publish-only — it never enters the command response body.
  * @param commandBuilder   alternative to factoryMethod+inputApplicator: builds a fully-configured
  *                         command from the raw input object; null for standard commands
  */
@@ -62,6 +65,7 @@ public record CommandRegistration<T>(
         BiConsumer<Command, T> inputApplicator,
         BiConsumer<Command, Object> fileApplicator,
         Function<Command, Object> resultExtractor,
+        Function<Command, Object> secondaryResultExtractor,
         Function<Object, Command> commandBuilder
 ) {
 }

--- a/modules/service-api/src/main/java/com/rreganjr/requel/service/api/CommandRegistry.java
+++ b/modules/service-api/src/main/java/com/rreganjr/requel/service/api/CommandRegistry.java
@@ -35,17 +35,35 @@ import java.util.function.Supplier;
 public interface CommandRegistry {
 
     /**
-     * Full registration: all fields including optional commandBuilder.
-     * When commandBuilder is non-null it is used in place of factoryMethod + inputApplicator —
-     * it receives the raw deserialized input and returns a fully-configured command.
-     * Use this for polymorphic commands where the correct subtype depends on the input.
+     * Full registration: all fields including the optional secondary result extractor and
+     * commandBuilder. When commandBuilder is non-null it is used in place of factoryMethod +
+     * inputApplicator — it receives the raw deserialized input and returns a fully-configured
+     * command. When secondaryResultExtractor is non-null the controller/gateway also publishes a
+     * targeted SSE event for that second entity (e.g. an association command's child); that second
+     * entity is publish-only and never enters the response body.
      */
     <T> void register(String commandType, Class<T> inputClass,
                       Supplier<Command> factoryMethod,
                       BiConsumer<Command, T> inputApplicator,
                       BiConsumer<Command, Object> fileApplicator,
                       Function<Command, Object> resultExtractor,
+                      Function<Command, Object> secondaryResultExtractor,
                       Function<Object, Command> commandBuilder);
+
+    /**
+     * Registration with a commandBuilder but no secondary result extractor. Delegates to the full
+     * signature with a null secondaryResultExtractor. This is the signature every other overload
+     * below funnels through, so they all get a null secondary extractor for free.
+     */
+    default <T> void register(String commandType, Class<T> inputClass,
+                              Supplier<Command> factoryMethod,
+                              BiConsumer<Command, T> inputApplicator,
+                              BiConsumer<Command, Object> fileApplicator,
+                              Function<Command, Object> resultExtractor,
+                              Function<Object, Command> commandBuilder) {
+        register(commandType, inputClass, factoryMethod, inputApplicator, fileApplicator,
+                resultExtractor, null, commandBuilder);
+    }
 
     /**
      * Standard registration: input class, factory, input applicator, file applicator, result extractor.

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/command/ApiCommandFactory.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/command/ApiCommandFactory.java
@@ -123,4 +123,18 @@ public class ApiCommandFactory {
         }
         return null;
     }
+
+    /**
+     * Extract the secondary result DTO from a command after execution. This entity is published as
+     * a targeted SSE event (e.g. an association command's child) but never returned in the response
+     * body. Returns null if no secondary extractor is registered.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public Object extractSecondaryResult(String commandType, Command command) {
+        CommandRegistration reg = registry.lookup(commandType);
+        if (reg.secondaryResultExtractor() != null) {
+            return reg.secondaryResultExtractor().apply(command);
+        }
+        return null;
+    }
 }

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/command/CommandController.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/command/CommandController.java
@@ -25,26 +25,19 @@ import com.rreganjr.platform.command.AuthorizationException;
 import com.rreganjr.platform.exception.EntityException;
 import com.rreganjr.command.Command;
 import com.rreganjr.command.CommandHandler;
-import com.rreganjr.requel.project.ProjectScopedCommand;
-import com.rreganjr.requel.project.command.EditProjectOrDomainEntityCommand;
 import com.rreganjr.requel.service.api.CommandResult;
 import com.rreganjr.requel.service.api.dto.ErrorResponse;
-import com.rreganjr.requel.service.stream.StreamEventPublisher;
 import com.rreganjr.repository.jpa.BeanValidationException;
 import com.rreganjr.validator.EntityValidationException;
 import jakarta.persistence.OptimisticLockException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.ReflectionUtils;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.lang.reflect.Method;
 import java.util.Map;
 
 /**
@@ -57,22 +50,19 @@ public class CommandController {
 
     private static final Logger log = LoggerFactory.getLogger(CommandController.class);
 
-    /** Sentinel project ID used as a broadcast channel for "any project changed". */
-    private static final long PROJECT_BROADCAST_ID = 0L;
-
     private final ApiCommandFactory apiCommandFactory;
     private final CommandHandler commandHandler;
     private final ObjectMapper objectMapper;
-    private final StreamEventPublisher streamEventPublisher;
+    private final CommandEventPublisher eventPublisher;
 
     public CommandController(ApiCommandFactory apiCommandFactory,
                              CommandHandler commandHandler,
                              ObjectMapper objectMapper,
-                             StreamEventPublisher streamEventPublisher) {
+                             CommandEventPublisher eventPublisher) {
         this.apiCommandFactory = apiCommandFactory;
         this.commandHandler = commandHandler;
         this.objectMapper = objectMapper;
-        this.streamEventPublisher = streamEventPublisher;
+        this.eventPublisher = eventPublisher;
     }
 
     /**
@@ -81,8 +71,9 @@ public class CommandController {
     @PostMapping(value = "/{commandType}", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> dispatchJson(
             @PathVariable String commandType,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId,
             @RequestBody(required = false) Map<String, Object> rawInput) {
-        return dispatch(commandType, rawInput, null);
+        return dispatch(commandType, rawInput, null, sessionId);
     }
 
     /**
@@ -92,13 +83,14 @@ public class CommandController {
     @PostMapping(value = "/{commandType}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<?> dispatchMultipart(
             @PathVariable String commandType,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId,
             @RequestPart(value = "input", required = false) Map<String, Object> rawInput,
             @RequestPart(value = "file", required = false) MultipartFile file) {
-        return dispatch(commandType, rawInput, file);
+        return dispatch(commandType, rawInput, file, sessionId);
     }
 
     private ResponseEntity<?> dispatch(String commandType, Map<String, Object> rawInput,
-                                       MultipartFile file) {
+                                       MultipartFile file, String sessionId) {
         try {
             // Deserialize raw JSON to the command's input DTO type (null for commands with no input mapping yet)
             Class<?> inputType = apiCommandFactory.getInputType(commandType);
@@ -112,14 +104,15 @@ public class CommandController {
             // Execute through the handler chain
             commandHandler.execute(command);
 
-            // Notify subscribers of project-level changes so the sidebar refreshes counts
-            publishProjectChangedIfScoped(command);
-
-            // Extract result DTO via the registration's resultExtractor (null if not registered)
+            // Extract result DTOs via the registration's extractors (null if not registered)
             Object result = apiCommandFactory.extractResult(commandType, command);
+            Object secondaryResult = apiCommandFactory.extractSecondaryResult(commandType, command);
 
-            // Notify any session subscribed to this specific entity (e.g. an open editor)
-            publishEntityChangedIfPresent(result);
+            // Publish SSE events: the Project:0 broadcast (all sidebar sessions) plus targeted
+            // events for the primary and secondary entities, excluding the originating session from
+            // the targeted events so it does not reload the form it just edited. A missing header
+            // (sessionId == null) excludes nobody.
+            eventPublisher.publish(command, result, secondaryResult, sessionId);
 
             return ResponseEntity.ok(CommandResult.success(result, commandType));
 
@@ -166,63 +159,6 @@ public class CommandController {
             log.error("Command execution failed: {} - {}", commandType, e.getMessage(), e);
             return ResponseEntity.internalServerError()
                     .body(ErrorResponse.of("INTERNAL_ERROR", "An unexpected error occurred. Please try again or contact support."));
-        }
-    }
-
-    /**
-     * If the result DTO has an {@code id()} accessor (all entity record DTOs do),
-     * publish a targeted SSE event so any editor session subscribed to that entity
-     * gets a live refresh signal. The entity type is derived from the DTO class name
-     * by stripping the "Dto" suffix (e.g. {@code GoalDto} → {@code "Goal"}).
-     */
-    private void publishEntityChangedIfPresent(Object result) {
-        if (result == null) return;
-        try {
-            Method idMethod = result.getClass().getMethod("id");
-            Object idValue = idMethod.invoke(result);
-            if (!(idValue instanceof Long entityId)) return;
-            String simpleName = result.getClass().getSimpleName();
-            String entityType = simpleName.endsWith("Dto")
-                    ? simpleName.substring(0, simpleName.length() - 3)
-                    : simpleName;
-            streamEventPublisher.publishTargetUpdate(entityType, entityId, Map.of("type", "refresh"));
-        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-            // Not an entity DTO with an id() accessor — skip silently
-        } catch (Exception e) {
-            log.warn("Failed to publish entity-changed SSE event: {}", e.getMessage());
-        }
-    }
-
-    /**
-     * If the command is project-scoped, publish a broadcast Project event so
-     * all sidebar sessions subscribed to {@code Project:0} reload their counts.
-     * Non-project commands (e.g. user management) are silently skipped.
-     */
-    private void publishProjectChangedIfScoped(Command command) {
-        try {
-            Object entity = null;
-            String discriminant = "neither";
-            if (command instanceof ProjectScopedCommand psc) {
-                entity = psc.getProject();
-                discriminant = "ProjectScopedCommand";
-            } else if (command instanceof EditProjectOrDomainEntityCommand podCmd) {
-                entity = podCmd.getProjectOrDomain();
-                discriminant = "EditProjectOrDomainEntityCommand";
-            }
-            // Log at DEBUG so we can verify each command type is broadcasting
-            // by enabling DEBUG on this class without flooding production logs.
-            // See StreamService for the broadcast-side fan-out logging.
-            if (log.isDebugEnabled()) {
-                log.debug("publishProjectChangedIfScoped command={} discriminant={} entity={} → {}",
-                        command.getClass().getSimpleName(), discriminant,
-                        entity != null ? entity.getClass().getSimpleName() : "null",
-                        entity != null ? "BROADCAST" : "skip");
-            }
-            if (entity != null) {
-                streamEventPublisher.publishTargetUpdate("Project", PROJECT_BROADCAST_ID, Map.of("type", "refresh"));
-            }
-        } catch (Exception e) {
-            log.warn("Failed to publish project-changed SSE event: {}", e.getMessage(), e);
         }
     }
 }

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/command/CommandEventPublisher.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/command/CommandEventPublisher.java
@@ -1,0 +1,136 @@
+/*
+ * This file is part of Requel - the Collaborative Requirements
+ * Elicitation System.
+ *
+ * Copyright 2026 Ron Regan Jr. All Rights Reserved.
+ *
+ * Requel is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Requel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Requel. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.rreganjr.requel.service.command;
+
+import com.rreganjr.command.Command;
+import com.rreganjr.requel.project.ProjectScopedCommand;
+import com.rreganjr.requel.project.command.EditProjectOrDomainEntityCommand;
+import com.rreganjr.requel.service.stream.StreamEventPublisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+/**
+ * Publishes the SSE change events for an executed command. Shared by the HTTP {@link CommandController}
+ * and the {@link com.rreganjr.requel.service.gateway.InProcessCommandGateway} so an association made
+ * over either path refreshes open browser sessions identically (issue #178), instead of each path
+ * carrying its own copy of the reflection-based targeting block.
+ */
+@Component
+public class CommandEventPublisher {
+
+    private static final Logger log = LoggerFactory.getLogger(CommandEventPublisher.class);
+
+    /** Sentinel project ID used as a broadcast channel for "any project changed". */
+    private static final long PROJECT_BROADCAST_ID = 0L;
+
+    private final StreamEventPublisher streamEventPublisher;
+
+    public CommandEventPublisher(StreamEventPublisher streamEventPublisher) {
+        this.streamEventPublisher = streamEventPublisher;
+    }
+
+    /**
+     * Publish every SSE event for an executed command: the Project:0 broadcast (all sidebar
+     * sessions, never excluded), a targeted event for the primary result entity, and a targeted
+     * event for the secondary entity (skipped when it resolves to the same type+id as the primary).
+     * Targeted events skip {@code excludeSessionId} — the originating HTTP session — so it does not
+     * reload the form it just edited; pass {@code null} to exclude nobody (the in-process gateway
+     * has no HTTP session).
+     */
+    public void publish(Command command, Object primaryResult, Object secondaryResult,
+                        String excludeSessionId) {
+        publishProjectChangedIfScoped(command);
+        TargetRef primary = publishTargeted(primaryResult, excludeSessionId, null);
+        publishTargeted(secondaryResult, excludeSessionId, primary);
+    }
+
+    private record TargetRef(String type, long id) {}
+
+    /**
+     * If the DTO has an {@code id()} accessor (all entity record DTOs do), publish a targeted SSE
+     * event so any editor subscribed to that entity refreshes. The entity type is the DTO simple
+     * name with a trailing "Dto" stripped ({@code GoalDto} -> {@code "Goal"}). Returns the
+     * (type, id) that was published, or {@code null} when the argument is not a targetable DTO.
+     * Skips publishing when the resolved (type, id) equals {@code skipIfSameAs} (the primary
+     * result), so an association whose child extractor happens to resolve to the same entity never
+     * fires two identical events.
+     */
+    private TargetRef publishTargeted(Object result, String excludeSessionId, TargetRef skipIfSameAs) {
+        if (result == null) return null;
+        try {
+            Method idMethod = result.getClass().getMethod("id");
+            Object idValue = idMethod.invoke(result);
+            if (!(idValue instanceof Long entityId)) return null;
+            String simpleName = result.getClass().getSimpleName();
+            String entityType = simpleName.endsWith("Dto")
+                    ? simpleName.substring(0, simpleName.length() - 3)
+                    : simpleName;
+            TargetRef self = new TargetRef(entityType, entityId);
+            if (self.equals(skipIfSameAs)) return self;
+            streamEventPublisher.publishTargetUpdate(entityType, entityId,
+                    Map.of("type", "refresh"), excludeSessionId);
+            return self;
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            // Not an entity DTO with an id() accessor — skip silently
+            return null;
+        } catch (Exception e) {
+            log.warn("Failed to publish entity-changed SSE event: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * If the command is project-scoped, publish a broadcast Project event so all sidebar sessions
+     * subscribed to {@code Project:0} reload their counts. This broadcast is never filtered by
+     * originating session — the acting session's own counts change too. Non-project commands
+     * (e.g. user management) are silently skipped.
+     */
+    private void publishProjectChangedIfScoped(Command command) {
+        try {
+            Object entity = null;
+            String discriminant = "neither";
+            if (command instanceof ProjectScopedCommand psc) {
+                entity = psc.getProject();
+                discriminant = "ProjectScopedCommand";
+            } else if (command instanceof EditProjectOrDomainEntityCommand podCmd) {
+                entity = podCmd.getProjectOrDomain();
+                discriminant = "EditProjectOrDomainEntityCommand";
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("publishProjectChangedIfScoped command={} discriminant={} entity={} -> {}",
+                        command.getClass().getSimpleName(), discriminant,
+                        entity != null ? entity.getClass().getSimpleName() : "null",
+                        entity != null ? "BROADCAST" : "skip");
+            }
+            if (entity != null) {
+                streamEventPublisher.publishTargetUpdate("Project", PROJECT_BROADCAST_ID,
+                        Map.of("type", "refresh"));
+            }
+        } catch (Exception e) {
+            log.warn("Failed to publish project-changed SSE event: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/command/CommandRegistryImpl.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/command/CommandRegistryImpl.java
@@ -51,18 +51,20 @@ public class CommandRegistryImpl implements CommandRegistry {
                              BiConsumer<Command, T> inputApplicator,
                              BiConsumer<Command, Object> fileApplicator,
                              Function<Command, Object> resultExtractor,
+                             Function<Command, Object> secondaryResultExtractor,
                              Function<Object, Command> commandBuilder) {
         var registration = new CommandRegistration<>(commandType, inputClass, factoryMethod,
-                inputApplicator, fileApplicator, resultExtractor, commandBuilder);
+                inputApplicator, fileApplicator, resultExtractor, secondaryResultExtractor, commandBuilder);
         var existing = registrations.putIfAbsent(commandType, registration);
         if (existing != null) {
             throw new IllegalStateException(
                     "Duplicate command type registration: " + commandType);
         }
-        log.debug("Registered command type: {} (input: {}, file: {}, result: {}, builder: {})", commandType,
+        log.debug("Registered command type: {} (input: {}, file: {}, result: {}, secondary: {}, builder: {})", commandType,
                 inputClass == Void.class ? "none" : inputClass.getSimpleName(),
                 fileApplicator != null ? "yes" : "no",
                 resultExtractor != null ? "yes" : "no",
+                secondaryResultExtractor != null ? "yes" : "no",
                 commandBuilder != null ? "yes" : "no");
     }
 

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/command/ProjectCommandRegistrar.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/command/ProjectCommandRegistrar.java
@@ -333,7 +333,13 @@ public class ProjectCommandRegistrar {
                     GoalContainer container = findGoalContainerById(project, i.goalContainerId(), i.containerType());
                     c.setGoalContainer(container);
                     c.setGoal(findGoalById(project, i.goalId()));
-                });
+                },
+                null,
+                cmd -> ProjectQueryController.toContainerDetailDto(
+                        ((AddGoalToGoalContainerCommand) cmd).getGoalContainer()),
+                cmd -> ProjectQueryController.toGoalDetailDto(
+                        ((AddGoalToGoalContainerCommand) cmd).getGoal()),
+                null);
 
         registry.register("RemoveGoalFromGoalContainer", RemoveGoalFromGoalContainerInput.class,
                 factory::newRemoveGoalFromGoalContainerCommand,
@@ -344,7 +350,13 @@ public class ProjectCommandRegistrar {
                     GoalContainer container = findGoalContainerById(project, i.goalContainerId(), i.containerType());
                     c.setGoalContainer(container);
                     c.setGoal(findGoalById(project, i.goalId()));
-                });
+                },
+                null,
+                cmd -> ProjectQueryController.toContainerDetailDto(
+                        ((RemoveGoalFromGoalContainerCommand) cmd).getGoalContainer()),
+                cmd -> ProjectQueryController.toGoalDetailDto(
+                        ((RemoveGoalFromGoalContainerCommand) cmd).getGoal()),
+                null);
 
         // Stories
         registry.register("EditStory", EditStoryInput.class,
@@ -396,7 +408,13 @@ public class ProjectCommandRegistrar {
                     Project project = projectRepository.findProjectByName(i.projectName());
                     c.setStoryContainer(findStoryContainerById(project, i.storyContainerId(), i.containerType()));
                     c.setStory(findStoryById(project, i.storyId()));
-                });
+                },
+                null,
+                cmd -> ProjectQueryController.toContainerDetailDto(
+                        ((AddStoryToStoryContainerCommand) cmd).getStoryContainer()),
+                cmd -> ProjectQueryController.toStoryDetailDto(
+                        ((AddStoryToStoryContainerCommand) cmd).getStory()),
+                null);
 
         registry.register("RemoveStoryFromStoryContainer", RemoveStoryFromStoryContainerInput.class,
                 factory::newRemoveStoryFromStoryContainerCommand,
@@ -406,7 +424,13 @@ public class ProjectCommandRegistrar {
                     Project project = projectRepository.findProjectByName(i.projectName());
                     c.setStoryContainer(findStoryContainerById(project, i.storyContainerId(), i.containerType()));
                     c.setStory(findStoryById(project, i.storyId()));
-                });
+                },
+                null,
+                cmd -> ProjectQueryController.toContainerDetailDto(
+                        ((RemoveStoryFromStoryContainerCommand) cmd).getStoryContainer()),
+                cmd -> ProjectQueryController.toStoryDetailDto(
+                        ((RemoveStoryFromStoryContainerCommand) cmd).getStory()),
+                null);
 
         // Actors
         registry.register("EditActor", EditActorInput.class,
@@ -436,7 +460,13 @@ public class ProjectCommandRegistrar {
                     Project project = projectRepository.findProjectByName(i.projectName());
                     c.setActorContainer(findActorContainerById(project, i.actorContainerId(), i.containerType()));
                     c.setActor(findActorById(project, i.actorId()));
-                });
+                },
+                null,
+                cmd -> ProjectQueryController.toContainerDetailDto(
+                        ((AddActorToActorContainerCommand) cmd).getActorContainer()),
+                cmd -> ProjectQueryController.toActorDetailDto(
+                        ((AddActorToActorContainerCommand) cmd).getActor()),
+                null);
 
         registry.register("RemoveActorFromActorContainer", RemoveActorFromActorContainerInput.class,
                 factory::newRemoveActorFromActorContainerCommand,
@@ -446,7 +476,13 @@ public class ProjectCommandRegistrar {
                     Project project = projectRepository.findProjectByName(i.projectName());
                     c.setActorContainer(findActorContainerById(project, i.actorContainerId(), i.containerType()));
                     c.setActor(findActorById(project, i.actorId()));
-                });
+                },
+                null,
+                cmd -> ProjectQueryController.toContainerDetailDto(
+                        ((RemoveActorFromActorContainerCommand) cmd).getActorContainer()),
+                cmd -> ProjectQueryController.toActorDetailDto(
+                        ((RemoveActorFromActorContainerCommand) cmd).getActor()),
+                null);
         registry.register("CopyActor", CopyActorInput.class,
                 factory::newCopyActorCommand,
                 (cmd, input) -> {

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/gateway/InProcessCommandGateway.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/gateway/InProcessCommandGateway.java
@@ -32,6 +32,7 @@ import com.rreganjr.requel.gateway.GatewayResult;
 import com.rreganjr.requel.gateway.PolicyDecision;
 import com.rreganjr.requel.service.api.CommandRegistry;
 import com.rreganjr.requel.service.command.ApiCommandFactory;
+import com.rreganjr.requel.service.command.CommandEventPublisher;
 import com.rreganjr.validator.EntityValidationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,9 +53,10 @@ import org.springframework.stereotype.Service;
  * for establishing that security context (HTTP filter for remote clients; an explicit context for
  * stdio/tests — wired in Slice 5).
  * <p>
- * TODO(Slice 4): publish the same SSE change events the controller emits
- * ({@code publishProjectChangedIfScoped} / {@code publishEntityChangedIfPresent}) when the MCP
- * transport is wired, so external writes refresh open UI sessions.
+ * SSE parity (issue #178): after executing, it publishes the same change events the HTTP
+ * controller emits, via the shared {@link CommandEventPublisher} — the Project:0 broadcast plus
+ * targeted events for the primary and secondary result entities — so a write made over the
+ * gateway (e.g. MCP) refreshes open browser sessions. Having no HTTP session, it excludes none.
  */
 @Service
 public class InProcessCommandGateway implements CommandGateway {
@@ -66,15 +68,17 @@ public class InProcessCommandGateway implements CommandGateway {
     private final ApiCommandFactory apiCommandFactory;
     private final CommandHandler commandHandler;
     private final ObjectMapper objectMapper;
+    private final CommandEventPublisher eventPublisher;
 
     public InProcessCommandGateway(CommandPolicy policy, CommandRegistry registry,
             ApiCommandFactory apiCommandFactory, CommandHandler commandHandler,
-            ObjectMapper objectMapper) {
+            ObjectMapper objectMapper, CommandEventPublisher eventPublisher) {
         this.policy = policy;
         this.registry = registry;
         this.apiCommandFactory = apiCommandFactory;
         this.commandHandler = commandHandler;
         this.objectMapper = objectMapper;
+        this.eventPublisher = eventPublisher;
     }
 
     @Override
@@ -101,6 +105,11 @@ public class InProcessCommandGateway implements CommandGateway {
             Command command = apiCommandFactory.newCommand(commandType, boundInput);
             commandHandler.execute(command);
             Object result = apiCommandFactory.extractResult(commandType, command);
+            Object secondaryResult = apiCommandFactory.extractSecondaryResult(commandType, command);
+            // Publish the same SSE events the HTTP controller emits so an association made over the
+            // gateway (e.g. MCP) refreshes open browser sessions. The gateway has no HTTP session,
+            // so it excludes nobody (null).
+            eventPublisher.publish(command, result, secondaryResult, null);
             return new GatewayResult(commandType, result);
         } catch (AuthorizationException e) {
             throw new GatewayException(GatewayException.Kind.UNAUTHORIZED, e.getMessage(), e);

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/query/ProjectQueryController.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/query/ProjectQueryController.java
@@ -987,6 +987,37 @@ public class ProjectQueryController {
     }
 
     /**
+     * Resolve a container to the detail DTO the client re-reads after an association changes.
+     * Arms are ordered most-specific first: {@link UseCase} and {@link Story} implement several
+     * of the container interfaces, so they must be matched before the single-interface types.
+     * Returns {@code null} when the container is the project itself — no component subscribes to a
+     * targeted {@code Project:<id>} channel (the sidebar uses the fixed {@code Project:0}
+     * broadcast), so there is nothing to target. An unrecognized container type also returns
+     * {@code null} but is logged, so a future container type surfaces in the logs instead of
+     * silently going quiet. See {@code doc/178-association-result-extractors-plan.md} §Decisions.
+     */
+    public static Object toContainerDetailDto(Object container) {
+        if (container instanceof UseCase useCase) {
+            return toUseCaseDetailDto(useCase);
+        }
+        if (container instanceof Story story) {
+            return toStoryDetailDto(story);
+        }
+        if (container instanceof Actor actor) {
+            return toActorDetailDto(actor);
+        }
+        if (container instanceof Stakeholder stakeholder) {
+            return toStakeholderDetailDto(stakeholder);
+        }
+        if (container instanceof ProjectOrDomain) {
+            return null;
+        }
+        log.warn("toContainerDetailDto: unrecognized container type {}",
+                container == null ? "null" : container.getClass().getName());
+        return null;
+    }
+
+    /**
      * Convert a GoalContainer referer to an EntityReferenceDto.
      * GoalContainer doesn't expose getId() — we check concrete types.
      */

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/stream/StreamEventPublisher.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/stream/StreamEventPublisher.java
@@ -29,5 +29,12 @@ public interface StreamEventPublisher {
 
     void publishTargetUpdate(String targetType, Long targetId, Object payload);
 
+    /**
+     * Publish a targeted update to every subscribed session except {@code excludeSessionId}
+     * (typically the session that issued the command, so it does not reload the form it just
+     * edited). A null {@code excludeSessionId} excludes nobody.
+     */
+    void publishTargetUpdate(String targetType, Long targetId, Object payload, String excludeSessionId);
+
     void publishTargetDeleted(String targetType, Long targetId);
 }

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/stream/StreamEventPublisherImpl.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/stream/StreamEventPublisherImpl.java
@@ -38,7 +38,13 @@ public class StreamEventPublisherImpl implements StreamEventPublisher {
 
     @Override
     public void publishTargetUpdate(String targetType, Long targetId, Object payload) {
-        streamService.pushToSubscribedSessions(targetType, targetId, payload);
+        publishTargetUpdate(targetType, targetId, payload, null);
+    }
+
+    @Override
+    public void publishTargetUpdate(String targetType, Long targetId, Object payload,
+                                    String excludeSessionId) {
+        streamService.pushToSubscribedSessions(targetType, targetId, payload, excludeSessionId);
     }
 
     @Override

--- a/modules/service-impl/src/main/java/com/rreganjr/requel/service/stream/StreamService.java
+++ b/modules/service-impl/src/main/java/com/rreganjr/requel/service/stream/StreamService.java
@@ -159,13 +159,31 @@ public class StreamService {
      * per-session and prune the offender so future broadcasts skip it.
      */
     public void pushToSubscribedSessions(String targetType, Long targetId, Object payload) {
+        pushToSubscribedSessions(targetType, targetId, payload, null);
+    }
+
+    /**
+     * Same as {@link #pushToSubscribedSessions(String, Long, Object)} but skips
+     * {@code excludeSessionId} (typically the session that issued the command, so it is not told to
+     * refresh an entity it just changed). A null {@code excludeSessionId} excludes nobody. The
+     * Project:0 broadcast never passes an exclusion — the acting session's sidebar counts must still
+     * update — so only targeted events are filtered.
+     */
+    public void pushToSubscribedSessions(String targetType, Long targetId, Object payload,
+                                         String excludeSessionId) {
         String targetKey = targetType + ":" + targetId;
         Set<String> sessionIds = sessionStore.getSessionsForTarget(targetKey);
-        log.debug("pushToSubscribedSessions targetKey={} sessions={}", targetKey, sessionIds.size());
+        log.debug("pushToSubscribedSessions targetKey={} sessions={} exclude={}", targetKey,
+                sessionIds.size(), excludeSessionId);
         StreamEventEnvelope envelope = payload != null
                 ? StreamEventEnvelope.data(targetType, targetId, payload)
                 : StreamEventEnvelope.targetDeleted(targetType, targetId);
         for (String sessionId : sessionIds) {
+            if (excludeSessionId != null && excludeSessionId.equals(sessionId)) {
+                log.debug("pushToSubscribedSessions skipping originator session {} for target {}",
+                        sessionId, targetKey);
+                continue;
+            }
             try {
                 sendEvent(sessionId, envelope);
             } catch (RuntimeException broadcastFailure) {

--- a/requel-angular/e2e/sse-refresh.e2e.ts
+++ b/requel-angular/e2e/sse-refresh.e2e.ts
@@ -1,6 +1,6 @@
 import { test, expect } from './fixtures/auth';
 import {
-  createProject, createGoal, updateGoal,
+  createProject, createGoal, updateGoal, createActor, addGoalToActor,
 } from './fixtures/api-helper';
 import { gotoAndWaitForGet } from './helpers/navigation';
 
@@ -96,6 +96,62 @@ test.describe('SSE live refresh', () => {
     const sentinelStillSet = await page.evaluate(() => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return (globalThis as any).__sseRefreshSentinel != null;
+    });
+    expect(sentinelStillSet, 'sentinel survives, proving no page reload happened').toBeTruthy();
+
+    await page.close();
+  });
+
+  test('open actor editor in context A; associate a goal via API → context A goals table refreshes via targeted SSE (issue #178)', async ({ adminContext, request }) => {
+    test.setTimeout(30_000);
+
+    const nonce = Date.now();
+    const projectName = `e2e-sse-assoc-${nonce}`;
+    const actorName = `SSE Assoc Actor ${nonce}`;
+    const goalName = `SSE Assoc Goal ${nonce}`;
+    await createProject(request, projectName, 'SSE association source');
+    const actor = await createActor(request, projectName, actorName, 'actor text');
+    const goal = await createGoal(request, projectName, goalName, 'goal text');
+
+    const page = await adminContext.newPage();
+
+    // Same rationale as the goal test above: wait for the editor's Actor:<id> subscription POST
+    // (which also confirms the SSE connection is live) before firing the simulated context-B write.
+    const subscriptionPromise = page.waitForResponse(
+      r => r.url().includes('/events/stream/subscriptions') &&
+           r.request().method() === 'POST' &&
+           r.status() === 200,
+      { timeout: 15_000 }
+    );
+
+    await gotoAndWaitForGet(
+      page,
+      `/projects/${encodeURIComponent(projectName)}/actors/${actor.id}`,
+      response => response.url().includes(`/actors/${actor.id}`)
+    );
+    await expect(page.getByTestId('actor-name')).toHaveValue(actorName);
+    await subscriptionPromise;
+
+    // No goal on the actor yet.
+    await expect(page.getByTestId('actor-goal-link')).toHaveCount(0);
+
+    await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).__sseAssocSentinel = Date.now();
+    });
+
+    // Simulated context-B write: AddGoalToGoalContainer. Before #178 this command registered no
+    // result extractor, so no targeted Actor:<id> event fired and this open editor never refreshed.
+    // Now the merged container's detail DTO is the result, so the editor gets a targeted event.
+    await addGoalToActor(request, projectName, actor.id, goal.id);
+
+    // The actor editor's events$ handler calls loadActor(false); the goals table now shows the goal.
+    await expect(page.getByTestId('actor-goal-link')).toHaveText(goalName, { timeout: 10_000 });
+
+    // Sentinel still set ⇒ no full page reload occurred — the update was SSE-driven change detection.
+    const sentinelStillSet = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (globalThis as any).__sseAssocSentinel != null;
     });
     expect(sentinelStillSet, 'sentinel survives, proving no page reload happened').toBeTruthy();
 

--- a/requel-angular/src/app/core/command.service.spec.ts
+++ b/requel-angular/src/app/core/command.service.spec.ts
@@ -3,14 +3,22 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 import { CommandService } from './command.service';
 import { CommandResult } from '../models/command';
+import { EventStreamService } from './event-stream.service';
 
 describe('CommandService', () => {
   let service: CommandService;
   let httpMock: HttpTestingController;
+  let sessionId: string | null;
 
   beforeEach(() => {
+    sessionId = null;
+    const eventStreamStub = { sessionId: () => sessionId };
     TestBed.configureTestingModule({
-      providers: [provideHttpClient(), provideHttpClientTesting()]
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: EventStreamService, useValue: eventStreamStub }
+      ]
     });
     service = TestBed.inject(CommandService);
     httpMock = TestBed.inject(HttpTestingController);
@@ -60,5 +68,23 @@ describe('CommandService', () => {
     req.flush({ success: true, entityType: 'DeleteGoal', entity: null, error: null, violations: null });
     const result = await promise;
     expect(result.success).toBe(true);
+  });
+
+  it('execute() sends the X-Session-Id header when a stream session exists', async () => {
+    sessionId = 'sess-xyz';
+    const promise = service.execute('EditGoal', { name: 'x' });
+    const req = httpMock.expectOne('/api/commands/EditGoal');
+    expect(req.request.headers.get('X-Session-Id')).toBe('sess-xyz');
+    req.flush({ success: true, entityType: 'EditGoal', entity: null, error: null, violations: null });
+    await promise;
+  });
+
+  it('execute() omits the X-Session-Id header when no stream session is open', async () => {
+    sessionId = null;
+    const promise = service.execute('EditGoal', { name: 'x' });
+    const req = httpMock.expectOne('/api/commands/EditGoal');
+    expect(req.request.headers.has('X-Session-Id')).toBe(false);
+    req.flush({ success: true, entityType: 'EditGoal', entity: null, error: null, violations: null });
+    await promise;
   });
 });

--- a/requel-angular/src/app/core/command.service.ts
+++ b/requel-angular/src/app/core/command.service.ts
@@ -19,10 +19,11 @@
  *
  */
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { environment } from '../../environments/environment';
 import { CommandResult, ErrorResponse } from '../models/command';
+import { EventStreamService } from './event-stream.service';
 
 /**
  * Service for dispatching commands via the CQRS command endpoint.
@@ -31,7 +32,7 @@ import { CommandResult, ErrorResponse } from '../models/command';
 @Injectable({ providedIn: 'root' })
 export class CommandService {
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private eventStreamService: EventStreamService) {}
 
   /**
    * Execute a command with a JSON body and return the result.
@@ -41,7 +42,8 @@ export class CommandService {
       return await firstValueFrom(
         this.http.post<CommandResult<T>>(
           `${environment.apiBaseUrl}/commands/${commandType}`,
-          input
+          input,
+          this.sessionHeaders()
         )
       );
     } catch (err) {
@@ -61,12 +63,25 @@ export class CommandService {
       return await firstValueFrom(
         this.http.post<CommandResult<T>>(
           `${environment.apiBaseUrl}/commands/${commandType}`,
-          formData
+          formData,
+          this.sessionHeaders()
         )
       );
     } catch (err) {
       return this.handleError(err, commandType);
     }
+  }
+
+  /**
+   * Build the request options carrying the caller's SSE session id in an `X-Session-Id` header,
+   * so the server can exclude this session from the targeted refresh events it fires for the
+   * entity being changed (issue #178) — the editor should not reload the form it just saved. The
+   * header is omitted entirely when no stream is open yet (`sessionId()` is null), which the server
+   * treats as "exclude nobody".
+   */
+  private sessionHeaders(): { headers?: HttpHeaders } {
+    const sid = this.eventStreamService.sessionId();
+    return sid ? { headers: new HttpHeaders({ 'X-Session-Id': sid }) } : {};
   }
 
   /**


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/178

178: Result extractors for the six association commands (targeted SSE refresh)

The six association commands (Add/Remove Goal-to-GoalContainer, Story-to-StoryContainer,
Actor-to-ActorContainer) registered with no result extractor, so ApiCommandFactory.extractResult
returned null and CommandController published no targeted SSE event. A second session with the
same actor/story/use-case open was never told to refresh after an association changed. This wires
result extractors that return the merged container's detail DTO, publishes a second targeted event
for the associated child, excludes the originating session from targeted events, and gives the MCP
gateway the same publishing the HTTP path has.

Closes #178.

Implements doc/178-association-result-extractors-plan.md (§4.1-§4.5).

Backend:
- ProjectQueryController: new public static toContainerDetailDto(Object) — resolves a container to
  its detail DTO (UseCase/Story/Actor/Stakeholder), returns null for the project itself (no
  targeted Project:<id> channel; the sidebar uses the Project:0 broadcast) and for unknown types
  (logged).
- CommandRegistration / CommandRegistry / CommandRegistryImpl / ApiCommandFactory: add an eighth
  registration component, secondaryResultExtractor, plus one new full register overload. Every
  existing overload defaults it to null, so no other registration changes. ApiCommandFactory gains
  extractSecondaryResult.
- ProjectCommandRegistrar: the six association registrations now pass the container detail DTO as
  the primary result and the associated child (goal/story/actor) detail DTO as the secondary,
  publish-only, result.
- CommandEventPublisher (new): shared collaborator that publishes the Project:0 broadcast plus
  targeted events for the primary and secondary entities, skipping a duplicate when the child
  resolves to the same (type,id) as the container. The reflection-based targeting block now lives
  here once instead of being copied between the controller and the gateway.
- CommandController: delegates SSE publishing to CommandEventPublisher and threads a new
  X-Session-Id request header (JSON + multipart) through so the originating session can be excluded
  from targeted events. A missing header excludes nobody.
- StreamEventPublisher(+Impl) / StreamService: new excludeSessionId-aware overloads;
  pushToSubscribedSessions skips the excluded session. The Project:0 broadcast is never filtered —
  the acting session's own sidebar counts must still update.
- InProcessCommandGateway: publishes the same events after execute (excludes nobody — no HTTP
  session), so an association made over MCP refreshes open browser sessions.

Frontend:
- command.service.ts: sends X-Session-Id (from EventStreamService.sessionId()) on command POSTs
  when a stream is open; omits the header when none is.

Tests:
- ProjectQueryControllerTest: per-arm toContainerDetailDto mapping tests incl. project -> null.
- CommandControllerTest: targeted events now assert the exclusion-aware overload; new tests for
  originator exclusion, container+child dual publish, and null-result (broadcast only).
- StreamServiceTest: exclusion skips exactly the excluded session; null exclusion delivers to all.
- command.service.spec.ts: header present when sessionId set, absent when null.
- sse-refresh.e2e.ts: an association issued via API refreshes an open actor editor via the targeted
  container event without a page reload.

Depends on #187 and #189 (already merged), which corrected the story/actor container lookups the
extractors read. The client-side cleanup (removing refreshVersionAfterAssociation) stays in #180.
