### PR TITLE
180: Consume the entity returned by association commands instead of refetching

### DIFF
--- a/doc/180-consume-association-entity-plan.md
+++ b/doc/180-consume-association-entity-plan.md
@@ -1,0 +1,127 @@
+# 180 — Consume the entity returned by association commands instead of refetching
+
+## Summary
+
+#178 made the six association commands return their merged container as `result.entity`
+(`AddGoalToGoalContainer`, `RemoveGoalFromGoalContainer`, `AddStoryToStoryContainer`,
+`RemoveStoryFromStoryContainer`, `AddActorToActorContainer`, `RemoveActorFromActorContainer`).
+The four editors that call those commands still ignore that entity and re-read the container over
+HTTP — a version-only GET (actor, stakeholder), a full refetch plus a second scenario GET
+(use case), or a full refetch behind a sequence guard (story). This ticket deletes that follow-up
+read everywhere and takes both the optimistic-lock `version` and the affected collections straight
+off `result.entity`.
+
+Net effect: one fewer round trip per association, and the editor stays in sync from the response
+rather than from a follow-up read. The principle being settled is that every mutating command
+returns its entity and the client consumes it — no command-specific refresh strategy.
+
+## Decisions
+
+1. **One authoritative rule.** On a successful association, set `this.version` from
+   `result.entity.version` and replace the affected collection signal(s) from `result.entity`.
+   Delete every GET-based refresh (`refreshVersionAfterAssociation`, `refreshCollections` usage in
+   the association handlers, `refreshAfterAssociation`) and the optimistic list patch
+   (`this.goals.update(...)`) — the response is the single source of truth.
+
+2. **On failure, leave state unchanged.** Keep the current behaviour: set `errorMessage` and touch
+   nothing else. A stale held `version` is self-correcting — the next save 409s into the existing
+   `recoverFromStaleVersion()` / stale-version recovery path. We do not refetch on failure.
+
+3. **Concurrency: version-monotonic guard, applied uniformly.** Two associations can be in flight
+   at once (e.g. two quick remove clicks); their responses can arrive out of order, and an older
+   snapshot landing last would silently restore a row the user just removed. Guard every apply with
+   `entity.version > heldVersion` (apply, and advance the held version, only when the response is
+   newer). Because each successful merge increments `@Version`, the highest version is by definition
+   the last-committed / most-complete state — so this keys off the server's own commit order, which
+   is strictly more correct than story-editor's current `storyReadSeq` (which keys off client issue
+   order). This replaces `storyReadSeq` and is added to all four editors, since after decision 1 all
+   four now apply server lists and share the same out-of-order exposure. #178 already excludes the
+   originating session from SSE, so an editor never races its own change against an echo.
+
+4. **use-case-editor drops `refreshCollections()` from the association path.** The six association
+   handlers stop calling `refreshCollections()` and apply the returned `UseCaseDto` directly. That
+   method refetched the use case *and* re-read the primary scenario, so removing it from the
+   association path saves two GETs per association; it stays in place solely for
+   `createPrimaryScenario()`, which still needs the freshly-created scenario.
+
+Testing is covered in the Test plan below, including the SSE e2e negative assertion #178 deferred to
+this ticket (the acting session issues no second container GET after an association).
+
+## Verified starting state (all on `release/2.0`, post-#178)
+
+- `command.service.ts` returns `CommandResult<T>` with `entity` populated from the server's
+  primary result extractor; the six commands now return their container DTO.
+- DTO shapes the editors will read: `ActorDto { version; goals: EntityReferenceDto[] | null }`,
+  `StakeholderDto { version; goals?: EntityReferenceDto[] }`,
+  `StoryDto { version; goals: EntityReferenceDto[] | null; actors: EntityReferenceDto[] | null }`,
+  `UseCaseDto { version; goals: GoalDto[] | null; stories; actors; additionalScenarios; scenarioId }`.
+- `actor-editor.ts` — `onGoalSelected`/`onRemoveGoal` optimistically patch `goals` then call
+  `refreshVersionAfterAssociation()` (version-only GET, ~L503).
+- `stakeholder-editor.ts` — same pattern; `refreshVersionAfterAssociation()` ~L637.
+- `use-case-editor.ts` — `addGoal/removeGoal/addStory/removeStory/addActorToList/removeActor` call
+  `refreshCollections()` (~L877), a full `getUseCase` GET that also refetches the primary scenario.
+  `refreshCollections` is also used by `createPrimaryScenario` (not an association — stays).
+- `story-editor.ts` — the four handlers call `refreshAfterAssociation()` (~L563), a full `getStory`
+  GET guarded by `storyReadSeq`.
+
+## Work items
+
+### Shared shape of every association handler (all four editors)
+
+On `result.success`:
+- `const entity = result.entity as <Dto> | null;`
+- `if (entity && (this.version == null || entity.version > this.version)) { this.version = entity.version; <set affected signals from entity>; }`
+- keep the existing success toast; keep the `else`/`catch` → `errorMessage` untouched.
+
+### 4.1 actor-editor.ts
+Replace the optimistic `goals.update(...)` + `await refreshVersionAfterAssociation()` in
+`onGoalSelected` and `onRemoveGoal` with the guarded apply, setting `goals` from
+`entity.goals ?? []`. Delete `refreshVersionAfterAssociation()` and its now-unused
+`actorService.getActor` import if nothing else uses it (check: `loadActor` still does).
+
+### 4.2 stakeholder-editor.ts
+Same as 4.1, setting `goals` from `entity.goals ?? []`. Delete
+`refreshVersionAfterAssociation()`; keep `stakeholderService.getStakeholder` if `loadStakeholder`
+still uses it (check).
+
+### 4.3 use-case-editor.ts
+In the six association handlers, replace `await refreshCollections()` with the guarded apply,
+setting `version`, `useCase`, `goals`, `stories`, `actors`, `additionalScenarios` from the returned
+`UseCaseDto`. Do **not** touch `primaryScenario` — associations never change it, which also drops
+the second `getScenario` GET. Keep `refreshCollections()` (still used by `createPrimaryScenario`).
+
+### 4.4 story-editor.ts
+Replace `await refreshAfterAssociation()` in the four handlers with the guarded apply, setting the
+`story` signal and `version` from the returned `StoryDto`. Delete `refreshAfterAssociation()` and
+the `storyReadSeq` field (the monotonic version guard replaces it).
+
+## Test plan
+
+- **Unit — each editor spec** (actor, stakeholder, use-case, story): a successful association
+  applies `version` and the affected list(s) from `result.entity` and issues **no** follow-up
+  container GET (assert the query service GET is not called). Add an out-of-order case: a stale
+  (lower-version) response arriving last is ignored. Update/remove specs that asserted the old
+  refresh methods.
+- **Unit — failure**: on `result.success === false`, state is unchanged and `errorMessage` is set;
+  no GET issued.
+- **e2e — `sse-refresh.e2e.ts`**: extend the association test so the acting context issues no second
+  detail GET after the association (the negative assertion deferred from #178), while a second
+  context still refreshes via SSE.
+- Gate: `mvn clean verify` (unaffected, but run) and `npm test`; Playwright e2e as available.
+
+## Acceptance criteria
+
+- No association handler in any of the four editors issues a follow-up GET on success.
+- After add/remove, the held `version` and the on-screen collections match the command response,
+  and an immediate save does not 409.
+- Two rapid associations cannot leave a stale list on screen (monotonic guard).
+- `refreshVersionAfterAssociation` (actor, stakeholder), the association usage of
+  `refreshCollections` (use case), `refreshAfterAssociation` and `storyReadSeq` (story) are gone.
+
+## Not in scope
+
+- Client-side serialization / disabling controls while an association is in flight (Option C in the
+  concurrency discussion) — a possible follow-up, not needed given the monotonic guard.
+- The rarer server-side case where two truly-concurrent association transactions collide into a 409
+  on the second — unchanged behaviour, surfaces through the existing error path.
+- Any backend change: #178 already returns the entity.

--- a/requel-angular/e2e/sse-refresh.e2e.ts
+++ b/requel-angular/e2e/sse-refresh.e2e.ts
@@ -158,4 +158,56 @@ test.describe('SSE live refresh', () => {
     await page.close();
   });
 
+  test('originating context adds a goal via the UI and issues no follow-up actor GET (issue #180)', async ({ adminContext, request }) => {
+    test.setTimeout(30_000);
+
+    const nonce = Date.now();
+    const projectName = `e2e-assoc-noget-${nonce}`;
+    const actorName = `NoGet Actor ${nonce}`;
+    const goalName = `NoGet Goal ${nonce}`;
+    await createProject(request, projectName, 'no-follow-up-GET source');
+    const actor = await createActor(request, projectName, actorName, 'actor text');
+    await createGoal(request, projectName, goalName, 'goal text');
+
+    const page = await adminContext.newPage();
+
+    const subscriptionPromise = page.waitForResponse(
+      r => r.url().includes('/events/stream/subscriptions') &&
+           r.request().method() === 'POST' &&
+           r.status() === 200,
+      { timeout: 15_000 }
+    );
+
+    await gotoAndWaitForGet(
+      page,
+      `/projects/${encodeURIComponent(projectName)}/actors/${actor.id}`,
+      response => response.url().includes(`/actors/${actor.id}`)
+    );
+    await expect(page.getByTestId('actor-name')).toHaveValue(actorName);
+    await subscriptionPromise;
+
+    // From here on, any GET of this actor's detail is a follow-up read we want to prove does NOT
+    // happen: #180 has the editor consume the association response, and #178 excludes the acting
+    // session from the targeted SSE event, so the originating context must not re-read the actor.
+    const detailPath = `/projects/${encodeURIComponent(projectName)}/actors/${actor.id}`;
+    let followUpActorGets = 0;
+    page.on('request', req => {
+      if (req.method() === 'GET' && req.url().includes(detailPath)) {
+        followUpActorGets += 1;
+      }
+    });
+
+    // Add the goal through the UI so the command carries this context's X-Session-Id.
+    await page.getByTestId('actor-add-goal').click();
+    await page.getByTestId('entity-selector-row').first().click();
+
+    // The goal lands in the table from result.entity...
+    await expect(page.getByTestId('actor-goal-link')).toHaveText(goalName, { timeout: 10_000 });
+
+    // ...and the acting context issued no follow-up actor GET to get there.
+    expect(followUpActorGets, 'originating context must not re-read the actor after its own association').toBe(0);
+
+    await page.close();
+  });
+
 });

--- a/requel-angular/src/app/features/actors/actor-editor.spec.ts
+++ b/requel-angular/src/app/features/actors/actor-editor.spec.ts
@@ -192,25 +192,22 @@ describe('ActorEditorComponent', () => {
     expect(comp.errorMessage()).toBe('Save failed.');
   });
 
-  // #173 required test (§10.3). The Goals step's associations bump the actor's @Version but
-  // return no entity, so the wizard has to refetch. If it did not, coming back to Details and
-  // pressing Continue would send the version captured at step 1 and 409.
+  // #173 required test (§10.3), updated for #180: the Goals step's associations bump the actor's
+  // @Version and now return the merged actor, so the wizard reads the new version from the response
+  // instead of refetching. If it did not, coming back to Details and pressing Continue would send
+  // the version captured at step 1 and 409.
   describe('wizard version contract (#173)', () => {
     it('survives create -> add goal -> back to Details -> rename -> Continue', async () => {
       fixture.detectChanges();
       await flush();
 
       let version = 0;
-      commandServiceMock.execute.mockImplementation(async (type: string) => {
-        if (type === 'EditActor') {
-          version += 1;
-          return { success: true, entity: { ...MOCK_ACTOR, id: 5, version } };
-        }
-        // Association commands return no entity - that is the whole point.
+      commandServiceMock.execute.mockImplementation(async () => {
+        // Every command here (EditActor and the goal association) merges the actor and returns it
+        // with a freshly bumped @Version (#180).
         version += 1;
-        return { success: true, entity: null };
+        return { success: true, entity: { ...MOCK_ACTOR, id: 5, version } };
       });
-      actorServiceMock.getActor.mockImplementation(async () => ({ ...MOCK_ACTOR, id: 5, version }));
 
       comp.detailsForm.controls.name.setValue('Customer');
 
@@ -300,11 +297,18 @@ describe('ActorEditorComponent', () => {
     expect(comp.errorMessage()).toBe('In use');
   });
 
-  it('onGoalSelected calls AddGoalToGoalContainer and appends to goals()', async () => {
+  it('onGoalSelected calls AddGoalToGoalContainer and applies the returned actor to goals()', async () => {
     paramMap$.next(convertToParamMap({ name: 'proj1', actorId: '5' }));
     fixture.detectChanges();
     await flush();
-    commandServiceMock.execute.mockResolvedValue({ success: true });
+    actorServiceMock.getActor.mockClear();
+    commandServiceMock.execute.mockResolvedValue({
+      success: true,
+      entity: { ...MOCK_ACTOR, version: 1, goals: [
+        { id: 1, name: 'Purchase item', entityType: 'Goal' },
+        { id: 7, name: 'Avoid late fees', entityType: 'Goal' }
+      ] }
+    });
     await comp.onGoalSelected({ id: 7, name: 'Avoid late fees', entityType: 'Goal' });
     expect(commandServiceMock.execute).toHaveBeenCalledWith('AddGoalToGoalContainer', expect.objectContaining({
       projectName: 'proj1',
@@ -312,42 +316,55 @@ describe('ActorEditorComponent', () => {
       goalId: 7,
       containerType: 'Actor'
     }));
+    // Goals and version come from result.entity, not a follow-up GET.
     expect(comp.goals().some(g => g.id === 7)).toBe(true);
+    expect(comp.version).toBe(1);
+    expect(actorServiceMock.getActor).not.toHaveBeenCalled();
     expect(messageServiceMock.add).toHaveBeenCalledWith(expect.objectContaining({
       severity: 'success', summary: 'Goal added'
     }));
   });
 
-  // Regression: AddGoal/RemoveGoal merge the container (this actor), bumping its @Version,
-  // but register no result extractor - so result.entity is null and the new version can only
-  // be had by refetching. Before this, adding a goal and then saving the name gave a 409.
-  describe('stale version after a goal association', () => {
-    it('re-reads version after adding a goal', async () => {
+  // #180: AddGoal/RemoveGoal merge the container (this actor) and now return it with the bumped
+  // @Version and refreshed goals, so both come straight off result.entity - no follow-up GET.
+  describe('version and goals from the association response', () => {
+    it('takes version and goals from the response after adding a goal', async () => {
       paramMap$.next(convertToParamMap({ name: 'proj1', actorId: '5' }));
       fixture.detectChanges();
       await flush();
       expect(comp.version).toBe(0);
+      actorServiceMock.getActor.mockClear();
 
-      commandServiceMock.execute.mockResolvedValue({ success: true, entity: null });
-      actorServiceMock.getActor.mockResolvedValue({ ...MOCK_ACTOR, version: 3 });
+      commandServiceMock.execute.mockResolvedValue({
+        success: true, entity: { ...MOCK_ACTOR, version: 3, goals: [
+          { id: 1, name: 'Purchase item', entityType: 'Goal' },
+          { id: 7, name: 'Avoid late fees', entityType: 'Goal' }
+        ] }
+      });
 
       await comp.onGoalSelected({ id: 7, name: 'Avoid late fees', entityType: 'Goal' });
       expect(comp.version).toBe(3);
+      expect(comp.goals().some(g => g.id === 7)).toBe(true);
+      expect(actorServiceMock.getActor).not.toHaveBeenCalled();
     });
 
-    it('re-reads version after removing a goal', async () => {
+    it('takes version and goals from the response after removing a goal', async () => {
       paramMap$.next(convertToParamMap({ name: 'proj1', actorId: '5' }));
       fixture.detectChanges();
       await flush();
+      actorServiceMock.getActor.mockClear();
 
-      commandServiceMock.execute.mockResolvedValue({ success: true, entity: null });
-      actorServiceMock.getActor.mockResolvedValue({ ...MOCK_ACTOR, version: 4 });
+      commandServiceMock.execute.mockResolvedValue({
+        success: true, entity: { ...MOCK_ACTOR, version: 4, goals: [] }
+      });
 
       await comp.onRemoveGoal({ id: 1, name: 'Purchase item', entityType: 'Goal' });
       expect(comp.version).toBe(4);
+      expect(comp.goals().some(g => g.id === 1)).toBe(false);
+      expect(actorServiceMock.getActor).not.toHaveBeenCalled();
     });
 
-    it('does not discard unsaved detail edits while refreshing the version', async () => {
+    it('does not discard unsaved detail edits while applying the response', async () => {
       paramMap$.next(convertToParamMap({ name: 'proj1', actorId: '5' }));
       fixture.detectChanges();
       await flush();
@@ -356,29 +373,50 @@ describe('ActorEditorComponent', () => {
       comp.detailsForm.controls.name.setValue('Renamed but unsaved');
       comp.detailsForm.controls.name.markAsDirty();
 
-      commandServiceMock.execute.mockResolvedValue({ success: true, entity: null });
-      actorServiceMock.getActor.mockResolvedValue({ ...MOCK_ACTOR, version: 9 });
+      commandServiceMock.execute.mockResolvedValue({ success: true, entity: { ...MOCK_ACTOR, version: 9 } });
       await comp.onGoalSelected({ id: 7, name: 'Avoid late fees', entityType: 'Goal' });
 
-      // The version advanced, but the in-progress edit survived - which is why the refresh
-      // is narrow instead of a full loadActor().
+      // The version advanced, but the in-progress edit survived - applyAssociationResult never
+      // touches the form.
       expect(comp.version).toBe(9);
       expect(comp.detailsForm.controls.name.value).toBe('Renamed but unsaved');
       expect(comp.hasUnsavedChanges()).toBe(true);
     });
 
-    it('leaves the held version alone when the refresh fetch fails', async () => {
+    it('ignores an out-of-order response older than the held version', async () => {
       paramMap$.next(convertToParamMap({ name: 'proj1', actorId: '5' }));
       fixture.detectChanges();
       await flush();
 
-      commandServiceMock.execute.mockResolvedValue({ success: true, entity: null });
-      actorServiceMock.getActor.mockRejectedValue(new Error('network'));
-
+      // First association lands version 5 with two goals.
+      commandServiceMock.execute.mockResolvedValue({
+        success: true, entity: { ...MOCK_ACTOR, version: 5, goals: [
+          { id: 1, name: 'Purchase item', entityType: 'Goal' },
+          { id: 7, name: 'Avoid late fees', entityType: 'Goal' }
+        ] }
+      });
       await comp.onGoalSelected({ id: 7, name: 'Avoid late fees', entityType: 'Goal' });
-      // Still 0, and no error surfaced: the association itself succeeded.
-      expect(comp.version).toBe(0);
+      expect(comp.version).toBe(5);
+
+      // A stale response (version 4) from an earlier in-flight association resolves last; the guard
+      // must not roll the list or version back.
+      commandServiceMock.execute.mockResolvedValue({
+        success: true, entity: { ...MOCK_ACTOR, version: 4, goals: [] }
+      });
+      await comp.onRemoveGoal({ id: 7, name: 'Avoid late fees', entityType: 'Goal' });
+      expect(comp.version).toBe(5);
       expect(comp.goals().some(g => g.id === 7)).toBe(true);
+    });
+
+    it('leaves state unchanged when the association returns no entity', async () => {
+      paramMap$.next(convertToParamMap({ name: 'proj1', actorId: '5' }));
+      fixture.detectChanges();
+      await flush();
+      const before = comp.version;
+
+      commandServiceMock.execute.mockResolvedValue({ success: true, entity: null });
+      await comp.onGoalSelected({ id: 7, name: 'Avoid late fees', entityType: 'Goal' });
+      expect(comp.version).toBe(before);
     });
   });
 
@@ -391,11 +429,11 @@ describe('ActorEditorComponent', () => {
     expect(comp.errorMessage()).toBe('Already linked');
   });
 
-  it('onRemoveGoal calls RemoveGoalFromGoalContainer and removes from goals()', async () => {
+  it('onRemoveGoal calls RemoveGoalFromGoalContainer and applies the returned actor to goals()', async () => {
     paramMap$.next(convertToParamMap({ name: 'proj1', actorId: '5' }));
     fixture.detectChanges();
     await flush();
-    commandServiceMock.execute.mockResolvedValue({ success: true });
+    commandServiceMock.execute.mockResolvedValue({ success: true, entity: { ...MOCK_ACTOR, version: 1, goals: [] } });
     await comp.onRemoveGoal({ id: 1, name: 'Purchase item', entityType: 'Goal' });
     expect(commandServiceMock.execute).toHaveBeenCalledWith('RemoveGoalFromGoalContainer', expect.objectContaining({
       goalId: 1,

--- a/requel-angular/src/app/features/actors/actor-editor.ts
+++ b/requel-angular/src/app/features/actors/actor-editor.ts
@@ -483,34 +483,27 @@ export class ActorEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
   }
 
   /**
-   * Re-reads the actor's optimistic-lock version after a goal association changes.
+   * Apply the merged container an association command returns (#180). Add/RemoveGoalFromGoalContainer
+   * end by merging the container — which IS this actor — so each returns the actor with its bumped
+   * `@Version` and refreshed goals as `result.entity`. Taking both from the response removes the
+   * follow-up GET this used to do.
    *
-   * `AddGoalToGoalContainerCommandImpl` / `RemoveGoalFromGoalContainerCommandImpl` end by
-   * merging the container - which IS this actor - so every add or remove bumps its
-   * `@Version`. The client cannot read the new value from the response: both commands are
-   * registered through the 4-arg `CommandRegistry.register` overload, which leaves
-   * `resultExtractor` null, so `ApiCommandFactory.extractResult` returns null and
-   * `result.entity` is empty. A refetch is the only way to see it.
+   * Guarded on `version`: two associations can be in flight at once (e.g. two quick removes) and
+   * their responses can arrive out of order. Since every successful merge increments `@Version`, a
+   * response older than what we already hold would restore a stale goals list, so we ignore it.
+   * A skipped version is self-correcting — the next save 409s into the existing recovery path.
    *
-   * Without this, adding a goal and then saving the name fails with a 409 the user did
-   * nothing to deserve. Pre-existing bug; #173's wizard makes it reachable in the create
-   * flow too, which is what surfaced it.
-   *
-   * Deliberately narrow — it takes `version` and nothing else. A full `loadActor()` here
-   * would overwrite whatever the user had typed into Name or Description before touching
-   * the Goals table.
+   * Never touches `detailsForm`, so an in-progress Name/Description edit survives.
    */
-  private async refreshVersionAfterAssociation(): Promise<void> {
-    if (this.actorId == null) {
+  private applyAssociationResult(entity: ActorDto | null): void {
+    if (!entity) {
       return;
     }
-    try {
-      const a = await this.actorService.getActor(this.projectName, this.actorId);
-      this.version = a.version;
-    } catch {
-      // Leave the held version as-is: a failed refresh is not worth blocking the user, and
-      // the next save reports the 409 with the existing recovery path.
+    if (this.version != null && entity.version <= this.version) {
+      return;
     }
+    this.version = entity.version;
+    this.goals.set(entity.goals ?? []);
   }
 
 
@@ -698,8 +691,7 @@ export class ActorEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
         containerType: 'Actor'
       });
       if (result.success) {
-        this.goals.update(list => [...list, goal].sort((a, b) => a.name.localeCompare(b.name)));
-        await this.refreshVersionAfterAssociation();
+        this.applyAssociationResult(result.entity as ActorDto | null);
         this.messageService.add({ severity: 'success', summary: 'Goal added', detail: `"${goal.name}" added successfully.` });
       } else {
         this.errorMessage.set(result.error ?? 'Failed to add goal.');
@@ -718,8 +710,7 @@ export class ActorEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
         containerType: 'Actor'
       });
       if (result.success) {
-        this.goals.update(list => list.filter(g => g.id !== goal.id));
-        await this.refreshVersionAfterAssociation();
+        this.applyAssociationResult(result.entity as ActorDto | null);
         this.messageService.add({ severity: 'info', summary: 'Goal removed', detail: `"${goal.name}" removed.` });
       } else {
         this.errorMessage.set(result.error ?? 'Failed to remove goal.');

--- a/requel-angular/src/app/features/stakeholders/stakeholder-editor.spec.ts
+++ b/requel-angular/src/app/features/stakeholders/stakeholder-editor.spec.ts
@@ -257,8 +257,9 @@ describe('StakeholderEditorComponent', () => {
     });
   });
 
-  // #173 required test (§10.3). Goal associations bump the stakeholder's @Version and return no
-  // entity, so the wizard refetches. Without that, returning to Details would 409.
+  // #173 required test (§10.3), updated for #180: goal associations bump the stakeholder's @Version
+  // and now return the merged stakeholder, so the wizard reads the new version from the response
+  // instead of refetching. Without that, returning to Details would 409.
   describe('wizard version contract (#173)', () => {
     it('survives create -> add goal -> back to Details -> edit -> Continue', async () => {
       paramMap$.next(convertToParamMap({ name: 'proj1', stakeholderId: 'new-nonuser' }));
@@ -266,13 +267,14 @@ describe('StakeholderEditorComponent', () => {
       await flush();
 
       let version = 0;
-      commandServiceMock.execute.mockImplementation(async (type: string) => {
+      commandServiceMock.execute.mockImplementation(async () => {
+        // Every command here merges the stakeholder and returns it with a bumped @Version (#180).
         version += 1;
-        if (type === 'EditNonUserStakeholder') {
-          return { success: true, entity: { ...MOCK_STAKEHOLDER_NONUSER, id: 51, version } };
-        }
-        return { success: true, entity: null };
+        return { success: true, entity: { ...MOCK_STAKEHOLDER_NONUSER, id: 51, version } };
       });
+      // saveDetails() still refetches once right after CREATE (loadStakeholder(false)) - that is a
+      // separate load from the association refetch #180 removes, so this mock must stay or the
+      // reload falls back to the default (a user stakeholder) and flips the editor's mode.
       stakeholderServiceMock.getStakeholder.mockImplementation(async () => ({
         ...MOCK_STAKEHOLDER_NONUSER, id: 51, version
       }));
@@ -301,17 +303,18 @@ describe('StakeholderEditorComponent', () => {
       expect(last.version).not.toBe(1);
     });
 
-    it('re-reads version after a goal association', async () => {
+    it('takes version from the association response', async () => {
       paramMap$.next(convertToParamMap({ name: 'proj1', stakeholderId: '50' }));
       fixture.detectChanges();
       await flush();
+      stakeholderServiceMock.getStakeholder.mockClear();
 
-      commandServiceMock.execute.mockResolvedValue({ success: true, entity: null });
-      stakeholderServiceMock.getStakeholder.mockResolvedValue({ ...MOCK_STAKEHOLDER_USER, version: 6 });
+      commandServiceMock.execute.mockResolvedValue({ success: true, entity: { ...MOCK_STAKEHOLDER_USER, version: 6 } });
 
       await comp.onGoalSelected({ id: 7, name: 'Avoid late fees', entityType: 'Goal' });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((comp as any).version).toBe(6);
+      expect(stakeholderServiceMock.getStakeholder).not.toHaveBeenCalled();
     });
   });
 
@@ -355,11 +358,14 @@ describe('StakeholderEditorComponent', () => {
     expect(comp.stakeholderName()).toBe('FASB');
   });
 
-  it('onGoalSelected calls AddGoalToGoalContainer and updates goals()', async () => {
+  it('onGoalSelected calls AddGoalToGoalContainer and applies the returned stakeholder to goals()', async () => {
     paramMap$.next(convertToParamMap({ name: 'proj1', stakeholderId: '50' }));
     fixture.detectChanges();
     await flush();
-    commandServiceMock.execute.mockResolvedValue({ success: true });
+    stakeholderServiceMock.getStakeholder.mockClear();
+    commandServiceMock.execute.mockResolvedValue({
+      success: true, entity: { ...MOCK_STAKEHOLDER_USER, version: 1, goals: [{ id: 10, name: 'Buy product', entityType: 'Goal' }] }
+    });
     await comp.onGoalSelected({ id: 10, name: 'Buy product', entityType: 'Goal' });
     expect(commandServiceMock.execute).toHaveBeenCalledWith('AddGoalToGoalContainer', expect.objectContaining({
       projectName: 'proj1',
@@ -368,6 +374,7 @@ describe('StakeholderEditorComponent', () => {
       containerType: 'Stakeholder'
     }));
     expect(comp.goals().some(g => g.id === 10)).toBe(true);
+    expect(stakeholderServiceMock.getStakeholder).not.toHaveBeenCalled();
   });
 
   it('onRemoveGoal calls RemoveGoalFromGoalContainer and removes from goals()', async () => {
@@ -379,7 +386,7 @@ describe('StakeholderEditorComponent', () => {
     paramMap$.next(convertToParamMap({ name: 'proj1', stakeholderId: '50' }));
     fixture.detectChanges();
     await flush();
-    commandServiceMock.execute.mockResolvedValue({ success: true });
+    commandServiceMock.execute.mockResolvedValue({ success: true, entity: { ...MOCK_STAKEHOLDER_USER, version: 1, goals: [] } });
     await comp.onRemoveGoal({ id: 10, name: 'Buy product', entityType: 'Goal' });
     expect(commandServiceMock.execute).toHaveBeenCalledWith('RemoveGoalFromGoalContainer', expect.objectContaining({
       goalId: 10,

--- a/requel-angular/src/app/features/stakeholders/stakeholder-editor.ts
+++ b/requel-angular/src/app/features/stakeholders/stakeholder-editor.ts
@@ -593,8 +593,7 @@ export class StakeholderEditorComponent implements OnInit, OnDestroy, DirtyCheck
         containerType: 'Stakeholder'
       });
       if (result.success) {
-        this.goals.update(list => [...list, goal].sort((a, b) => a.name.localeCompare(b.name)));
-        await this.refreshVersionAfterAssociation();
+        this.applyAssociationResult(result.entity as StakeholderDto | null);
         this.messageService.add({ severity: 'success', summary: 'Goal added', detail: 'Goal added.' });
       } else {
         this.errorMessage.set(result.error ?? 'Failed to add goal.');
@@ -613,8 +612,7 @@ export class StakeholderEditorComponent implements OnInit, OnDestroy, DirtyCheck
         containerType: 'Stakeholder'
       });
       if (result.success) {
-        this.goals.update(list => list.filter(g => g.id !== goal.id));
-        await this.refreshVersionAfterAssociation();
+        this.applyAssociationResult(result.entity as StakeholderDto | null);
         this.messageService.add({ severity: 'success', summary: 'Goal removed', detail: 'Goal removed.' });
       } else {
         this.errorMessage.set(result.error ?? 'Failed to remove goal.');
@@ -625,25 +623,25 @@ export class StakeholderEditorComponent implements OnInit, OnDestroy, DirtyCheck
   }
 
   /**
-   * Re-reads the version after a goal association changes.
+   * Apply the merged container an association command returns (#180). Add/RemoveGoalFromGoalContainer
+   * end by merging the container — this stakeholder — so each returns it with its bumped `@Version`
+   * and refreshed goals as `result.entity`. Taking both from the response removes the follow-up GET.
    *
-   * Add/RemoveGoalFromGoalContainer merge the container - this stakeholder - so each bumps its
-   * `@Version`, but they register no result extractor, so `result.entity` is null and a refetch
-   * is the only way to see the new value. Without it, adding a goal then saving 409s. Same bug
-   * and same fix as actor-editor (#173 slice 2); #178/#180 remove the refetch.
+   * Guarded on `version`: two associations can be in flight at once and resolve out of order; since
+   * every merge increments `@Version`, a response older than what we hold would restore a stale
+   * goals list, so we ignore it. A skipped version self-corrects through the next-save 409 path.
    *
-   * Narrow on purpose: `version` only, never the form, so an in-progress edit survives.
+   * Never touches the form, so an in-progress edit survives.
    */
-  private async refreshVersionAfterAssociation(): Promise<void> {
-    if (this.stakeholderId == null) {
+  private applyAssociationResult(entity: StakeholderDto | null): void {
+    if (!entity) {
       return;
     }
-    try {
-      const s = await this.stakeholderService.getStakeholder(this.projectName, this.stakeholderId);
-      this.version = s.version;
-    } catch {
-      // Leave the held version alone; the existing 409 path recovers on the next save.
+    if (this.version != null && entity.version <= this.version) {
+      return;
     }
+    this.version = entity.version;
+    this.goals.set(entity.goals ?? []);
   }
 
   onGoalClick(goal: EntityReferenceDto): void {

--- a/requel-angular/src/app/features/stories/story-editor.spec.ts
+++ b/requel-angular/src/app/features/stories/story-editor.spec.ts
@@ -426,18 +426,19 @@ describe('StoryEditorComponent', () => {
     });
   });
 
-  // Regression #179. AddGoal/RemoveGoal/AddActor/RemoveActor all merge the container — which
-  // here is the story — so each bumps its @Version, but none of the four registers a result
-  // extractor, so result.entity is null and the new value can only be read back (#178).
-  // Before this, adding a goal and then saving the name gave a 409 the user could not avoid.
-  describe('association refresh (#179)', () => {
+  // Regression #179, updated for #180. AddGoal/RemoveGoal/AddActor/RemoveActor all merge the
+  // container — here the story — bumping its @Version. Since #178 they return the merged story as
+  // result.entity, so the component reads the new version and lists off the response instead of
+  // refetching. Before this, adding a goal and then saving the name gave a 409 the user could not
+  // avoid.
+  describe('association result (#179/#180)', () => {
     const GOAL_A = { id: 7, name: 'Avoid late fees', entityType: 'Goal' };
     const GOAL_B = { id: 8, name: 'Buy quickly', entityType: 'Goal' };
     const ACTOR_A = { id: 1, name: 'Customer', entityType: 'Actor' };
 
-    /** Association commands answer `entity: null` — that is the whole reason for the refetch. */
-    function associationSucceeds(): void {
-      commandServiceMock.execute.mockResolvedValue({ success: true, entity: null });
+    /** The association command returns the merged story as `result.entity` (#180). */
+    function associationSucceeds(entity: unknown = MOCK_STORY): void {
+      commandServiceMock.execute.mockResolvedValue({ success: true, entity });
     }
 
     /** Renames and saves, so the version the component now holds shows up on the wire. */
@@ -454,15 +455,17 @@ describe('StoryEditorComponent', () => {
       ['onRemoveGoal', GOAL_A, 6],
       ['onActorSelected', ACTOR_A, 7],
       ['onRemoveActor', ACTOR_A, 8],
-    ] as const)('%s takes the bumped version and sends it on the next save', async (method, ref, bumped) => {
+    ] as const)('%s takes the bumped version from the response and sends it on the next save', async (method, ref, bumped) => {
       await renderExisting();
-      associationSucceeds();
-      storyServiceMock.getStory.mockResolvedValue({ ...MOCK_STORY, version: bumped });
+      storyServiceMock.getStory.mockClear();
+      associationSucceeds({ ...MOCK_STORY, version: bumped });
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await (comp as any)[method](ref);
 
-      // Without the refresh this would still be MOCK_STORY's 4 and the save would 409.
+      // No follow-up GET: the version came off result.entity.
+      expect(storyServiceMock.getStory).not.toHaveBeenCalled();
+      // Without it this would still be MOCK_STORY's 4 and the save would 409.
       expect(await saveAndReadVersion()).toBe(bumped);
     });
 
@@ -494,26 +497,24 @@ describe('StoryEditorComponent', () => {
 
     it('takes the goals list from the response instead of patching it locally', async () => {
       await renderExisting();
-      associationSucceeds();
+      storyServiceMock.getStory.mockClear();
       // The server sorted, renamed and assigned — none of which a local patch could know.
-      storyServiceMock.getStory.mockResolvedValue({
-        ...MOCK_STORY, version: 5, goals: [GOAL_A, GOAL_B]
-      });
+      associationSucceeds({ ...MOCK_STORY, version: 5, goals: [GOAL_A, GOAL_B] });
 
       await comp.onGoalSelected(GOAL_A);
 
       expect(comp.story()?.goals).toEqual([GOAL_A, GOAL_B]);
       expect(comp.existingGoalIds()).toEqual([7, 8]);
+      expect(storyServiceMock.getStory).not.toHaveBeenCalled();
     });
 
-    it('discards an out-of-order refresh so the newer read wins', async () => {
+    it('ignores an out-of-order response so the newer one wins', async () => {
       await renderExisting();
-      associationSucceeds();
 
-      // Two removes in flight at once — two clicks on the goals table. Their GETs are held so
-      // they can be resolved in the wrong order on purpose.
-      const resolvers: Array<(story: unknown) => void> = [];
-      storyServiceMock.getStory.mockImplementation(
+      // Two removes in flight at once — two clicks on the goals table. Their command responses are
+      // held so they can be resolved in the wrong order on purpose.
+      const resolvers: Array<(result: unknown) => void> = [];
+      commandServiceMock.execute.mockImplementation(
         () => new Promise(resolve => resolvers.push(resolve))
       );
 
@@ -523,26 +524,25 @@ describe('StoryEditorComponent', () => {
       await flush();
       expect(resolvers.length).toBe(2);
 
-      // Newer read lands first, then the older one — the case the sequence guard exists for.
-      resolvers[1]({ ...MOCK_STORY, version: 9, goals: [] });
-      resolvers[0]({ ...MOCK_STORY, version: 7, goals: [GOAL_B] });
+      // Newer response lands first, then the older one — the case the version guard exists for.
+      resolvers[1]({ success: true, entity: { ...MOCK_STORY, version: 9, goals: [] } });
+      resolvers[0]({ success: true, entity: { ...MOCK_STORY, version: 7, goals: [GOAL_B] } });
       await Promise.all([first, second]);
 
-      // Unguarded, the stale snapshot would resurrect GOAL_B and roll the version back to 7.
+      // Unguarded, the stale response would resurrect GOAL_B and roll the version back to 7.
       expect(comp.story()?.goals).toEqual([]);
       expect(comp.story()?.version).toBe(9);
       expect(await saveAndReadVersion()).toBe(9);
     });
 
-    it('keeps the held version and list when the refresh itself fails', async () => {
+    it('leaves the held version and list unchanged when the response carries no entity', async () => {
       await renderExisting();
-      associationSucceeds();
-      storyServiceMock.getStory.mockRejectedValue(new Error('network'));
+      associationSucceeds(null);
 
       await comp.onGoalSelected(GOAL_A);
 
-      // A failed refresh must not block the user: nothing is surfaced, the stale version is
-      // still sent, and the 409 it earns is reported through recoverFromStaleVersion().
+      // Nothing is surfaced, the held version is still sent, and any resulting 409 is reported
+      // through recoverFromStaleVersion() on the next save.
       expect(comp.errorMessage()).toBeNull();
       expect(comp.story()?.goals).toEqual([]);
       expect(await saveAndReadVersion()).toBe(4);

--- a/requel-angular/src/app/features/stories/story-editor.ts
+++ b/requel-angular/src/app/features/stories/story-editor.ts
@@ -389,12 +389,6 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
   projectName = '';
   storyId: number | null = null;
   private version: number | null = null;
-  /**
-   * Monotonic ticket for story reads. `refreshAfterAssociation()` takes one before its GET
-   * and applies the response only if it is still the newest, so an older read cannot land
-   * last and undo a newer one. See that method for why the guard is needed.
-   */
-  private storyReadSeq = 0;
   private paramSub?: Subscription;
   private sseSub?: Subscription;
 
@@ -502,9 +496,6 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
     }
     try {
       const s = await this.storyService.getStory(this.projectName, this.storyId!);
-      // A full load supersedes any association refresh still in flight: whichever of the two
-      // reads resolves last would otherwise win, and this one carries the form reset.
-      this.storyReadSeq++;
       // Always take the version. The entity moved on, and holding the stale one guarantees a
       // 409 on the next save.
       this.story.set(s);
@@ -540,43 +531,27 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
   }
 
   /**
-   * Re-reads the story after an association command so the held `@Version` and the goals /
-   * actors tables both come from the server rather than from a locally patched array.
+   * Apply the merged story an association command returns (#180). Add/Remove Goal/Actor merge the
+   * container — this story — so each returns it with its bumped `@Version` and refreshed goals /
+   * actors as `result.entity`. Consuming that removes the follow-up GET this used to do.
    *
-   * `Add`/`RemoveGoalToGoalContainer` and `Add`/`RemoveActorToActorContainer` merge their
-   * container — which here is the story — so each one bumps its `@Version`. None of the four
-   * registers a result extractor, so `result.entity` is null and the new version can only be
-   * read back (#178). Without this, adding a goal and then saving the name 409s (#179).
+   * Guarded on `version`: two associations can be in flight at once (easiest by clicking two remove
+   * buttons) and resolve out of order. Since every merge increments `@Version`, a response older
+   * than what we already hold would restore a stale list, so we ignore it — this replaces the old
+   * `storyReadSeq` ticket and keys off the server's commit order rather than client issue order. A
+   * skipped version self-corrects through the next-save 409 recovery.
    *
-   * Applying the response is guarded by `storyReadSeq`. Two associations in quick succession —
-   * easiest by clicking two remove buttons — issue two GETs that can resolve in either order,
-   * and the older snapshot landing last would silently restore a row the user just removed.
-   * A stale *version* is self-correcting, since the next save 409s into
-   * `recoverFromStaleVersion()`, but a stale *list* is not, which is why the guard exists at
-   * all now that the tables are refreshed too.
-   *
-   * Unlike `loadStory()` this never touches `detailsForm`, so it cannot discard unsaved edits:
-   * the form belongs to the user, the signal to the server.
-   *
-   * #180 deletes this method: once the four commands return their merged container, the
-   * version and the lists both come off `result.entity` and the extra GET goes away.
+   * Never touches `detailsForm`, so an in-progress edit survives.
    */
-  private async refreshAfterAssociation(): Promise<void> {
-    if (this.storyId == null) {
+  private applyAssociationResult(entity: StoryDto | null): void {
+    if (!entity) {
       return;
     }
-    const seq = ++this.storyReadSeq;
-    try {
-      const s = await this.storyService.getStory(this.projectName, this.storyId);
-      if (seq !== this.storyReadSeq) {
-        return;
-      }
-      this.version = s.version;
-      this.story.set(s);
-    } catch {
-      // Leave the held version and lists as they are. A failed refresh is not worth blocking
-      // the user on, and a resulting 409 still reports itself through the existing recovery.
+    if (this.version != null && entity.version <= this.version) {
+      return;
     }
+    this.version = entity.version;
+    this.story.set(entity);
   }
 
   existingGoalIds(): number[] {
@@ -771,7 +746,7 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
         containerType: 'Story'
       });
       if (result.success) {
-        await this.refreshAfterAssociation();
+        this.applyAssociationResult(result.entity as StoryDto | null);
         this.messageService.add({ severity: 'success', summary: 'Goal added', detail: 'Goal added.' });
       } else {
         this.errorMessage.set(result.error ?? 'Failed to add goal.');
@@ -790,7 +765,7 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
         containerType: 'Story'
       });
       if (result.success) {
-        await this.refreshAfterAssociation();
+        this.applyAssociationResult(result.entity as StoryDto | null);
         this.messageService.add({ severity: 'success', summary: 'Goal removed', detail: 'Goal removed.' });
       } else {
         this.errorMessage.set(result.error ?? 'Failed to remove goal.');
@@ -810,7 +785,7 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
         containerType: 'Story'
       });
       if (result.success) {
-        await this.refreshAfterAssociation();
+        this.applyAssociationResult(result.entity as StoryDto | null);
         this.messageService.add({ severity: 'success', summary: 'Actor added', detail: 'Actor added.' });
       } else {
         this.errorMessage.set(result.error ?? 'Failed to add actor.');
@@ -829,7 +804,7 @@ export class StoryEditorComponent implements OnInit, OnDestroy, DirtyCheckable {
         containerType: 'Story'
       });
       if (result.success) {
-        await this.refreshAfterAssociation();
+        this.applyAssociationResult(result.entity as StoryDto | null);
         this.messageService.add({ severity: 'success', summary: 'Actor removed', detail: 'Actor removed.' });
       } else {
         this.errorMessage.set(result.error ?? 'Failed to remove actor.');

--- a/requel-angular/src/app/features/use-cases/use-case-editor.spec.ts
+++ b/requel-angular/src/app/features/use-cases/use-case-editor.spec.ts
@@ -230,15 +230,15 @@ describe('UseCaseEditorComponent', () => {
   });
 
   describe('wizard version contract (#173)', () => {
-    it('re-reads version after an association, so a later save does not 409', async () => {
+    it('takes version from the association response, so a later save does not 409', async () => {
       paramMap$.next(convertToParamMap({ name: 'proj1', useCaseId: '30' }));
       fixture.detectChanges();
       await flush();
+      useCaseServiceMock.getUseCase.mockClear();
 
-      commandServiceMock.execute.mockResolvedValue({ success: true, entity: null });
-      useCaseServiceMock.getUseCase.mockResolvedValue({ ...MOCK_USE_CASE, version: 5 });
-
+      commandServiceMock.execute.mockResolvedValue({ success: true, entity: { ...MOCK_USE_CASE, version: 5 } });
       await comp.addGoal({ id: 7, name: 'Avoid late fees', entityType: 'Goal' });
+      expect(useCaseServiceMock.getUseCase).not.toHaveBeenCalled();
 
       commandServiceMock.execute.mockClear();
       commandServiceMock.execute.mockResolvedValue({
@@ -287,11 +287,17 @@ describe('UseCaseEditorComponent', () => {
     });
   });
 
-  it('addGoal calls AddGoalToGoalContainer and refreshes collections', async () => {
+  it('addGoal calls AddGoalToGoalContainer and applies the returned use case (no refetch)', async () => {
     paramMap$.next(convertToParamMap({ name: 'proj1', useCaseId: '30' }));
     fixture.detectChanges();
     await flush();
-    const callsBefore = useCaseServiceMock.getUseCase.mock.calls.length;
+    useCaseServiceMock.getUseCase.mockClear();
+    commandServiceMock.execute.mockResolvedValue({
+      success: true, entity: { ...MOCK_USE_CASE, version: 1, goals: [
+        { id: 1, name: 'Buy product', entityType: 'Goal' },
+        { id: 10, name: 'New Goal', entityType: 'Goal' }
+      ] }
+    });
     await comp.addGoal({ id: 10, name: 'New Goal', entityType: 'Goal' });
     expect(commandServiceMock.execute).toHaveBeenCalledWith('AddGoalToGoalContainer', expect.objectContaining({
       projectName: 'proj1',
@@ -299,7 +305,9 @@ describe('UseCaseEditorComponent', () => {
       goalId: 10,
       containerType: 'UseCase'
     }));
-    expect(useCaseServiceMock.getUseCase.mock.calls.length).toBeGreaterThan(callsBefore);
+    expect(comp.goals().some(g => g.id === 10)).toBe(true);
+    // Applied from result.entity; no follow-up use-case GET (and no primary-scenario GET either).
+    expect(useCaseServiceMock.getUseCase).not.toHaveBeenCalled();
   });
 
   it('removeGoal calls RemoveGoalFromGoalContainer', async () => {

--- a/requel-angular/src/app/features/use-cases/use-case-editor.ts
+++ b/requel-angular/src/app/features/use-cases/use-case-editor.ts
@@ -898,13 +898,40 @@ export class UseCaseEditorComponent implements OnInit, OnDestroy, DirtyCheckable
     }
   }
 
+  /**
+   * Apply the merged use case an association command returns (#180). Every goal/story/actor
+   * association here merges the use case and returns it — version, goals, stories, actors and
+   * additional scenarios — as `result.entity`, so we consume that instead of refetching.
+   * Associations never change the primary scenario, so unlike `refreshCollections()` this issues no
+   * scenario GET either. (The scenario commands keep `refreshCollections()` precisely because they
+   * do change the primary scenario.)
+   *
+   * Guarded on `version`: concurrent associations can resolve out of order, and since every merge
+   * increments `@Version`, a response older than what we hold would restore stale lists, so we
+   * ignore it. A skipped version self-corrects through the next-save 409 recovery.
+   */
+  private applyAssociationResult(entity: UseCaseDto | null): void {
+    if (!entity) {
+      return;
+    }
+    if (this.version != null && entity.version <= this.version) {
+      return;
+    }
+    this.version = entity.version;
+    this.useCase.set(entity);
+    this.goals.set(entity.goals ?? []);
+    this.stories.set(entity.stories ?? []);
+    this.actors.set(entity.actors ?? []);
+    this.additionalScenarios.set(entity.additionalScenarios ?? []);
+  }
+
   async addGoal(ref: EntityReferenceDto): Promise<void> {
     this.showGoalSelector = false;
     const result = await this.commandService.execute('AddGoalToGoalContainer', {
       projectName: this.projectName, goalContainerId: this.useCaseId, goalId: ref.id,
       containerType: 'UseCase'
     });
-    if (result.success) await this.refreshCollections();
+    if (result.success) this.applyAssociationResult(result.entity as UseCaseDto | null);
     else this.errorMessage.set(result.error ?? 'Failed to add goal.');
   }
 
@@ -913,7 +940,7 @@ export class UseCaseEditorComponent implements OnInit, OnDestroy, DirtyCheckable
       projectName: this.projectName, goalContainerId: this.useCaseId, goalId: goal.id,
       containerType: 'UseCase'
     });
-    if (result.success) await this.refreshCollections();
+    if (result.success) this.applyAssociationResult(result.entity as UseCaseDto | null);
     else this.errorMessage.set(result.error ?? 'Failed to remove goal.');
   }
 
@@ -923,7 +950,7 @@ export class UseCaseEditorComponent implements OnInit, OnDestroy, DirtyCheckable
       projectName: this.projectName, storyContainerId: this.useCaseId, storyId: ref.id,
       containerType: 'UseCase'
     });
-    if (result.success) await this.refreshCollections();
+    if (result.success) this.applyAssociationResult(result.entity as UseCaseDto | null);
     else this.errorMessage.set(result.error ?? 'Failed to add story.');
   }
 
@@ -932,7 +959,7 @@ export class UseCaseEditorComponent implements OnInit, OnDestroy, DirtyCheckable
       projectName: this.projectName, storyContainerId: this.useCaseId, storyId: story.id,
       containerType: 'UseCase'
     });
-    if (result.success) await this.refreshCollections();
+    if (result.success) this.applyAssociationResult(result.entity as UseCaseDto | null);
     else this.errorMessage.set(result.error ?? 'Failed to remove story.');
   }
 
@@ -942,7 +969,7 @@ export class UseCaseEditorComponent implements OnInit, OnDestroy, DirtyCheckable
       projectName: this.projectName, actorContainerId: this.useCaseId, actorId: ref.id,
       containerType: 'UseCase'
     });
-    if (result.success) await this.refreshCollections();
+    if (result.success) this.applyAssociationResult(result.entity as UseCaseDto | null);
     else this.errorMessage.set(result.error ?? 'Failed to add actor.');
   }
 
@@ -951,7 +978,7 @@ export class UseCaseEditorComponent implements OnInit, OnDestroy, DirtyCheckable
       projectName: this.projectName, actorContainerId: this.useCaseId, actorId: actor.id,
       containerType: 'UseCase'
     });
-    if (result.success) await this.refreshCollections();
+    if (result.success) this.applyAssociationResult(result.entity as UseCaseDto | null);
     else this.errorMessage.set(result.error ?? 'Failed to remove actor.');
   }
 


### PR DESCRIPTION
https://github.com/rreganjr/Requel/issues/180

180: Consume the entity returned by association commands instead of refetching

Since #178 the six association commands (Add/Remove Goal/Story/Actor to their containers) return
their merged container as `result.entity`. The four editors that call them still ignored it and
re-read the container over HTTP — a version-only GET (actor, stakeholder), a full refetch plus a
second primary-scenario GET (use case), or a full refetch behind a sequence guard (story). This
deletes that follow-up read everywhere and takes both the optimistic-lock `version` and the
affected collections straight off `result.entity`.

Closes #180. Implements doc/180-consume-association-entity-plan.md.

One authoritative rule, applied in all four editors via a small `applyAssociationResult(entity)`
helper: on a successful association, set `version` and the affected collection signal(s) from
`result.entity`; on failure, leave state untouched and let the next-save 409 recovery handle a
stale version. The helper is guarded so an out-of-order response from a second in-flight
association (`entity.version <= heldVersion`) is ignored — it keys off the server's commit order
(the monotonic `@Version`) rather than client issue order, which lets it replace story-editor's
`storyReadSeq` ticket and cover the other three editors, which previously had no such guard.

Per editor:
- actor-editor / stakeholder-editor: drop `refreshVersionAfterAssociation()` (a version-only GET)
  and the optimistic list patch; goals + version now come from the response.
- use-case-editor: the six goal/story/actor handlers stop calling `refreshCollections()` and apply
  the returned `UseCaseDto` directly — two fewer GETs per association, since `refreshCollections`
  also re-read the primary scenario. That method stays for `createPrimaryScenario()` and the
  scenario association handlers, which do change the primary scenario.
- story-editor: drop `refreshAfterAssociation()` and the `storyReadSeq` field; version + lists come
  off the response, guarded by version.

The optimistic patch in actor/stakeholder was dropped deliberately so all four editors behave
identically (single source of truth), trading a few hundred ms of instant feedback for consistency.

Tests:
- Each editor spec now asserts version + lists come from `result.entity` and no follow-up detail
  GET is issued, plus an out-of-order case (a lower-version response is ignored) and a null-entity
  case (state unchanged). The old refetch-based specs are removed.
- sse-refresh.e2e.ts: the #178 cross-session refresh test stays; a new test drives an association
  from the acting context's own UI and asserts it issues no follow-up actor GET — the negative
  assertion #178 deferred to this ticket.

Frontend only: #178 already returns the entity, so no backend change.
